### PR TITLE
Fix CI timing issue

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,6 +245,14 @@ List endpoints support `offset` and `limit` query parameters:
 - Default limit: 10,000 records
 - Maximum limit: 10,000 records (enforced)
 
+### Job Completion and Unblocking
+**CRITICAL**: Job completions trigger unblocking of dependent jobs via a background task for performance reasons.
+- When a job completes, `manage_job_status_change` sets `unblocking_processed = 0` and signals the background task
+- The background task runs periodically and processes all pending unblocks in batch
+- **Do NOT add direct calls to `unblock_jobs_waiting_for` in the completion path** - this would hurt performance
+- The API endpoint `manage_status_change` should NOT be used to set completion statuses; use `complete_job` instead
+- Tests simulating job completions MUST use `complete_job` (not `manage_status_change`) to ensure proper unblocking
+
 ### OpenAPI Code Generation
 - Server and client use OpenAPI-generated code for base types and routing
 - **Do not modify** generated code directly


### PR DESCRIPTION
A test in CI failed due a timing issue. Summary from Claude, which seems reasonable:

Root Cause: The idle timeout calculation in src/client/job_runner.rs used wall clock time (chrono::Utc::now()) instead of a monotonic clock. When the system clock goes backwards (common in CI environments due to NTP synchronization), the time difference became negative. Casting a negative i64 to u64 wraps to a very large positive number, causing the idle timeout check to trigger immediately and exit the job runner prematurely.

The Bug (line 379 before fix):
(Utc::now() - last_time).num_seconds() as u64

If Utc::now() is before last_time (clock went backwards), this produces a negative number that wraps to ~18 quintillion when cast to u64, exceeding any idle timeout threshold.

The Fix: Changed from DateTime<Utc> to std::time::Instant, which is a monotonic clock designed specifically for measuring elapsed time. It's immune to system clock adjustments.

Files Changed: src/client/job_runner.rs
  - Changed last_job_claimed_time from Option<DateTime<Utc>> to Option<Instant>
  - Updated idle timeout check to use last_time.elapsed().as_secs() instead of manual time subtraction
  - Updated two places where last_job_claimed_time is set to use Instant::now()

This explains why the test failure was:
1. Non-deterministic: Only occurred when NTP adjusted the clock backwards
2. More common in CI: CI environments have more clock drift and NTP adjustments 3. Left finalize in Blocked state: Job runner exited before the background unblock task could process work_fail's completion