### PR TITLE
Restore bulk_jobs body limit in live router

### DIFF
--- a/docs/src/core/reference/configuration.md
+++ b/docs/src/core/reference/configuration.md
@@ -287,18 +287,19 @@ Environment variables use double underscore (`__`) to separate nested keys.
 
 These environment variables are still supported directly by clap:
 
-| Variable                              | Component | Description                             |
-| ------------------------------------- | --------- | --------------------------------------- |
-| `TORC_API_URL`                        | Client    | Server API URL (CLI only)               |
-| `TORC_PASSWORD`                       | Client    | Authentication password (CLI only)      |
-| `TORC_TLS_CA_CERT`                    | Client    | PEM-encoded CA certificate path         |
-| `TORC_TLS_INSECURE`                   | Client    | Skip certificate verification           |
-| `TORC_AUTH_FILE`                      | Server    | htpasswd file path                      |
-| `TORC_LOG_DIR`                        | Server    | Log directory                           |
-| `TORC_COMPLETION_CHECK_INTERVAL_SECS` | Server    | Completion check interval               |
-| `TORC_ADMIN_USERS`                    | Server    | Comma-separated list of admin usernames |
-| `DATABASE_URL`                        | Server    | SQLite database URL                     |
-| `RUST_LOG`                            | All       | Log level filter                        |
+| Variable                              | Component | Description                              |
+| ------------------------------------- | --------- | ---------------------------------------- |
+| `TORC_API_URL`                        | Client    | Server API URL (CLI only)                |
+| `TORC_PASSWORD`                       | Client    | Authentication password (CLI only)       |
+| `TORC_TLS_CA_CERT`                    | Client    | PEM-encoded CA certificate path          |
+| `TORC_TLS_INSECURE`                   | Client    | Skip certificate verification            |
+| `TORC_AUTH_FILE`                      | Server    | htpasswd file path                       |
+| `TORC_LOG_DIR`                        | Server    | Log directory                            |
+| `TORC_COMPLETION_CHECK_INTERVAL_SECS` | Server    | Completion check interval                |
+| `TORC_ADMIN_USERS`                    | Server    | Comma-separated list of admin usernames  |
+| `TORC_MAX_REQUEST_BODY_MB`            | Server    | Bulk job upload request-body limit (MiB) |
+| `DATABASE_URL`                        | Server    | SQLite database URL                      |
+| `RUST_LOG`                            | All       | Log level filter                         |
 
 ## Complete Example
 

--- a/docs/src/specialized/admin/server-deployment.md
+++ b/docs/src/specialized/admin/server-deployment.md
@@ -136,14 +136,19 @@ RUST_LOG=debug torc-server run --log-dir /var/log/torc
 
 - `TORC_LOG_DIR`: Default log directory
 - `RUST_LOG`: Default log level
+- `TORC_MAX_REQUEST_BODY_MB`: Override the bulk job upload request-body limit in MiB
 
 Example:
 
 ```bash
 export TORC_LOG_DIR=/var/log/torc
 export RUST_LOG=info
+export TORC_MAX_REQUEST_BODY_MB=500
 torc-server run
 ```
+
+`TORC_MAX_REQUEST_BODY_MB` applies to `POST /torc-service/v1/bulk_jobs`. Other JSON routes still use
+Axum's default `2 MiB` body limit.
 
 ## Daemonization (Unix/Linux Only)
 

--- a/src/server/live_router.rs
+++ b/src/server/live_router.rs
@@ -56,16 +56,16 @@ macro_rules! path_handler {
 
 /// Default maximum allowed request body size for bulk job creation (200 MiB).
 /// Override at runtime with TORC_MAX_REQUEST_BODY_MB (value in MiB).
-const DEFAULT_MAX_REQUEST_BODY_BYTES: usize = 200 * 1024 * 1024;
+const DEFAULT_MAX_BULK_REQUEST_BODY_BYTES: usize = 200 * 1024 * 1024;
 
-fn max_request_body_bytes() -> usize {
+fn max_bulk_request_body_bytes() -> usize {
     static CACHED: OnceLock<usize> = OnceLock::new();
     *CACHED.get_or_init(|| {
         std::env::var("TORC_MAX_REQUEST_BODY_MB")
             .ok()
             .and_then(|v| v.parse::<usize>().ok())
             .and_then(|mb| mb.checked_mul(1024 * 1024))
-            .unwrap_or(DEFAULT_MAX_REQUEST_BODY_BYTES)
+            .unwrap_or(DEFAULT_MAX_BULK_REQUEST_BODY_BYTES)
     })
 }
 
@@ -73,8 +73,10 @@ pub fn app_router(state: LiveRouterState) -> Router {
     Router::new()
         .merge(
             Router::new()
+                // Axum defaults JSON request bodies to 2 MiB, so bulk job creation needs an
+                // explicit override to preserve large workflow submissions.
                 .route("/torc-service/v1/bulk_jobs", post(create_jobs))
-                .layer(DefaultBodyLimit::max(max_request_body_bytes())),
+                .layer(DefaultBodyLimit::max(max_bulk_request_body_bytes())),
         )
         .route(
             "/torc-service/v1/access_groups",


### PR DESCRIPTION
  ## Summary

  Restore the larger request-body limit for `/torc-service/v1/bulk_jobs`
  in the Axum live router.

  This fixes a regression where `torc submit` could fail on large
  parameterized workflows with:

  `413 Failed to buffer the request body: length limit exceeded`

  The change applies the larger body limit only to `/bulk_jobs`, while
  leaving the default Axum body limit in place for other routes.

  ## Changes

  - reintroduce a `/bulk_jobs`-specific request body limit in
    `src/server/live_router.rs`
  - keep the default limit for non-bulk routes
  - restore support for `TORC_MAX_REQUEST_BODY_MB`
  - add router regression tests covering:
    - large JSON requests accepted on `/bulk_jobs`
    - large JSON requests still rejected on a non-bulk JSON endpoint

  ## Verification

  - `cargo fmt -- --check`
  - `dprint check`
  - `DATABASE_URL=sqlite:db/sqlite/dev.db cargo clippy --all --all-targets --all-features -- -D warnings`
  - `SQLX_OFFLINE=true cargo test bulk_jobs_route_accepts_body_larger_than_default_limit --features openapi-codegen`
  - `SQLX_OFFLINE=true cargo test non_bulk_json_route_still_uses_default_body_limit --features openapi-codegen`