### PR TITLE
Fix bug that under-allocated compute nodes

### DIFF
--- a/src/client/scheduler_plan.rs
+++ b/src/client/scheduler_plan.rs
@@ -45,6 +45,9 @@ struct AllocationParams {
     nodes_per_job: u32,
     /// Total number of jobs in the group
     job_count: usize,
+    /// Actual walltime (seconds) that will be assigned to each allocation.
+    /// Used to calculate how many sequential job batches fit within an allocation.
+    allocation_walltime_secs: u64,
 }
 
 /// Calculate the number of allocations needed for a group of jobs.
@@ -79,9 +82,9 @@ fn calculate_allocations(
         ),
     );
 
-    // Factor in runtime: how many sequential batches can run within the walltime
+    // Factor in runtime: how many sequential batches can run within the allocation walltime
     let time_slots = if params.max_runtime_secs > 0 {
-        std::cmp::max(1, partition.max_walltime_secs / params.max_runtime_secs)
+        std::cmp::max(1, params.allocation_walltime_secs / params.max_runtime_secs)
     } else {
         1
     };
@@ -391,6 +394,15 @@ fn process_scheduler_group<RR: ResourceRequirements>(
             )
         })?;
 
+    // Calculate walltime based on strategy (must be computed before allocations
+    // since time_slots depends on the actual allocation walltime, not partition max)
+    let walltime_secs = calculate_walltime(
+        runtime_secs,
+        partition.max_walltime_secs,
+        walltime_strategy,
+        walltime_multiplier,
+    );
+
     // Calculate allocations using the shared helper function
     let alloc_params = AllocationParams {
         max_cpus: rr.num_cpus() as u32,
@@ -399,6 +411,7 @@ fn process_scheduler_group<RR: ResourceRequirements>(
         max_gpus: gpus.unwrap_or(0),
         nodes_per_job: rr.num_nodes() as u32,
         job_count: group.job_count,
+        allocation_walltime_secs: walltime_secs,
     };
 
     let num_allocations = calculate_allocations(&alloc_params, partition, single_allocation)
@@ -433,14 +446,6 @@ fn process_scheduler_group<RR: ResourceRequirements>(
     } else {
         format!("{}m", partition.memory_mb)
     };
-
-    // Calculate walltime based on strategy
-    let walltime_secs = calculate_walltime(
-        runtime_secs,
-        partition.max_walltime_secs,
-        walltime_strategy,
-        walltime_multiplier,
-    );
 
     let scheduler = PlannedScheduler {
         name: scheduler_name.clone(),
@@ -651,6 +656,13 @@ fn generate_plan_grouped_by_partition<RR: ResourceRequirements>(
             gpus,
         )?;
 
+        let alloc_walltime_secs = calculate_walltime(
+            pg.max_runtime_secs,
+            partition.max_walltime_secs,
+            walltime_strategy,
+            walltime_multiplier,
+        );
+
         let params = AllocationParams {
             max_cpus: pg.max_cpus as u32,
             max_memory_mb: pg.max_memory_mb,
@@ -658,6 +670,7 @@ fn generate_plan_grouped_by_partition<RR: ResourceRequirements>(
             max_gpus: pg.max_gpus as u32,
             nodes_per_job: pg.max_nodes as u32,
             job_count: pg.job_count,
+            allocation_walltime_secs: alloc_walltime_secs,
         };
 
         calculate_allocations(&params, partition, single_allocation)
@@ -738,6 +751,15 @@ fn generate_plan_grouped_by_partition<RR: ResourceRequirements>(
             }
         };
 
+        // Calculate walltime based on strategy (must be computed before allocations
+        // since time_slots depends on the actual allocation walltime, not partition max)
+        let walltime_secs = calculate_walltime(
+            pg.max_runtime_secs,
+            partition.max_walltime_secs,
+            walltime_strategy,
+            walltime_multiplier,
+        );
+
         // Calculate allocations using the shared helper function
         let alloc_params = AllocationParams {
             max_cpus: pg.max_cpus as u32,
@@ -746,6 +768,7 @@ fn generate_plan_grouped_by_partition<RR: ResourceRequirements>(
             max_gpus: gpus.unwrap_or(0),
             nodes_per_job: pg.max_nodes as u32,
             job_count: pg.job_count,
+            allocation_walltime_secs: walltime_secs,
         };
 
         let num_allocations =
@@ -784,14 +807,6 @@ fn generate_plan_grouped_by_partition<RR: ResourceRequirements>(
         } else {
             format!("{}m", partition.memory_mb)
         };
-
-        // Calculate walltime based on strategy
-        let walltime_secs = calculate_walltime(
-            pg.max_runtime_secs,
-            partition.max_walltime_secs,
-            walltime_strategy,
-            walltime_multiplier,
-        );
 
         let scheduler = PlannedScheduler {
             name: scheduler_name.clone(),

--- a/tests/test_hpc.rs
+++ b/tests/test_hpc.rs
@@ -1223,10 +1223,11 @@ fn test_generate_schedulers_auto_calculates_allocations() {
 
     // 10 jobs, 26 CPUs each, 1 hour runtime
     // Concurrent capacity: 104 CPUs / 26 CPUs = 4 jobs per node
-    // Time slots: 4h walltime / 1h runtime = 4 sequential batches
-    // Jobs per allocation: 4 concurrent × 4 time slots = 16 jobs
-    // Allocations needed: ceil(10 / 16) = 1
-    assert_eq!(action.num_allocations, Some(1));
+    // Allocation walltime: 1h × 1.5 multiplier = 1.5h
+    // Time slots: floor(1.5h / 1h) = 1 sequential batch
+    // Jobs per allocation: 4 concurrent × 1 time slot = 4 jobs
+    // Allocations needed: ceil(10 / 4) = 3
+    assert_eq!(action.num_allocations, Some(3));
 }
 
 /// Test auto-calculation with parameterized jobs
@@ -1283,10 +1284,11 @@ fn test_generate_schedulers_auto_calculates_with_parameters() {
 
     // 100 jobs (from parameterized expansion), 52 CPUs each, 1 hour runtime
     // Concurrent capacity: 104 CPUs / 52 CPUs = 2 jobs per node
-    // Time slots: 4h walltime / 1h runtime = 4 sequential batches
-    // Jobs per allocation: 2 concurrent × 4 time slots = 8 jobs
-    // Allocations needed: ceil(100 / 8) = 13
-    assert_eq!(action.num_allocations, Some(13));
+    // Allocation walltime: 1h × 1.5 multiplier = 1.5h
+    // Time slots: floor(1.5h / 1h) = 1 sequential batch
+    // Jobs per allocation: 2 concurrent × 1 time slot = 2 jobs
+    // Allocations needed: ceil(100 / 2) = 50
+    assert_eq!(action.num_allocations, Some(50));
 }
 
 /// Test stage-aware scheduling: jobs with and without dependencies get separate schedulers.
@@ -1432,13 +1434,96 @@ fn test_generate_schedulers_memory_constrained_allocation() {
     let action = &actions[0];
     // 10 jobs, 120GB memory each, 1 hour runtime
     // Concurrent by memory: 246,064MB / 122,880MB = 2 jobs per node
-    // Time slots: 4h walltime / 1h runtime = 4 sequential batches
-    // Jobs per allocation: 2 concurrent × 4 time slots = 8 jobs
-    // Allocations needed: ceil(10 / 8) = 2
+    // Allocation walltime: 1h × 1.5 multiplier = 1.5h
+    // Time slots: floor(1.5h / 1h) = 1 sequential batch
+    // Jobs per allocation: 2 concurrent × 1 time slot = 2 jobs
+    // Allocations needed: ceil(10 / 2) = 5
     assert_eq!(
         action.num_allocations,
-        Some(2),
-        "Should allocate 2 nodes for 10 memory-heavy jobs (2 concurrent × 4 time slots = 8 jobs per allocation)"
+        Some(5),
+        "Should allocate 5 nodes for 10 memory-heavy jobs (2 concurrent × 1 time slot = 2 jobs per allocation)"
+    );
+}
+
+/// Test that long-running whole-node jobs each get their own allocation.
+///
+/// Regression test: previously, time_slots was calculated from partition max walltime
+/// instead of the actual allocation walltime. With MaxJobRuntime strategy and 1.5x multiplier,
+/// a 20h job gets a 30h allocation walltime. But the bug used the 48h partition max,
+/// giving time_slots = 48h/20h = 2, which halved the allocation count (5 instead of 10).
+#[rstest]
+fn test_generate_schedulers_whole_node_long_runtime() {
+    // 10 jobs each consuming an entire node: 12 CPUs, 160GB memory, 20 hours runtime.
+    // On Kestrel standard partition (104 CPUs, 246,064MB, 48h max walltime):
+    // - Only 1 job fits per node (160GB = 163,840MB, 246,064/163,840 = 1)
+    // - Allocation walltime: 20h × 1.5 = 30h (MaxJobRuntime strategy)
+    // - Time slots: floor(30h / 20h) = 1
+    // - Each allocation can run exactly 1 job, so we need 10 allocations.
+    let jobs: Vec<JobSpec> = (0..10)
+        .map(|i| JobSpec {
+            name: format!("draw_{}_extreme_week", i + 1),
+            command: format!("julia outagesim.jl {}", i + 1),
+            resource_requirements: Some("whole_node".to_string()),
+            ..Default::default()
+        })
+        .collect();
+
+    let mut spec = WorkflowSpec {
+        name: "nodal_test".to_string(),
+        description: Some("Long-running whole-node jobs".to_string()),
+        jobs,
+        resource_requirements: Some(vec![ResourceRequirementsSpec {
+            name: "whole_node".to_string(),
+            num_cpus: 12,
+            num_gpus: 0,
+            num_nodes: 1,
+            memory: "160g".to_string(),
+            runtime: "PT20H".to_string(),
+        }]),
+        ..Default::default()
+    };
+
+    let profile = kestrel_profile();
+    let result = generate_schedulers_for_workflow(
+        &mut spec,
+        &profile,
+        "testaccount",
+        false,
+        GroupByStrategy::ResourceRequirements,
+        WalltimeStrategy::MaxJobRuntime,
+        1.5,
+        true,
+        false,
+    )
+    .unwrap();
+
+    assert_eq!(result.scheduler_count, 1);
+    assert_eq!(result.action_count, 1);
+
+    let actions = spec.actions.as_ref().unwrap();
+    let action = &actions[0];
+
+    // 10 jobs, 12 CPUs, 160GB memory, 20h runtime
+    // Concurrent by memory: 246,064MB / 163,840MB = 1 job per node
+    // Concurrent by CPU: 104 / 12 = 8 jobs per node
+    // Concurrent = min(8, 1) = 1 job per node (memory-limited)
+    // Allocation walltime: 20h × 1.5 = 30h
+    // Time slots: floor(30h / 20h) = 1
+    // Jobs per allocation: 1 concurrent × 1 time slot = 1 job
+    // Allocations needed: ceil(10 / 1) = 10
+    assert_eq!(
+        action.num_allocations,
+        Some(10),
+        "Each whole-node job should get its own allocation (10 jobs = 10 allocations)"
+    );
+
+    // Verify walltime is based on job runtime, not partition max
+    let schedulers = spec.slurm_schedulers.as_ref().unwrap();
+    assert_eq!(schedulers.len(), 1);
+    // 20h × 1.5 = 30h = "1-06:00:00"
+    assert_eq!(
+        schedulers[0].walltime, "1-06:00:00",
+        "Walltime should be 20h × 1.5 = 30h, not the partition max of 48h"
     );
 }
 
@@ -1509,13 +1594,14 @@ fn test_generate_schedulers_cpu_vs_memory_constraint() {
     // Concurrent by CPU: 104/52 = 2 jobs per node
     // Concurrent by memory: 246064/61440 = 4 jobs per node
     // Concurrent = min(2, 4) = 2 jobs per node (CPU-limited)
-    // Time slots: 4h walltime / 1h runtime = 4 sequential batches
-    // Jobs per allocation: 2 concurrent × 4 time slots = 8 jobs
-    // Allocations needed: ceil(4 / 8) = 1
+    // Allocation walltime: 1h × 1.5 multiplier = 1.5h
+    // Time slots: floor(1.5h / 1h) = 1 sequential batch
+    // Jobs per allocation: 2 concurrent × 1 time slot = 2 jobs
+    // Allocations needed: ceil(4 / 2) = 2
     assert_eq!(
         action.num_allocations,
-        Some(1),
-        "Should allocate 1 node for 4 CPU-heavy jobs (2 concurrent × 4 time slots = 8 jobs per allocation)"
+        Some(2),
+        "Should allocate 2 nodes for 4 CPU-heavy jobs (2 concurrent × 1 time slot = 2 jobs per allocation)"
     );
 }
 
@@ -1719,13 +1805,14 @@ fn test_generate_schedulers_gpu_constrained_allocation() {
     // Concurrent by CPU: 128/32 = 4 jobs per node
     // Concurrent by memory: 360000/92160 = 3.9 = 3 jobs per node
     // Concurrent = min(4, 3, 2) = 2 jobs per node
-    // Time slots: 4h walltime / 1h runtime = 4 sequential batches
-    // Jobs per allocation: 2 concurrent × 4 time slots = 8 jobs
-    // Allocations needed: ceil(8 / 8) = 1
+    // Allocation walltime: 1h × 1.5 multiplier = 1.5h
+    // Time slots: floor(1.5h / 1h) = 1 sequential batch
+    // Jobs per allocation: 2 concurrent × 1 time slot = 2 jobs
+    // Allocations needed: ceil(8 / 2) = 4
     assert_eq!(
         action.num_allocations,
-        Some(1),
-        "Should allocate 1 node for 8 GPU jobs (2 concurrent × 4 time slots = 8 jobs per allocation)"
+        Some(4),
+        "Should allocate 4 nodes for 8 GPU jobs (2 concurrent × 1 time slot = 2 jobs per allocation)"
     );
 }
 

--- a/tests/test_slurm_commands.rs
+++ b/tests/test_slurm_commands.rs
@@ -1911,7 +1911,8 @@ fn test_slurm_generate_auto_merge_small_allocations() {
     // - 1 job depending on all job_* (join)
     //
     // With num_cpus=52, concurrent capacity is only 2 jobs per node.
-    // But with 10-minute jobs and 4-hour walltime, 24 time slots are available,
+    // Using max-partition-time strategy, the allocation walltime equals the partition max (4h).
+    // With 10-minute jobs and 4-hour walltime, 24 time slots are available,
     // so jobs_per_allocation = 2 * 24 = 48, which can handle all 12 jobs in 1 allocation.
     let workflow_json = r#"{
   "name": "test_auto_merge",
@@ -1960,7 +1961,9 @@ fn test_slurm_generate_auto_merge_small_allocations() {
     std::io::Write::write_all(&mut workflow_file, workflow_json.as_bytes())
         .expect("Failed to write temp workflow file");
 
-    // Run slurm generate with --group-by partition
+    // Run slurm generate with --group-by partition and max-partition-time strategy.
+    // max-partition-time is needed so the allocation walltime equals the partition max (4h),
+    // allowing time_slots = 4h / 10min = 24 sequential batches per allocation.
     let output = Command::new(common::get_exe_path("./target/debug/torc"))
         .args([
             "slurm",
@@ -1972,6 +1975,8 @@ fn test_slurm_generate_auto_merge_small_allocations() {
             "partition",
             "--profile",
             "kestrel",
+            "--walltime-strategy",
+            "max-partition-time",
         ])
         .output()
         .expect("Failed to execute slurm generate");


### PR DESCRIPTION
The scheduling algorithm was not correctly accounting for walltime in this case and scheduled half the required number of nodes.