### PR TITLE
Fix segfault on HPC systems with large LDAP user databases

### DIFF
--- a/src/run_jobs_cmd.rs
+++ b/src/run_jobs_cmd.rs
@@ -15,7 +15,7 @@ use log::{LevelFilter, error, info};
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
-use sysinfo::{System, SystemExt};
+use sysinfo::{CpuRefreshKind, RefreshKind, System, SystemExt};
 
 /// A writer that writes to both stdout and a file
 struct MultiWriter {
@@ -224,7 +224,12 @@ pub fn run(args: &Args) {
         None
     };
 
-    let mut system = System::new_all();
+    // Use new_with_specifics to only refresh CPU and memory, avoiding user enumeration
+    // which can crash on HPC systems with large LDAP user databases
+    let refresh_kind = RefreshKind::new()
+        .with_cpu(CpuRefreshKind::everything())
+        .with_memory();
+    let mut system = System::new_with_specifics(refresh_kind);
     system.refresh_all();
     let system_cpus = system.cpus().len() as i64;
     let system_memory_gb = (system.total_memory() as f64) / (1024.0 * 1024.0 * 1024.0);


### PR DESCRIPTION
Replace System::new_all() with System::new_with_specifics() to avoid enumerating users when only CPU/memory/process info is needed.

The sysinfo 0.29 crate's get_users_list() crashes on HPC systems with thousands of LDAP users due to a bug in user enumeration. This caused intermittent segfaults in release builds of torc-slurm-job-runner.

The fix specifies exactly which system info to collect:
- slurm_interface.rs: memory only (for get_memory_gb)
- run_jobs_cmd.rs: CPU + memory (for resource detection)
- resource_monitor.rs: processes + CPU + memory (for job monitoring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)