### PR TITLE
Set the torc password in the slurm job runner

### DIFF
--- a/src/bin/torc-slurm-job-runner.rs
+++ b/src/bin/torc-slurm-job-runner.rs
@@ -78,6 +78,10 @@ mod unix_main {
         /// Skip TLS certificate verification (for testing only)
         #[arg(long, env = "TORC_TLS_INSECURE")]
         tls_insecure: bool,
+
+        /// Password for authentication (can also use TORC_PASSWORD env var)
+        #[arg(long, env = "TORC_PASSWORD", hide_env_values = true)]
+        password: Option<String>,
     }
 
     pub fn main() {
@@ -153,6 +157,13 @@ mod unix_main {
         };
         let mut config = Configuration::with_tls(tls);
         config.base_path = args.url;
+
+        // Set up authentication if password is provided
+        if let Some(ref password) = args.password {
+            let username =
+                std::env::var("USER").unwrap_or_else(|_| std::env::var("USERNAME").unwrap());
+            config.basic_auth = Some((username, Some(password.clone())));
+        }
 
         // First, ping the server to ensure we can connect
         match utils::send_with_retries(

--- a/src/client/hpc/slurm_interface.rs
+++ b/src/client/hpc/slurm_interface.rs
@@ -252,14 +252,11 @@ impl HpcInterface for SlurmInterface {
         }
 
         script.push('\n');
-        script.push_str(&format!("TORC_URL=\"{}\"\n", server_url));
-
-        script.push('\n');
 
         // Build the torc-slurm-job-runner command
         let mut command = format!(
-            "torc-slurm-job-runner $TORC_URL {} {} --poll-interval {}",
-            workflow_id, output_path, poll_interval
+            "torc-slurm-job-runner {} {} {} --poll-interval {}",
+            server_url, workflow_id, output_path, poll_interval
         );
 
         if let Some(max_jobs) = max_parallel_jobs {


### PR DESCRIPTION
This bug caused jobs to fail if authentication was enabled on the server.