### PR TITLE
fix: Set minimum Rust version to 1.86.0 in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ license.workspace = true
 edition.workspace = true
 repository.workspace = true
 description.workspace = true
-rust-version = "1.86.0"
+rust-version = "1.88.0"
 
 [[bin]]
 name = "torc"


### PR DESCRIPTION
Fixes #147 