### PR TITLE
Fix GPU device allocation without srun

### DIFF
--- a/src/client/async_cli_command.rs
+++ b/src/client/async_cli_command.rs
@@ -104,6 +104,7 @@ impl AsyncCliCommand {
         resource_monitor: Option<&ResourceMonitor>,
         api_url: &str,
         resource_requirements: Option<&ResourceRequirementsModel>,
+        gpu_visible_devices: Option<&str>,
         limit_resources: bool,
         use_srun: bool,
         enable_cpu_bind: bool,
@@ -228,6 +229,13 @@ impl AsyncCliCommand {
             shell.arg(&command_str);
             shell
         };
+
+        if let Some(v) = gpu_visible_devices {
+            cmd.env("CUDA_VISIBLE_DEVICES", v)
+                .env("HIP_VISIBLE_DEVICES", v)
+                .env("ROCR_VISIBLE_DEVICES", v)
+                .env("TORC_GPU_VISIBLE_DEVICES", v);
+        }
 
         let child = cmd
             .env("TORC_WORKFLOW_ID", workflow_id_str)

--- a/src/client/job_runner.rs
+++ b/src/client/job_runner.rs
@@ -26,7 +26,7 @@
 
 use chrono::{DateTime, Utc};
 use log::{self, debug, error, info, warn};
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -240,6 +240,13 @@ pub struct JobRunner {
     is_subtask: bool,
     running_jobs: HashMap<i64, AsyncCliCommand>,
     job_resources: HashMap<i64, ResourceRequirementsModel>,
+    /// Pool of GPU device identifiers available to this runner (e.g. `"0"`, `"1"` or UUIDs).
+    ///
+    /// When `srun` is disabled, Torc runs jobs directly and must set `CUDA_VISIBLE_DEVICES`
+    /// (and friends) itself to prevent concurrent GPU jobs from all defaulting to GPU 0.
+    available_gpu_devices: VecDeque<String>,
+    /// GPUs assigned to a running job, keyed by job_id.
+    job_gpu_devices: HashMap<i64, Vec<String>>,
     /// Per-node resource tracker for multi-node Slurm allocations.
     /// None for single-node allocations where dividing total by 1 is correct.
     node_tracker: Option<PerNodeTracker>,
@@ -264,6 +271,100 @@ pub struct JobRunner {
 }
 
 impl JobRunner {
+    fn parse_visible_devices_list(value: &str) -> Vec<String> {
+        value
+            .split(',')
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .collect()
+    }
+
+    fn detect_gpu_devices(resources_num_gpus: i64) -> (VecDeque<String>, bool) {
+        // Prefer an explicit allocation-scoped device list if present.
+        // - Slurm: CUDA_VISIBLE_DEVICES is commonly set at allocation scope.
+        // - Some clusters also set SLURM_JOB_GPUS / SLURM_STEP_GPUS.
+        if let Ok(v) = std::env::var("CUDA_VISIBLE_DEVICES") {
+            let parsed = Self::parse_visible_devices_list(&v);
+            if !parsed.is_empty() {
+                return (VecDeque::from(parsed), true);
+            }
+        }
+        if let Ok(v) = std::env::var("SLURM_STEP_GPUS") {
+            let parsed = Self::parse_visible_devices_list(&v)
+                .into_iter()
+                .map(|s| {
+                    s.trim_start_matches("gpu:")
+                        .trim_start_matches("GPU:")
+                        .to_string()
+                })
+                .collect::<Vec<_>>();
+            if !parsed.is_empty() {
+                return (VecDeque::from(parsed), true);
+            }
+        }
+        if let Ok(v) = std::env::var("SLURM_JOB_GPUS") {
+            let parsed = Self::parse_visible_devices_list(&v)
+                .into_iter()
+                .map(|s| {
+                    s.trim_start_matches("gpu:")
+                        .trim_start_matches("GPU:")
+                        .to_string()
+                })
+                .collect::<Vec<_>>();
+            if !parsed.is_empty() {
+                return (VecDeque::from(parsed), true);
+            }
+        }
+
+        // Fall back to ordinal device indices.
+        let fallback = (0..resources_num_gpus.max(0))
+            .map(|i| i.to_string())
+            .collect::<Vec<_>>();
+        (VecDeque::from(fallback), false)
+    }
+
+    fn allocate_gpu_devices(&mut self, job_id: i64, num_gpus: i64) -> Option<String> {
+        if num_gpus <= 0 {
+            return None;
+        }
+
+        let requested = num_gpus as usize;
+        if self.available_gpu_devices.len() < requested {
+            error!(
+                "Insufficient GPUs to start job workflow_id={} job_id={} requested={} available={}",
+                self.workflow_id,
+                job_id,
+                requested,
+                self.available_gpu_devices.len()
+            );
+            return None;
+        }
+
+        let mut assigned = Vec::with_capacity(requested);
+        for _ in 0..requested {
+            if let Some(dev) = self.available_gpu_devices.pop_front() {
+                assigned.push(dev);
+            }
+        }
+
+        let visible = assigned.join(",");
+        self.job_gpu_devices.insert(job_id, assigned);
+        debug!(
+            "Assigned GPUs workflow_id={} job_id={} gpus={}",
+            self.workflow_id, job_id, visible
+        );
+        Some(visible)
+    }
+
+    fn release_gpu_devices(&mut self, job_id: i64) {
+        if let Some(devs) = self.job_gpu_devices.remove(&job_id) {
+            for dev in devs {
+                self.available_gpu_devices.push_back(dev);
+            }
+        }
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         config: Configuration,
@@ -295,6 +396,15 @@ impl JobRunner {
         );
         let slurm_config = SlurmConfig::from_workflow_model(&workflow);
         let job_resources: HashMap<i64, ResourceRequirementsModel> = HashMap::new();
+
+        // If the environment already constrains visible GPUs (common inside Slurm allocations),
+        // use that list as the authoritative pool and sync the resource counts to match.
+        let mut resources = resources;
+        let (available_gpu_devices, env_constrained) = Self::detect_gpu_devices(resources.num_gpus);
+        if env_constrained {
+            resources.num_gpus = available_gpu_devices.len() as i64;
+        }
+
         let orig_resources = ComputeNodesResources {
             id: resources.id,
             num_cpus: resources.num_cpus,
@@ -352,6 +462,8 @@ impl JobRunner {
             is_subtask,
             running_jobs,
             job_resources,
+            available_gpu_devices,
+            job_gpu_devices: HashMap::new(),
             node_tracker,
             job_nodes: HashMap::new(),
             slurm_config,
@@ -1167,6 +1279,7 @@ impl JobRunner {
         }
         self.running_jobs.remove(&job_id);
         self.job_resources.remove(&job_id);
+        self.release_gpu_devices(job_id);
     }
 
     /// Run a recovery script with environment variables set.
@@ -1612,6 +1725,12 @@ impl JobRunner {
                     }
 
                     let attempt_id = async_job.job.attempt_id.unwrap_or(1);
+                    let use_srun = self.slurm_config.use_srun();
+                    let gpu_visible_devices = if use_srun {
+                        None
+                    } else {
+                        self.allocate_gpu_devices(job_id, job_rr.num_gpus)
+                    };
                     match async_job.start(
                         &self.output_dir,
                         self.workflow_id,
@@ -1620,8 +1739,9 @@ impl JobRunner {
                         self.resource_monitor.as_ref(),
                         &self.config.base_path,
                         Some(&job_rr),
+                        gpu_visible_devices.as_deref(),
                         self.slurm_config.limit_resources(),
-                        self.slurm_config.use_srun(),
+                        use_srun,
                         self.slurm_config.enable_cpu_bind(),
                         self.end_time,
                         self.slurm_config.srun_termination_signal.as_deref(),
@@ -1649,6 +1769,7 @@ impl JobRunner {
                                 "Job start failed workflow_id={} job_id={} error={}",
                                 self.workflow_id, job_id, e
                             );
+                            self.release_gpu_devices(job_id);
                             continue;
                         }
                     }
@@ -1742,6 +1863,12 @@ impl JobRunner {
                     }
 
                     let attempt_id = async_job.job.attempt_id.unwrap_or(1);
+                    let use_srun = self.slurm_config.use_srun();
+                    let gpu_visible_devices = if use_srun {
+                        None
+                    } else {
+                        self.allocate_gpu_devices(job_id, job_rr.num_gpus)
+                    };
                     match async_job.start(
                         &self.output_dir,
                         self.workflow_id,
@@ -1750,8 +1877,9 @@ impl JobRunner {
                         self.resource_monitor.as_ref(),
                         &self.config.base_path,
                         Some(&job_rr),
+                        gpu_visible_devices.as_deref(),
                         self.slurm_config.limit_resources(),
-                        self.slurm_config.use_srun(),
+                        use_srun,
                         self.slurm_config.enable_cpu_bind(),
                         self.end_time,
                         self.slurm_config.srun_termination_signal.as_deref(),
@@ -1773,6 +1901,7 @@ impl JobRunner {
                                 "Job start failed workflow_id={} job_id={} error={}",
                                 self.workflow_id, job_id, e
                             );
+                            self.release_gpu_devices(job_id);
                             continue;
                         }
                     }

--- a/tests/test_async_cli_command.rs
+++ b/tests/test_async_cli_command.rs
@@ -66,6 +66,7 @@ fn test_async_cli_command_start_simple_command(start_server: &ServerProcess) {
         None,
         "http://localhost:8080/torc-service/v1",
         None,
+        None, // gpu_visible_devices
         true,
         true,
         false,
@@ -108,6 +109,7 @@ fn test_async_cli_command_start_already_running() {
             None,
             "http://localhost:8080/torc-service/v1",
             None,
+            None, // gpu_visible_devices
             true,
             true,
             false,
@@ -127,6 +129,7 @@ fn test_async_cli_command_start_already_running() {
         None,
         "http://localhost:8080/torc-service/v1",
         None,
+        None, // gpu_visible_devices
         true,
         true,
         false,
@@ -157,6 +160,7 @@ fn test_async_cli_command_start_invalid_directory() {
         None,
         "http://localhost:8080/torc-service/v1",
         None,
+        None, // gpu_visible_devices
         true,
         true,
         false,
@@ -183,6 +187,7 @@ fn test_async_cli_command_check_status_completion() {
             None,
             "http://localhost:8080/torc-service/v1",
             None,
+            None, // gpu_visible_devices
             true,
             true,
             false,
@@ -231,6 +236,7 @@ fn test_async_cli_command_with_exit_code_success() {
             None,
             "http://localhost:8080/torc-service/v1",
             None,
+            None, // gpu_visible_devices
             true,
             true,
             false,
@@ -263,6 +269,7 @@ fn test_async_cli_command_with_exit_code_failure() {
             None,
             "http://localhost:8080/torc-service/v1",
             None,
+            None, // gpu_visible_devices
             true,
             true,
             false,
@@ -296,6 +303,7 @@ fn test_async_cli_command_cancel() {
             None,
             "http://localhost:8080/torc-service/v1",
             None,
+            None, // gpu_visible_devices
             true,
             true,
             false,
@@ -342,6 +350,7 @@ fn test_async_cli_command_terminate() {
             None,
             "http://localhost:8080/torc-service/v1",
             None,
+            None, // gpu_visible_devices
             true,
             true,
             false,
@@ -381,6 +390,7 @@ fn test_async_cli_command_wait_for_completion() {
             None,
             "http://localhost:8080/torc-service/v1",
             None,
+            None, // gpu_visible_devices
             true,
             true,
             false,
@@ -422,6 +432,7 @@ fn test_async_cli_command_get_result() {
             None,
             "http://localhost:8080/torc-service/v1",
             None,
+            None, // gpu_visible_devices
             true,
             true,
             false,
@@ -470,6 +481,7 @@ fn test_async_cli_command_with_invocation_script() {
         None,
         "http://localhost:8080/torc-service/v1",
         None,
+        None, // gpu_visible_devices
         true,
         true,
         false,
@@ -505,6 +517,7 @@ fn test_async_cli_command_environment_variables() {
             None,
             "http://localhost:8080/torc-service/v1",
             None,
+            None, // gpu_visible_devices
             true,
             true,
             false,
@@ -527,6 +540,66 @@ fn test_async_cli_command_environment_variables() {
 
 #[rstest]
 #[cfg(unix)]
+fn test_async_cli_command_gpu_visible_devices_env() {
+    let job = create_test_job_model(
+        1,
+        124,
+        "echo CUDA=$CUDA_VISIBLE_DEVICES HIP=$HIP_VISIBLE_DEVICES ROCR=$ROCR_VISIBLE_DEVICES TORC=$TORC_GPU_VISIBLE_DEVICES",
+    );
+    let mut async_cmd = AsyncCliCommand::new(job);
+
+    let temp_dir = create_temp_output_dir();
+
+    async_cmd
+        .start(
+            temp_dir.path(),
+            1, // workflow_id
+            1, // run_id
+            1, // attempt_id
+            None,
+            "http://localhost:8080/torc-service/v1",
+            None,
+            Some("1,3"), // gpu_visible_devices
+            true,
+            false, // use_srun disabled (direct execution)
+            false,
+            None,
+            None,
+            None, // target_node
+        )
+        .expect("Failed to start command");
+    let _ = async_cmd.wait_for_completion();
+
+    let stdout_path = temp_dir
+        .path()
+        .join("job_stdio")
+        .join("job_wf1_j124_r1_a1.o");
+    let contents = fs::read_to_string(stdout_path).expect("Failed to read stdout");
+
+    assert!(
+        contents.contains("CUDA=1,3"),
+        "Missing CUDA_VISIBLE_DEVICES: {}",
+        contents
+    );
+    assert!(
+        contents.contains("HIP=1,3"),
+        "Missing HIP_VISIBLE_DEVICES: {}",
+        contents
+    );
+    assert!(
+        contents.contains("ROCR=1,3"),
+        "Missing ROCR_VISIBLE_DEVICES: {}",
+        contents
+    );
+    assert!(
+        contents.contains("TORC=1,3"),
+        "Missing TORC_GPU_VISIBLE_DEVICES: {}",
+        contents
+    );
+}
+
+#[rstest]
+#[cfg(unix)]
 fn test_async_cli_command_stdout_stderr_separation() {
     let job = create_test_job_model(1, 1, "echo 'stdout message'; echo 'stderr message' >&2");
     let mut async_cmd = AsyncCliCommand::new(job);
@@ -542,6 +615,7 @@ fn test_async_cli_command_stdout_stderr_separation() {
             None,
             "http://localhost:8080/torc-service/v1",
             None,
+            None, // gpu_visible_devices
             true,
             true,
             false,
@@ -579,6 +653,7 @@ fn test_async_cli_command_multiple_jobs_same_workflow() {
             None,
             "http://localhost:8080/torc-service/v1",
             None,
+            None, // gpu_visible_devices
             true,
             true,
             false,
@@ -599,6 +674,7 @@ fn test_async_cli_command_multiple_jobs_same_workflow() {
             None,
             "http://localhost:8080/torc-service/v1",
             None,
+            None, // gpu_visible_devices
             true,
             true,
             false,
@@ -619,6 +695,7 @@ fn test_async_cli_command_multiple_jobs_same_workflow() {
             None,
             "http://localhost:8080/torc-service/v1",
             None,
+            None, // gpu_visible_devices
             true,
             true,
             false,
@@ -663,6 +740,7 @@ fn test_async_cli_command_long_running_job() {
             None,
             "http://localhost:8080/torc-service/v1",
             None,
+            None, // gpu_visible_devices
             true,
             true,
             false,
@@ -713,6 +791,7 @@ fn test_async_cli_command_complex_shell_command() {
             None,
             "http://localhost:8080/torc-service/v1",
             None,
+            None, // gpu_visible_devices
             true,
             true,
             false,
@@ -753,6 +832,7 @@ fn test_async_cli_command_file_creation() {
             None,
             "http://localhost:8080/torc-service/v1",
             None,
+            None, // gpu_visible_devices
             true,
             true,
             false,
@@ -787,6 +867,7 @@ fn test_async_cli_command_drop_while_running() {
             None,
             "http://localhost:8080/torc-service/v1",
             None,
+            None, // gpu_visible_devices
             true,
             true,
             false,
@@ -823,6 +904,7 @@ fn test_async_cli_command_execution_time() {
             None,
             "http://localhost:8080/torc-service/v1",
             None,
+            None, // gpu_visible_devices
             true,
             true,
             false,
@@ -855,6 +937,7 @@ fn test_async_cli_command_empty_command() {
         None,
         "http://localhost:8080/torc-service/v1",
         None,
+        None, // gpu_visible_devices
         true,
         true,
         false,
@@ -884,6 +967,7 @@ fn test_async_cli_command_command_not_found() {
             None,
             "http://localhost:8080/torc-service/v1",
             None,
+            None, // gpu_visible_devices
             true,
             true,
             false,

--- a/tests/test_srun_args.rs
+++ b/tests/test_srun_args.rs
@@ -99,6 +99,7 @@ fn run_and_capture_srun_args(
         None,
         "http://localhost:8080/torc-service/v1",
         rr,
+        None, // gpu_visible_devices
         limit_resources,
         use_srun,
         enable_cpu_bind,
@@ -598,6 +599,7 @@ fn test_srun_step_name_format() {
         None,
         "http://localhost:8080/torc-service/v1",
         Some(&rr),
+        None, // gpu_visible_devices
         true,
         true,
         false,


### PR DESCRIPTION
When srun is disabled, assign GPU jobs a unique subset of devices and export CUDA/HIP/ROCR_VISIBLE_DEVICES to prevent all jobs defaulting to GPU0.