### PR TITLE
Optimize deletes of large workflows

### DIFF
--- a/src/server/api/workflows.rs
+++ b/src/server/api/workflows.rs
@@ -667,14 +667,30 @@ where
             }
         };
 
+        // Update workflow_status with the workflow_id back-reference
+        let workflow_id = workflow_result[0].id;
+        let status_id = status_result[0].id;
+        if let Err(e) = sqlx::query("UPDATE workflow_status SET workflow_id = $1 WHERE id = $2")
+            .bind(workflow_id)
+            .bind(status_id)
+            .execute(&mut *tx)
+            .await
+        {
+            let _ = tx.rollback().await;
+            return Err(database_error_with_msg(
+                e,
+                "Failed to update workflow_status with workflow_id",
+            ));
+        }
+
         // Commit the transaction
         if let Err(e) = tx.commit().await {
             return Err(database_error_with_msg(e, "Failed to commit transaction"));
         }
 
-        debug!("Workflow inserted with id: {:?}", workflow_result[0].id);
-        body.id = Some(workflow_result[0].id);
-        body.status_id = Some(status_result[0].id);
+        debug!("Workflow inserted with id: {:?}", workflow_id);
+        body.id = Some(workflow_id);
+        body.status_id = Some(status_id);
         let response = CreateWorkflowResponse::SuccessfulResponse(body);
         Ok(response)
     }
@@ -1577,10 +1593,24 @@ where
         }
         .await;
 
-        // Always re-enable FK checks before returning the connection to the pool.
-        // If this fails, drop the connection instead of returning it to the pool
-        // with FK checks disabled — this prevents any subsequent operation on this
-        // connection from silently bypassing FK enforcement.
+        // On error, ROLLBACK to close the transaction before restoring FK checks.
+        // PRAGMA foreign_keys is a no-op inside an open transaction, so we must
+        // close it first. If rollback fails, detach the connection to prevent
+        // returning it to the pool with an open write lock.
+        if let Err(delete_err) = result {
+            if let Err(rb_err) = sqlx::query("ROLLBACK").execute(&mut *conn).await {
+                error!("Failed to rollback transaction: {rb_err}; dropping connection");
+                conn.detach();
+            } else {
+                // Rollback succeeded. Re-enable FK checks before returning.
+                let _ = sqlx::query("PRAGMA foreign_keys = ON")
+                    .execute(&mut *conn)
+                    .await;
+            }
+            return Err(delete_err);
+        }
+
+        // Success path: re-enable FK checks before returning connection to pool.
         if sqlx::query("PRAGMA foreign_keys = ON")
             .execute(&mut *conn)
             .await
@@ -1589,8 +1619,6 @@ where
             error!("Failed to re-enable foreign key checks; dropping connection");
             conn.detach();
         }
-
-        result?;
 
         info!(
             "Successfully deleted workflow {} (name: {:?})",

--- a/tests/test_workflows.rs
+++ b/tests/test_workflows.rs
@@ -417,6 +417,13 @@ fn test_workflows_delete_command_json(start_server: &ServerProcess) {
     // Verify the workflow is actually deleted by trying to get it
     let get_result = default_api::get_workflow(config, workflow_id);
     assert!(get_result.is_err(), "Workflow should be deleted");
+
+    // Verify the workflow status is also cleaned up (not orphaned)
+    let status_result = default_api::get_workflow_status(config, workflow_id);
+    assert!(
+        status_result.is_err(),
+        "Workflow status should be deleted with the workflow"
+    );
 }
 
 #[rstest]

--- a/torc-server/migrations/20260222000001_add_workflow_id_to_workflow_status.down.sql
+++ b/torc-server/migrations/20260222000001_add_workflow_id_to_workflow_status.down.sql
@@ -1,0 +1,17 @@
+-- Revert: SQLite does not support DROP COLUMN, so this is a table recreation.
+-- The workflow_id column is removed by recreating the table without it.
+
+CREATE TABLE workflow_status_old (
+  id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  run_id INTEGER NOT NULL DEFAULT 1,
+  has_detected_need_to_run_completion_script INTEGER NOT NULL DEFAULT 0,
+  is_canceled INTEGER NOT NULL DEFAULT 0,
+  is_archived INTEGER NOT NULL DEFAULT 0
+);
+
+INSERT INTO workflow_status_old (id, run_id, has_detected_need_to_run_completion_script, is_canceled, is_archived)
+SELECT id, run_id, has_detected_need_to_run_completion_script, is_canceled, is_archived
+FROM workflow_status;
+
+DROP TABLE workflow_status;
+ALTER TABLE workflow_status_old RENAME TO workflow_status;

--- a/torc-server/migrations/20260222000001_add_workflow_id_to_workflow_status.up.sql
+++ b/torc-server/migrations/20260222000001_add_workflow_id_to_workflow_status.up.sql
@@ -1,0 +1,16 @@
+-- Add workflow_id column to workflow_status.
+-- Previously workflow_status had no back-reference to workflow, causing
+-- orphaned status records when workflows were deleted.
+--
+-- Note: SQLite ALTER TABLE ADD COLUMN cannot include FK constraints, so
+-- there is no CASCADE here. The delete_workflow function handles cleanup
+-- explicitly (and runs with PRAGMA foreign_keys = OFF anyway).
+
+ALTER TABLE workflow_status ADD COLUMN workflow_id INTEGER NULL;
+
+-- Populate workflow_id from the workflow table's status_id reference
+UPDATE workflow_status
+SET workflow_id = (SELECT w.id FROM workflow w WHERE w.status_id = workflow_status.id);
+
+-- Delete orphaned status records (no matching workflow)
+DELETE FROM workflow_status WHERE workflow_id IS NULL;


### PR DESCRIPTION
Deleting a workflow with 100,000 jobs and results was timing out.