### PR TITLE
Fix workflow restarts with manually blocked jobs

### DIFF
--- a/db_service/src/query.js
+++ b/db_service/src/query.js
@@ -753,6 +753,7 @@ function initializeJobStatus(workflow, onlyUninitialized) {
         FILTER job.status != ${JobStatus.Disabled}
           && job.status != ${JobStatus.Blocked}
           && job.status != ${JobStatus.Done}
+          && job.status != ${JobStatus.Canceled}
         UPDATE job WITH { status: ${JobStatus.Ready} } IN ${jobs}
   `;
   console.debug(


### PR DESCRIPTION
The workflow restart command was incorrectly resetting canceled jobs to uninitialized they had a dependency on a job that failed.