### PR TITLE
Remove sstat polling by default

### DIFF
--- a/docs/src/core/monitoring/debugging.md
+++ b/docs/src/core/monitoring/debugging.md
@@ -34,7 +34,7 @@ torc results list <workflow_id>
 ```
 Results for workflow ID 2:
 ╭────┬────────┬───────┬────────┬─────────────┬───────────┬──────────┬────────────┬──────────────────────────┬────────╮
-│ ID │ Job ID │ WF ID │ Run ID │ Return Code │ Exec Time │ Peak Mem │ Peak CPU % │ Completion Time          │ Status │
+│ ID │ Job ID │ WF ID │ Run ID │ Return Code │ Exec Time │ Peak Mem │ Avg CPU % │ Completion Time          │ Status │
 ├────┼────────┼───────┼────────┼─────────────┼───────────┼──────────┼────────────┼──────────────────────────┼────────┤
 │ 4  │ 6      │ 2     │ 1      │ 1           │ 1.01      │ 73.8MB   │ 21.9%      │ 2025-11-13T13:35:43.289Z │ Done   │
 │ 5  │ 4      │ 2     │ 1      │ 0           │ 1.01      │ 118.1MB  │ 301.3%     │ 2025-11-13T13:35:43.393Z │ Done   │
@@ -53,7 +53,7 @@ torc results list <workflow_id> --failed
 ```
 Results for workflow ID 2:
 ╭────┬────────┬───────┬────────┬─────────────┬───────────┬──────────┬────────────┬──────────────────────────┬────────╮
-│ ID │ Job ID │ WF ID │ Run ID │ Return Code │ Exec Time │ Peak Mem │ Peak CPU % │ Completion Time          │ Status │
+│ ID │ Job ID │ WF ID │ Run ID │ Return Code │ Exec Time │ Peak Mem │ Avg CPU % │ Completion Time          │ Status │
 ├────┼────────┼───────┼────────┼─────────────┼───────────┼──────────┼────────────┼──────────────────────────┼────────┤
 │ 4  │ 6      │ 2     │ 1      │ 1           │ 1.01      │ 73.8MB   │ 21.9%      │ 2025-11-13T13:35:43.289Z │ Done   │
 ╰────┴────────┴───────┴────────┴─────────────┴───────────┴──────────┴────────────┴──────────────────────────┴────────╯

--- a/slurm-tests/lib/test_framework.sh
+++ b/slurm-tests/lib/test_framework.sh
@@ -309,25 +309,25 @@ assert_multi_node_dispatch() {
     assert_ge "$count" "$expected" "workflow $wf_id dispatched to >= $expected distinct nodes (got $count)"
 }
 
-# assert_peak_cpu_nonzero WF_ID JOB_NAME
-#   Checks that peak_cpu_percent > 0 in the results for this job.
-assert_peak_cpu_nonzero() {
+# assert_avg_cpu_nonzero WF_ID JOB_NAME
+#   Checks that avg_cpu_percent > 0 in the results for this job.
+assert_avg_cpu_nonzero() {
     local wf_id="$1" job_name="$2"
-    local job_id peak_cpu
+    local job_id avg_cpu
     job_id=$(torc --url "$TORC_API_URL" -f json jobs list "$wf_id" 2>/dev/null \
         | jq -r ".jobs[] | select(.name == \"$job_name\") | .id")
-    peak_cpu=$(torc --url "$TORC_API_URL" -f json results list "$wf_id" 2>/dev/null \
-        | jq -r "[.results[] | select(.job_id == $job_id)] | sort_by(.attempt_id) | last | .peak_cpu_percent // 0")
-    assert_gt_float "${peak_cpu:-0}" "0" "job '$job_name' peak_cpu_percent > 0 (got $peak_cpu)"
+    avg_cpu=$(torc --url "$TORC_API_URL" -f json results list "$wf_id" 2>/dev/null \
+        | jq -r "[.results[] | select(.job_id == $job_id)] | sort_by(.attempt_id) | last | .avg_cpu_percent // 0")
+    assert_gt_float "${avg_cpu:-0}" "0" "job '$job_name' avg_cpu_percent > 0 (got $avg_cpu)"
 }
 
-# assert_any_peak_cpu_nonzero WF_ID — at least one job in the workflow has peak_cpu > 0
-assert_any_peak_cpu_nonzero() {
+# assert_any_avg_cpu_nonzero WF_ID — at least one job in the workflow has avg_cpu > 0
+assert_any_avg_cpu_nonzero() {
     local wf_id="$1"
-    local max_peak_cpu
-    max_peak_cpu=$(torc --url "$TORC_API_URL" -f json results list "$wf_id" 2>/dev/null \
-        | jq -r '[.results[].peak_cpu_percent // 0] | max // 0')
-    assert_gt_float "${max_peak_cpu:-0}" "0" "at least one job has peak_cpu_percent > 0 (max=$max_peak_cpu)"
+    local max_avg_cpu
+    max_avg_cpu=$(torc --url "$TORC_API_URL" -f json results list "$wf_id" 2>/dev/null \
+        | jq -r '[.results[].avg_cpu_percent // 0] | max // 0')
+    assert_gt_float "${max_avg_cpu:-0}" "0" "at least one job has avg_cpu_percent > 0 (max=$max_avg_cpu)"
 }
 
 # assert_peak_memory_nonzero WF_ID JOB_NAME

--- a/slurm-tests/tests/test_no_srun_basic.sh
+++ b/slurm-tests/tests/test_no_srun_basic.sh
@@ -5,7 +5,7 @@
 # Verifies:
 #   - Workflow completes successfully with use_srun=false
 #   - Both jobs complete with return code 0
-#   - peak_cpu_percent > 0 for cpu_work
+#   - avg_cpu_percent > 0 for cpu_work
 #   - peak_memory_bytes > 0 for memory_work
 #   - Time-series resource metrics DB exists and has sample data
 
@@ -25,7 +25,7 @@ run_test_no_srun_basic() {
     assert_return_code "$wf_id" "memory_work" "0"
 
     # Resource monitoring data captured (via process-level sysinfo, not sstat)
-    assert_peak_cpu_nonzero "$wf_id" "cpu_work"
+    assert_avg_cpu_nonzero "$wf_id" "cpu_work"
     assert_peak_memory_nonzero "$wf_id" "memory_work"
 
     # Check time-series resource metrics DB exists and has data

--- a/slurm-tests/tests/test_resource_monitoring.sh
+++ b/slurm-tests/tests/test_resource_monitoring.sh
@@ -4,7 +4,7 @@
 #
 # Verifies:
 #   - Both jobs complete successfully
-#   - peak_cpu_percent > 0 for cpu_work
+#   - avg_cpu_percent > 0 for cpu_work
 #   - peak_memory_bytes > 0 for memory_work
 
 run_test_resource_monitoring() {
@@ -23,7 +23,7 @@ run_test_resource_monitoring() {
     assert_return_code "$wf_id" "memory_work" "0"
 
     # Resource monitoring data captured
-    assert_peak_cpu_nonzero "$wf_id" "cpu_work"
+    assert_avg_cpu_nonzero "$wf_id" "cpu_work"
     assert_peak_memory_nonzero "$wf_id" "memory_work"
 
     # Also check that results are available in reports

--- a/slurm-tests/workflows/resource_monitoring.yaml
+++ b/slurm-tests/workflows/resource_monitoring.yaml
@@ -2,7 +2,7 @@
 #
 # 1-node allocation with resource monitoring enabled.
 # 2 jobs: cpu_work (sustained load 30s) + memory_work (allocate 500MB for 30s).
-# Verifies peak_cpu_percent > 0 and peak_memory_bytes > 0 in reports results.
+# Verifies avg_cpu_percent > 0 and peak_memory_bytes > 0 in reports results.
 
 name: resource_monitoring
 description: Resource monitoring validation — CPU and memory usage captured

--- a/src/client/async_cli_command.rs
+++ b/src/client/async_cli_command.rs
@@ -259,10 +259,14 @@ impl AsyncCliCommand {
         // slurmstepd (not as a child of the srun process), so sysinfo process-tree
         // monitoring captures only the negligible srun overhead.  Instead:
         //   - TimeSeries mode: use sstat polling via start_monitoring_slurm().
-        //   - Summary mode: skip the monitor; sacct backfill in job_runner provides final stats.
+        //   - Summary mode: skip the monitor entirely; sacct backfill in job_runner
+        //     provides authoritative peak memory (MaxRSS) and average CPU data after
+        //     job completion without the overhead of periodic sstat/squeue polling.
         if let Some(monitor) = resource_monitor {
             if let Some(ref step) = self.step_name {
-                if let Ok(slurm_job_id) = std::env::var("SLURM_JOB_ID") {
+                if monitor.is_timeseries()
+                    && let Ok(slurm_job_id) = std::env::var("SLURM_JOB_ID")
+                {
                     // Discover the numeric step ID that Slurm assigned. sstat requires
                     // numeric IDs (e.g., "1") — name-based lookup doesn't work on all
                     // Slurm installations (notably HPE Cray EX).

--- a/src/client/commands/results.rs
+++ b/src/client/commands/results.rs
@@ -90,8 +90,8 @@ struct ResultTableRow {
     exec_time: String,
     #[tabled(rename = "Peak Mem")]
     peak_memory: String,
-    #[tabled(rename = "Peak CPU %")]
-    peak_cpu: String,
+    #[tabled(rename = "Avg CPU %")]
+    avg_cpu: String,
     #[tabled(rename = "Completion Time")]
     completion_time: String,
     #[tabled(rename = "Status")]
@@ -276,7 +276,7 @@ pub fn handle_result_commands(config: &Configuration, command: &ResultCommands, 
                                 return_code: result.return_code,
                                 exec_time: format!("{:.2}", result.exec_time_minutes),
                                 peak_memory: format_memory(result.peak_memory_bytes),
-                                peak_cpu: format_cpu(result.peak_cpu_percent),
+                                avg_cpu: format_cpu(result.avg_cpu_percent),
                                 completion_time: result.completion_time.clone(),
                                 status: format!("{:?}", result.status),
                             })
@@ -311,7 +311,6 @@ pub fn handle_result_commands(config: &Configuration, command: &ResultCommands, 
                     // Display resource metrics if available
                     if result.peak_memory_bytes.is_some()
                         || result.avg_memory_bytes.is_some()
-                        || result.peak_cpu_percent.is_some()
                         || result.avg_cpu_percent.is_some()
                     {
                         println!("\n  Resource Metrics:");
@@ -320,9 +319,6 @@ pub fn handle_result_commands(config: &Configuration, command: &ResultCommands, 
                         }
                         if let Some(avg_mem) = result.avg_memory_bytes {
                             println!("    Avg Memory:  {}", format_memory(Some(avg_mem)));
-                        }
-                        if let Some(peak_cpu) = result.peak_cpu_percent {
-                            println!("    Peak CPU:    {}", format_cpu(Some(peak_cpu)));
                         }
                         if let Some(avg_cpu) = result.avg_cpu_percent {
                             println!("    Avg CPU:     {}", format_cpu(Some(avg_cpu)));

--- a/src/client/resource_monitor.rs
+++ b/src/client/resource_monitor.rs
@@ -209,14 +209,14 @@ impl ResourceMonitor {
         Ok(())
     }
 
-    /// Register a Slurm step for sstat-based monitoring.
+    /// Register a Slurm step for sstat-based monitoring (`TimeSeries` mode only).
     ///
-    /// Registers a Slurm step for sstat-based monitoring in both `TimeSeries` and `Summary` modes.
+    /// In `TimeSeries` mode the per-sample data is written to the time-series database,
+    /// enabling detailed resource utilization plots over time.
     ///
-    /// In `TimeSeries` mode the per-sample data is written to the time-series database.
-    /// In `Summary` mode only the peak metrics are kept in memory — this provides a fallback
-    /// when sacct has no useful data for short or failed steps (sacct may report MaxRSS=0 /
-    /// AveCPU=00:00:00 for steps that finished before the accounting daemon could flush).
+    /// In `Summary` mode this method should **not** be called — sacct backfill after job
+    /// completion provides authoritative peak memory (MaxRSS) and average CPU data without
+    /// the overhead of periodic sstat/squeue polling.
     ///
     /// `pid` must be the srun process PID so that the existing `stop_monitoring(pid)` API
     /// continues to work without changes.

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -733,7 +733,14 @@ fn draw_results_table(f: &mut Frame, area: Rect, app: &mut App) {
         .add_modifier(Modifier::BOLD);
 
     let header = Row::new(vec![
-        "ID", "Job ID", "Run", "Attempt", "Return", "Status", "Peak Mem", "Peak CPU",
+        "ID",
+        "Job ID",
+        "Run",
+        "Attempt",
+        "Return",
+        "Status",
+        "Peak Mem",
+        "Avg CPU %",
     ])
     .style(header_style)
     .bottom_margin(1);
@@ -752,9 +759,9 @@ fn draw_results_table(f: &mut Frame, area: Rect, app: &mut App) {
             .map(format_bytes)
             .unwrap_or_else(|| "-".to_string());
 
-        // Format peak CPU percentage
-        let peak_cpu = result
-            .peak_cpu_percent
+        // Format average CPU percentage
+        let avg_cpu = result
+            .avg_cpu_percent
             .map(|pct| format!("{:.1}%", pct))
             .unwrap_or_else(|| "-".to_string());
 
@@ -776,7 +783,7 @@ fn draw_results_table(f: &mut Frame, area: Rect, app: &mut App) {
             )),
             Cell::from(Span::styled(status, Style::default().fg(row_color))),
             Cell::from(peak_mem),
-            Cell::from(peak_cpu),
+            Cell::from(avg_cpu),
         ])
     });
 
@@ -808,7 +815,7 @@ fn draw_results_table(f: &mut Frame, area: Rect, app: &mut App) {
             Constraint::Length(7),  // Return
             Constraint::Length(12), // Status
             Constraint::Length(10), // Peak Mem
-            Constraint::Length(10), // Peak CPU
+            Constraint::Length(10), // Avg CPU %
         ],
     )
     .header(header)
@@ -920,7 +927,7 @@ fn draw_slurm_stats_table(f: &mut Frame, area: Rect, app: &mut App) {
         "Max RSS",
         "Max VM",
         "Ave CPU (s)",
-        "CPU %",
+        "Avg CPU %",
         "Nodes",
     ])
     .style(header_style)
@@ -1007,7 +1014,7 @@ fn draw_slurm_stats_table(f: &mut Frame, area: Rect, app: &mut App) {
             Constraint::Length(10), // Max RSS
             Constraint::Length(10), // Max VM
             Constraint::Length(12), // Ave CPU (s)
-            Constraint::Length(10), // CPU %
+            Constraint::Length(10), // Avg CPU %
             Constraint::Min(10),    // Nodes
         ],
     )

--- a/tests/test_srun_args.rs
+++ b/tests/test_srun_args.rs
@@ -112,9 +112,14 @@ fn run_and_capture_srun_args(
         result.err()
     );
 
-    // Wait for the job to finish
-    thread::sleep(Duration::from_millis(500));
-    let _ = cmd.check_status();
+    // Poll until the process finishes (up to 10s).
+    for _ in 0..100 {
+        let _ = cmd.check_status();
+        if !cmd.is_running {
+            break;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
 
     if args_log.exists() {
         Some(fs::read_to_string(args_log).expect("Failed to read srun args log"))

--- a/torc-dash/static/js/app-details.js
+++ b/torc-dash/static/js/app-details.js
@@ -425,7 +425,7 @@ Object.assign(TorcDashboard.prototype, {
                         <td><span class="status-badge status-${statusNames[result.status]?.toLowerCase() || 'unknown'}">${statusNames[result.status] || result.status}</span></td>
                         <td>${result.exec_time_minutes != null ? result.exec_time_minutes.toFixed(2) : '-'}</td>
                         <td>${this.formatBytes(result.peak_memory_bytes)}</td>
-                        <td>${result.peak_cpu_percent != null ? result.peak_cpu_percent.toFixed(1) : '-'}</td>
+                        <td>${result.avg_cpu_percent != null ? result.avg_cpu_percent.toFixed(1) : '-'}</td>
                     </tr>
                 `).join('');
 
@@ -608,7 +608,7 @@ Object.assign(TorcDashboard.prototype, {
             'return_code': () => item.return_code,
             'exec_time': () => item.exec_time_minutes,
             'peak_mem': () => item.peak_memory_bytes,
-            'peak_cpu': () => item.peak_cpu_percent,
+            'avg_cpu': () => item.avg_cpu_percent,
             'modified': () => item.st_mtime,
         };
         if (fieldMap[field]) {

--- a/torc-dash/static/js/app-job-details.js
+++ b/torc-dash/static/js/app-job-details.js
@@ -205,7 +205,7 @@ Object.assign(TorcDashboard.prototype, {
                                     <th>Status</th>
                                     <th>Exec Time (min)</th>
                                     <th>Peak Mem</th>
-                                    <th>Peak CPU %</th>
+                                    <th>Avg CPU %</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -217,7 +217,7 @@ Object.assign(TorcDashboard.prototype, {
                                         <td><span class="status-badge status-${statusNames[r.status]?.toLowerCase() || 'unknown'}">${statusNames[r.status] || r.status}</span></td>
                                         <td>${r.exec_time_minutes != null ? r.exec_time_minutes.toFixed(2) : '-'}</td>
                                         <td>${this.formatBytes(r.peak_memory_bytes)}</td>
-                                        <td>${r.peak_cpu_percent != null ? r.peak_cpu_percent.toFixed(1) : '-'}</td>
+                                        <td>${r.avg_cpu_percent != null ? r.avg_cpu_percent.toFixed(1) : '-'}</td>
                                     </tr>
                                 `).join('')}
                             </tbody>

--- a/torc-dash/static/js/app-tables.js
+++ b/torc-dash/static/js/app-tables.js
@@ -143,7 +143,7 @@ Object.assign(TorcDashboard.prototype, {
                         ${this.renderSortableHeader('Status', 'status')}
                         ${this.renderSortableHeader('Exec Time (min)', 'exec_time_minutes')}
                         ${this.renderSortableHeader('Peak Mem', 'peak_memory_bytes')}
-                        ${this.renderSortableHeader('Peak CPU %', 'peak_cpu_percent')}
+                        ${this.renderSortableHeader('Avg CPU %', 'avg_cpu_percent')}
                     </tr>
                 </thead>
                 <tbody>
@@ -157,7 +157,7 @@ Object.assign(TorcDashboard.prototype, {
                             <td><span class="status-badge status-${statusNames[result.status]?.toLowerCase() || 'unknown'}">${statusNames[result.status] || result.status}</span></td>
                             <td>${result.exec_time_minutes != null ? result.exec_time_minutes.toFixed(2) : '-'}</td>
                             <td>${this.formatBytes(result.peak_memory_bytes)}</td>
-                            <td>${result.peak_cpu_percent != null ? result.peak_cpu_percent.toFixed(1) : '-'}</td>
+                            <td>${result.avg_cpu_percent != null ? result.avg_cpu_percent.toFixed(1) : '-'}</td>
                         </tr>
                     `).join('')}
                 </tbody>


### PR DESCRIPTION
The resource monitor will now only poll for stats with sstat if the user enabled time-series monitoring.