### PR TITLE
Add TORC_PASSWORD and basic auth support to TUI

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -733,7 +733,8 @@ fn main() {
             handle_config_commands(command);
         }
         Commands::Tui(args) => {
-            if let Err(e) = tui_runner::run(args) {
+            let basic_auth = config.basic_auth.clone();
+            if let Err(e) = tui_runner::run(args, basic_auth) {
                 eprintln!("Error running TUI: {}", e);
                 std::process::exit(1);
             }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -8,6 +8,7 @@ use crossterm::{
 };
 use ratatui::{Terminal, backend::CrosstermBackend};
 
+use crate::client::apis::configuration::BasicAuth;
 use crate::client::apis::default_api;
 
 mod api;
@@ -23,9 +24,11 @@ use components::StatusMessage;
 fn check_server_connection(
     base_url: &str,
     tls: &crate::client::apis::configuration::TlsConfig,
+    basic_auth: &Option<BasicAuth>,
 ) -> bool {
     let mut config = crate::client::apis::configuration::Configuration::with_tls(tls.clone());
     config.base_path = base_url.to_string();
+    config.basic_auth = basic_auth.clone();
 
     default_api::ping(&config).is_ok()
 }
@@ -36,6 +39,7 @@ pub fn run(
     database: Option<String>,
     tls_ca_cert: Option<String>,
     tls_insecure: bool,
+    basic_auth: Option<BasicAuth>,
 ) -> Result<()> {
     env_logger::init();
 
@@ -47,14 +51,21 @@ pub fn run(
     let mut terminal = Terminal::new(backend)?;
 
     // Create app - this will work even if server is not running
-    let mut app = App::new_with_options(standalone, port, database, tls_ca_cert, tls_insecure)?;
+    let mut app = App::new_with_options(
+        standalone,
+        port,
+        database,
+        tls_ca_cert,
+        tls_insecure,
+        basic_auth,
+    )?;
 
     // In standalone mode, auto-start the server
     if standalone {
         app.start_server_standalone();
         // Give server a moment to start, then try to connect
         std::thread::sleep(std::time::Duration::from_millis(500));
-        if check_server_connection(&app.server_url, &app.tls) {
+        if check_server_connection(&app.server_url, &app.tls, &app.basic_auth) {
             app.set_status(StatusMessage::success("Server started in standalone mode"));
             let _ = app.refresh_workflows();
             // Check server version
@@ -66,7 +77,7 @@ pub fn run(
         }
     } else {
         // Check if server is running and show appropriate message
-        if check_server_connection(&app.server_url, &app.tls) {
+        if check_server_connection(&app.server_url, &app.tls, &app.basic_auth) {
             // Connected - check version
             app.check_server_version();
         } else {

--- a/src/tui/api.rs
+++ b/src/tui/api.rs
@@ -1,4 +1,4 @@
-use crate::client::apis::configuration::{Configuration, TlsConfig};
+use crate::client::apis::configuration::{BasicAuth, Configuration, TlsConfig};
 use crate::client::apis::default_api;
 use crate::client::config::TorcConfig;
 use crate::client::workflow_spec::WorkflowSpec;
@@ -15,10 +15,10 @@ pub struct TorcClient {
 impl TorcClient {
     #[allow(dead_code)]
     pub fn new() -> Result<Self> {
-        Self::new_with_tls(TlsConfig::default())
+        Self::new_with_tls(TlsConfig::default(), None)
     }
 
-    pub fn new_with_tls(tls: TlsConfig) -> Result<Self> {
+    pub fn new_with_tls(tls: TlsConfig, basic_auth: Option<BasicAuth>) -> Result<Self> {
         // Load configuration from files (system, user, local) and environment variables
         // Priority: TORC_API_URL env var > config system > default
         //
@@ -32,18 +32,24 @@ impl TorcClient {
 
         let mut config = Configuration::with_tls(tls);
         config.base_path = base_url;
+        config.basic_auth = basic_auth;
 
         Ok(Self { config })
     }
 
     #[allow(dead_code)]
     pub fn from_url(base_url: String) -> Result<Self> {
-        Self::from_url_with_tls(base_url, TlsConfig::default())
+        Self::from_url_with_tls(base_url, TlsConfig::default(), None)
     }
 
-    pub fn from_url_with_tls(base_url: String, tls: TlsConfig) -> Result<Self> {
+    pub fn from_url_with_tls(
+        base_url: String,
+        tls: TlsConfig,
+        basic_auth: Option<BasicAuth>,
+    ) -> Result<Self> {
         let mut config = Configuration::with_tls(tls);
         config.base_path = base_url;
+        config.basic_auth = basic_auth;
 
         Ok(Self { config })
     }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -13,7 +13,7 @@ use crate::client::log_paths::{
 use crate::client::sse_client::SseEvent;
 use crate::models::{FileModel, JobModel, ResultModel, ScheduledComputeNodesModel, WorkflowModel};
 
-use crate::client::apis::configuration::TlsConfig;
+use crate::client::apis::configuration::{BasicAuth, TlsConfig};
 
 use super::api::TorcClient;
 use super::components::{
@@ -269,12 +269,15 @@ pub struct App {
 
     // TLS configuration
     pub tls: TlsConfig,
+
+    // Authentication
+    pub basic_auth: Option<BasicAuth>,
 }
 
 impl App {
     #[allow(dead_code)]
     pub fn new() -> Result<Self> {
-        Self::new_with_options(false, 8080, None, None, false)
+        Self::new_with_options(false, 8080, None, None, false, None)
     }
 
     pub fn new_with_options(
@@ -283,12 +286,13 @@ impl App {
         database: Option<String>,
         tls_ca_cert: Option<String>,
         tls_insecure: bool,
+        basic_auth: Option<BasicAuth>,
     ) -> Result<Self> {
         let tls = TlsConfig {
             ca_cert_path: tls_ca_cert.as_ref().map(std::path::PathBuf::from),
             insecure: tls_insecure,
         };
-        let client = TorcClient::new_with_tls(tls.clone())?;
+        let client = TorcClient::new_with_tls(tls.clone(), basic_auth.clone())?;
 
         // In standalone mode, override the server URL to use the specified port
         let server_url = if standalone {
@@ -346,6 +350,7 @@ impl App {
             sse_thread: None,
             sse_workflow_id: None,
             tls,
+            basic_auth,
         };
 
         // Update client to use the correct URL
@@ -755,9 +760,12 @@ impl App {
             return Ok(());
         }
 
-        // Create new client with updated URL
-        self.client =
-            TorcClient::from_url_with_tls(self.server_url_input.clone(), self.tls.clone())?;
+        // Create new client with updated URL, preserving authentication
+        self.client = TorcClient::from_url_with_tls(
+            self.server_url_input.clone(),
+            self.tls.clone(),
+            self.basic_auth.clone(),
+        )?;
         self.server_url = self.server_url_input.clone();
         self.focus = Focus::Workflows;
 
@@ -905,6 +913,7 @@ impl App {
         let mut config =
             crate::client::apis::configuration::Configuration::with_tls(self.tls.clone());
         config.base_path = self.server_url.clone();
+        config.basic_auth = self.basic_auth.clone();
 
         let result = version_check::check_version(&config);
 
@@ -2055,11 +2064,13 @@ impl App {
         // Get the base URL for SSE connection
         let base_url = self.server_url.clone();
         let tls = self.tls.clone();
+        let basic_auth = self.basic_auth.clone();
 
         // Start background thread for SSE connection
         let handle = std::thread::spawn(move || {
             let mut config = crate::client::apis::configuration::Configuration::with_tls(tls);
             config.base_path = base_url;
+            config.basic_auth = basic_auth;
 
             match crate::client::sse_client::SseConnection::connect(&config, workflow_id, None) {
                 Ok(mut connection) => {

--- a/src/tui_runner.rs
+++ b/src/tui_runner.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
 use clap::Parser;
 
+use crate::client::apis::configuration::BasicAuth;
+
 #[derive(Parser, Debug)]
 #[command(about = "Interactive terminal UI for managing workflows", long_about = None)]
 pub struct Args {
@@ -25,7 +27,7 @@ pub struct Args {
     pub tls_insecure: bool,
 }
 
-pub fn run(args: &Args) -> Result<()> {
+pub fn run(args: &Args, basic_auth: Option<BasicAuth>) -> Result<()> {
     // Initialize the TUI
     // The TUI code will be in the optional 'tui' module
     #[cfg(feature = "tui")]
@@ -36,12 +38,14 @@ pub fn run(args: &Args) -> Result<()> {
             args.database.clone(),
             args.tls_ca_cert.clone(),
             args.tls_insecure,
+            basic_auth,
         )
     }
 
     #[cfg(not(feature = "tui"))]
     {
         let _ = args; // Suppress unused warning
+        let _ = basic_auth;
         eprintln!("Error: TUI support was not compiled into this binary");
         eprintln!("Please rebuild with --features tui or use the standalone torc-tui binary");
         std::process::exit(1);


### PR DESCRIPTION
The TUI was not using TORC_PASSWORD for API requests, unlike all other commands. Thread basic_auth from the CLI config through tui_runner, tui::run, App, and TorcClient so that authentication works for all TUI API calls including SSE streaming, server version checks, and URL changes.