### PR TITLE
Retry database failures in the JobRunner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,13 +128,11 @@ export TORC_API_URL="http://localhost:8080/torc-service/v1"
 # Quick workflow execution (convenience commands)
 ./target/release/torc run examples/sample_workflow.yaml    # Create and run locally
 ./target/release/torc submit examples/sample_workflow.yaml # Submit (requires scheduler actions)
-./target/release/torc submit-slurm --account myproject examples/sample_workflow.yaml  # Auto-generate Slurm schedulers
 
 # Or use explicit workflow management
-./target/release/torc workflows create examples/sample_workflow.yaml
-./target/release/torc workflows create-slurm --account myproject examples/sample_workflow.yaml  # With Slurm schedulers
-./target/release/torc workflows submit <workflow_id>  # Submit to scheduler
-./target/release/torc workflows run <workflow_id>     # Run locally
+./target/release/torc create examples/sample_workflow.yaml
+./target/release/torc submit <workflow_id>  # Submit to scheduler
+./target/release/torc run <workflow_id>     # Run locally
 
 # Other commands
 ./target/release/torc tui                              # Launch interactive TUI
@@ -400,7 +398,7 @@ For a new subcommand (e.g., `torc workflows correct-resources`):
 
 1. Write workflow spec file (JSON/JSON5/YAML) following `WorkflowSpec` format
 2. See `examples/sample_workflow.json` for complete example
-3. Run: `torc workflows create <spec_file>`
+3. Run: `torc create <spec_file>`
 4. The command creates all components (workflow, jobs, files, user_data, schedulers) atomically
 5. If any step fails, the entire workflow is rolled back
 
@@ -413,20 +411,15 @@ For a new subcommand (e.g., `torc workflows correct-resources`):
 
 **Explicit method:**
 
-1. Create workflow: `torc workflows create <spec_file>`
-2. Run workflow: `torc workflows run <workflow_id>`
+1. Create workflow: `torc create <spec_file>`
+2. Run workflow: `torc run <workflow_id>`
 3. Monitor progress: `torc workflows status <workflow_id>`
 4. View job results: `torc jobs list <workflow_id>`
 5. Launch interactive UI: `torc tui`
 
 ### Submitting a Workflow to Scheduler
 
-**Quick method (Slurm with auto-generated schedulers):**
-
-- `torc submit-slurm --account <account> <spec_file>` - Auto-generate Slurm schedulers, create
-  workflow, and submit
-
-**Quick method (pre-configured schedulers):**
+**Quick method:**
 
 - `torc submit <spec_file>` - Create from spec and submit (requires on_workflow_start/schedule_nodes
   action in spec)
@@ -434,9 +427,8 @@ For a new subcommand (e.g., `torc workflows correct-resources`):
 
 **Explicit method:**
 
-1. Create workflow: `torc workflows create <spec_file>` or
-   `torc workflows create-slurm --account <account> <spec_file>`
-2. Submit workflow: `torc workflows submit <workflow_id>`
+1. Create workflow: `torc create <spec_file>`
+2. Submit workflow: `torc submit <workflow_id>`
 
 ### Debugging
 
@@ -477,8 +469,7 @@ sqlite3 server/db/sqlite/dev.db
 2. **Build Unified CLI**: `cargo build --release --bin torc --features "client,tui,plot_resources"`
 3. **Quick Execution**: `torc run examples/sample_workflow.yaml` OR
    `torc submit examples/sample_workflow.yaml`
-4. **Or Explicit**: `torc workflows create examples/sample_workflow.yaml` →
-   `torc workflows run <id>`
+4. **Or Explicit**: `torc create examples/sample_workflow.yaml` → `torc run <id>`
 
 **Note**: The server is run as a separate binary (`torc-server run`), not through the unified CLI.
 
@@ -492,12 +483,9 @@ sqlite3 server/db/sqlite/dev.db
 
 **Workflow Management**:
 
-- `torc workflows create <file>` - Create workflow from specification
+- `torc create <file>` - Create workflow from specification
 - `torc workflows new` - Create empty workflow interactively
 - `torc workflows list` - List all workflows
-- `torc workflows submit <id>` - Submit workflow to scheduler (requires
-  on_workflow_start/schedule_nodes action)
-- `torc workflows run <id>` - Run workflow locally
 - `torc workflows init <id>` - Initialize workflow (set up dependencies without execution)
 - `torc workflows status <id>` - Check workflow status
 
@@ -517,7 +505,6 @@ sqlite3 server/db/sqlite/dev.db
 
 - `torc run <workflow_spec_or_id>` - Run workflow locally (top-level command)
 - `torc submit <workflow_spec_or_id>` - Submit workflow to scheduler (top-level command)
-- `torc submit-slurm --account <account> <spec_file>` - Submit with auto-generated Slurm schedulers
 - `torc tui` - Interactive terminal UI
 
 **Global Options** (available on all commands):

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ torc-server run --url localhost --port 8080 --threads 8 --database path/to/db.sq
 
 # 2. Use the unified CLI for all client operations
 # Create a workflow from a specification file
-torc workflows create my_workflow.yaml
+torc create my_workflow.yaml
 
 # Run jobs locally
 torc run <workflow_id>

--- a/docs/src/core/monitoring/dashboard.md
+++ b/docs/src/core/monitoring/dashboard.md
@@ -80,13 +80,24 @@ Options:
       --server-port <PORT>    Server port in standalone mode (0 = auto-detect) [default: 0]
       --database <PATH>       Database path for standalone server
       --completion-check-interval-secs <SECS>  Server polling interval [default: 5]
-      --anthropic-api-key           Anthropic API key [env: ANTHROPIC_API_KEY]
+      --torc-mcp-server-bin        Path to torc-mcp-server [default: torc-mcp-server]
+
+  AI Chat options:
+      --llm-provider               LLM provider: anthropic, openai, ollama, github [env: LLM_PROVIDER]
+      --anthropic-api-key          Anthropic API key [env: ANTHROPIC_API_KEY]
       --anthropic-foundry-api-key  Foundry API key [env: ANTHROPIC_FOUNDRY_API_KEY]
       --anthropic-foundry-resource Foundry resource [env: ANTHROPIC_FOUNDRY_RESOURCE]
       --anthropic-base-url         Override API base URL [env: ANTHROPIC_BASE_URL]
       --anthropic-auth-header      Override auth header name [env: ANTHROPIC_AUTH_HEADER]
-      --torc-mcp-server-bin        Path to torc-mcp-server [default: torc-mcp-server]
       --anthropic-model            Claude model [default: claude-sonnet-4-20250514]
+      --openai-api-key             OpenAI API key [env: OPENAI_API_KEY]
+      --openai-base-url            OpenAI API URL [default: https://api.openai.com/v1]
+      --openai-model               OpenAI model [default: gpt-4o] [env: OPENAI_MODEL]
+      --ollama-base-url            Ollama API URL [default: http://localhost:11434/v1]
+      --ollama-model               Ollama model [default: llama3.2] [env: OLLAMA_MODEL]
+      --github-token               GitHub token for GitHub Models [env: GITHUB_TOKEN]
+      --github-models-base-url     GitHub Models URL [default: https://models.inference.ai.azure.com]
+      --github-models-model        GitHub Models model [default: gpt-4o] [env: GITHUB_MODELS_MODEL]
 ```
 
 ## Features
@@ -180,16 +191,22 @@ Requires workflows run with `granularity: "time_series"` in `resource_monitor` c
 
 ### AI Chat Tab
 
-The AI Chat tab provides an AI assistant powered by Claude that can interact with your workflows
-using natural language. The assistant uses the Torc MCP server to access workflow data, job logs,
-and management tools.
+The AI Chat tab provides an AI assistant that can interact with your workflows using natural
+language. The assistant uses the Torc MCP server to access workflow data, job logs, and management
+tools.
+
+**Supported Providers:**
+
+The dashboard supports multiple LLM providers:
+
+- **Anthropic Claude** (direct API or Azure AI Foundry)
+- **OpenAI** (GPT-4o, GPT-4o-mini, o1, etc.)
+- **Ollama** (local, no API key required)
+- **GitHub Models** (Azure-hosted models with GitHub token)
 
 **Setup:**
 
-The AI Chat tab requires an API key so the dashboard can call Claude directly. There are two
-supported API backends:
-
-_Option 1: Direct Anthropic API_
+_Option 1: Anthropic Claude (Direct API)_
 
 ```bash
 export ANTHROPIC_API_KEY="sk-ant-..."
@@ -198,7 +215,7 @@ torc-dash
 
 _Option 2: Microsoft Azure AI Foundry_
 
-If you access Claude through Azure AI Foundry, set the Foundry-specific variables instead:
+If you access Claude through Azure AI Foundry:
 
 ```bash
 export ANTHROPIC_FOUNDRY_API_KEY="your-foundry-key"
@@ -209,20 +226,85 @@ torc-dash
 The dashboard constructs the Foundry endpoint automatically:
 `https://{resource}.services.ai.azure.com/anthropic/v1/messages`
 
-When both direct and Foundry keys are set, Foundry takes precedence.
+_Option 3: OpenAI_
 
-You also need the `torc-mcp-server` binary in your PATH (built alongside `torc-dash` when using
+Use OpenAI's GPT models:
+
+```bash
+export OPENAI_API_KEY="sk-..."
+LLM_PROVIDER=openai torc-dash
+
+# Or specify a different model
+LLM_PROVIDER=openai OPENAI_MODEL=gpt-4o-mini torc-dash
+```
+
+You can also use OpenAI-compatible services by setting a custom base URL:
+
+```bash
+LLM_PROVIDER=openai torc-dash --openai-base-url https://my-openai-proxy.example.com/v1
+```
+
+_Option 4: Ollama (Local)_
+
+Run AI completely locally with [Ollama](https://ollama.ai). No API key required:
+
+```bash
+# First, start Ollama and pull a model
+ollama pull qwen3.5:35b-a3b
+
+# Then start torc-dash with Ollama provider
+LLM_PROVIDER=ollama torc-dash
+
+# Or specify a different model
+LLM_PROVIDER=ollama OLLAMA_MODEL=qwen3.5:35b-a3b torc-dash
+```
+
+Ollama runs at `http://localhost:11434` by default. For remote Ollama servers:
+
+```bash
+LLM_PROVIDER=ollama torc-dash --ollama-base-url http://ollama-server:11434/v1
+```
+
+_Option 5: GitHub Models_
+
+Use models hosted on GitHub Models (requires a GitHub token with `models:read` scope):
+
+```bash
+export GITHUB_TOKEN="ghp_..."
+LLM_PROVIDER=github torc-dash
+
+# Or specify a different model
+LLM_PROVIDER=github GITHUB_MODELS_MODEL=Meta-Llama-3.1-70B-Instruct torc-dash
+```
+
+Available models include `gpt-4o`, `gpt-4o-mini`, `Meta-Llama-3.1-70B-Instruct`, and others. See
+[GitHub Models](https://github.com/marketplace/models) for the full list.
+
+**Runtime Configuration:**
+
+You can also configure the provider through the dashboard UI without environment variables:
+
+1. Open the AI Chat tab
+2. If not configured, a setup dialog appears
+3. Select your provider from the dropdown
+4. Enter credentials and model as needed
+5. Click "Connect"
+
+Credentials configured this way are stored in memory only for the current session.
+
+**MCP Server:**
+
+You need the `torc-mcp-server` binary in your PATH (built alongside `torc-dash` when using
 `--all-features` or `--features mcp-server`). If installed elsewhere, specify its location:
 
 ```bash
 torc-dash --torc-mcp-server-bin /path/to/torc-mcp-server
 ```
 
-**Don't have an API key?**
+**Alternative: Use Your Own AI Tool**
 
-If you use Claude through a subscription (Claude Pro/Max) or GitHub Copilot through an enterprise
-account, those credentials cannot be used with the dashboard's built-in chat. However, you can still
-get AI-assisted workflow management by connecting `torc-mcp-server` directly to your AI tool:
+If you prefer to use Claude through a subscription (Claude Pro/Max) or GitHub Copilot through an
+enterprise account, you can connect `torc-mcp-server` directly to your AI tool:
 
 - **Claude Code** (Pro/Max/Team/Enterprise): Add `torc-mcp-server` as an MCP server -- see
   [AI-Assisted Workflow Management](../../specialized/tools/ai-assistant.md#quick-setup-claude-code)
@@ -250,17 +332,26 @@ terminal or editor instead of the dashboard.
 
 **Configuration:**
 
-| Setting                      | Default                    | Description                      |
-| ---------------------------- | -------------------------- | -------------------------------- |
-| `ANTHROPIC_API_KEY`          | (none)                     | API key for direct Anthropic API |
-| `ANTHROPIC_FOUNDRY_API_KEY`  | (none)                     | API key for Azure AI Foundry     |
-| `ANTHROPIC_FOUNDRY_RESOURCE` | (none)                     | Foundry resource name            |
-| `--anthropic-model`          | `claude-sonnet-4-20250514` | Claude model to use              |
-| `--torc-mcp-server-bin`      | `torc-mcp-server`          | Path to MCP server binary        |
+| Setting                      | Default                                 | Description                                 |
+| ---------------------------- | --------------------------------------- | ------------------------------------------- |
+| `LLM_PROVIDER`               | `anthropic`                             | Provider: anthropic, openai, ollama, github |
+| `ANTHROPIC_API_KEY`          | (none)                                  | API key for direct Anthropic API            |
+| `ANTHROPIC_FOUNDRY_API_KEY`  | (none)                                  | API key for Azure AI Foundry                |
+| `ANTHROPIC_FOUNDRY_RESOURCE` | (none)                                  | Foundry resource name                       |
+| `--anthropic-model`          | `claude-sonnet-4-20250514`              | Claude model to use                         |
+| `OPENAI_API_KEY`             | (none)                                  | OpenAI API key                              |
+| `OPENAI_MODEL`               | `gpt-4o`                                | OpenAI model to use                         |
+| `--openai-base-url`          | `https://api.openai.com/v1`             | OpenAI API URL                              |
+| `OLLAMA_MODEL`               | `llama3.2`                              | Ollama model to use                         |
+| `--ollama-base-url`          | `http://localhost:11434/v1`             | Ollama API URL                              |
+| `GITHUB_TOKEN`               | (none)                                  | GitHub token for GitHub Models              |
+| `GITHUB_MODELS_MODEL`        | `gpt-4o`                                | GitHub Models model to use                  |
+| `--github-models-base-url`   | `https://models.inference.ai.azure.com` | GitHub Models API URL                       |
+| `--torc-mcp-server-bin`      | `torc-mcp-server`                       | Path to MCP server binary                   |
 
-At least one of `ANTHROPIC_API_KEY` or `ANTHROPIC_FOUNDRY_API_KEY` (with
-`ANTHROPIC_FOUNDRY_RESOURCE`) must be set. If neither is configured, the AI Chat tab appears
-disabled in the sidebar.
+For Anthropic, at least one of `ANTHROPIC_API_KEY` or `ANTHROPIC_FOUNDRY_API_KEY` (with
+`ANTHROPIC_FOUNDRY_RESOURCE`) must be set. For OpenAI, `OPENAI_API_KEY` is required. For GitHub
+Models, `GITHUB_TOKEN` is required. Ollama requires no credentials (runs locally).
 
 > **Note:** The API key is kept server-side and never sent to the browser. All AI requests are
 > proxied through the `torc-dash` backend.

--- a/docs/src/core/reference/cli.md
+++ b/docs/src/core/reference/cli.md
@@ -351,33 +351,25 @@ Workflow management commands
 
 ###### **Subcommands:**
 
-- `create` — Create a workflow from a specification file (supports JSON, JSON5, YAML, and KDL
-  formats)
-- `create-slurm` — Create a workflow with auto-generated Slurm schedulers
 - `new` — Create a new empty workflow
+- `init` — Initialize workflow dependencies
+- `reinit` — Reinitialize jobs with changed inputs
+- `reset-status` — Reset workflow and job statuses
+- `is-complete` — Check if workflow is complete
+- `sync-status` — Detect orphaned jobs from ended Slurm allocations
 - `list` — List workflows
 - `get` — Get a specific workflow by ID
-- `update` — Update an existing workflow
-- `cancel` — Cancel a workflow and all associated Slurm jobs
-- `delete` — Delete one or more workflows
-- `archive` — Archive or unarchive one or more workflows
-- `submit` — Submit a workflow: initialize if needed and schedule nodes for on_workflow_start
-  actions. This command requires the workflow to have an on_workflow_start action with
-  schedule_nodes
-- `run` — Run a workflow locally on the current node
-- `initialize` — Initialize a workflow, including all job statuses
-- `reinitialize` — Reinitialize a workflow. This will reinitialize all jobs with a status of
-  canceled, submitting, pending, or terminated. Jobs with a status of done will also be
-  reinitialized if an input_file or user_data record has changed
-- `status` — Get workflow status
-- `reset-status` — Reset workflow and job status
 - `execution-plan` — Show the execution plan for a workflow specification or existing workflow
-- `list-actions` — List workflow actions and their statuses (useful for debugging action triggers)
-- `is-complete` — Check if a workflow is complete
-- `export` — Export a workflow to a portable JSON file
-- `import` — Import a workflow from an exported JSON file
-- `sync-status` — Synchronize job statuses with Slurm (detect and fail orphaned jobs)
+- `list-actions` — List workflow actions and their statuses
+- `update` — Update workflow properties
+- `archive` — Archive or unarchive workflows
 - `correct-resources` — Correct resource requirements based on actual job usage
+- `check-resources` — Check for resource utilization violations
+- `export` — Export a workflow to JSON
+- `import` — Import a workflow from JSON
+
+Note: Lifecycle commands (`create`, `run`, `submit`, `status`, `cancel`, `delete`) are at the top
+level. Run `torc --help` to see all commands.
 
 ## `torc create`
 
@@ -399,33 +391,6 @@ Create a workflow from a specification file (supports JSON, JSON5, YAML, and KDL
   Default: `false`
 - `--dry-run` — Validate the workflow specification without creating it (dry-run mode). Returns a
   summary of what would be created including job count after parameter expansion.
-
-## `torc create-slurm`
-
-Create a workflow with auto-generated Slurm schedulers
-
-Automatically generates Slurm schedulers based on job resource requirements and HPC profile. For
-Slurm workflows without pre-configured schedulers.
-
-**Usage:** `torc create-slurm [OPTIONS] --account <ACCOUNT> --user <USER> <FILE>`
-
-###### **Arguments:**
-
-- `<FILE>` — Path to specification file containing WorkflowSpec
-
-###### **Options:**
-
-- `--account <ACCOUNT>` — Slurm account to use for allocations
-- `--hpc-profile <HPC_PROFILE>` — HPC profile to use (auto-detected if not specified)
-- `--single-allocation` — Bundle all nodes into a single Slurm allocation per scheduler. By default,
-  creates one Slurm allocation per node (N×1 mode). With this flag, creates one large allocation
-  with all nodes (1×N mode).
-- `-u`, `--user <USER>` — User that owns the workflow (defaults to USER environment variable)
-- `--no-resource-monitoring` — Disable resource monitoring (default: enabled with summary
-  granularity and 5s sample rate). Default: `false`
-- `--skip-checks` — Skip validation checks (e.g., scheduler node requirements). Use with caution.
-  Default: `false`
-- `--dry-run` — Validate the workflow specification without creating it (dry-run mode)
 
 ## `torc workflows new`
 

--- a/docs/src/specialized/design/recovery.md
+++ b/docs/src/specialized/design/recovery.md
@@ -160,7 +160,7 @@ sequenceDiagram
 ### Step 2: Group Jobs Using WorkflowGraph
 
 The system builds a `WorkflowGraph` from pending jobs and uses `scheduler_groups()` to group them by
-`(resource_requirements, has_dependencies)`. This aligns with the behavior of `torc create-slurm`:
+`(resource_requirements, has_dependencies)`. This aligns with the behavior of `torc slurm generate`:
 
 - **Jobs without dependencies**: Can be scheduled immediately with `on_workflow_start`
 - **Jobs with dependencies** (deferred): Need `on_jobs_ready` recovery actions to schedule when they
@@ -293,7 +293,7 @@ Key implementation notes:
 1. **WorkflowGraph construction**: A `WorkflowGraph` is built from pending jobs using `from_jobs()`,
    which reconstructs the dependency structure from `depends_on_job_ids`
 2. **Scheduler grouping**: Jobs are grouped using `scheduler_groups()` by
-   `(resource_requirements, has_dependencies)`, matching `create-slurm` behavior
+   `(resource_requirements, has_dependencies)`, matching `slurm generate` behavior
 3. **Deferred schedulers**: Groups with dependencies get a `_deferred` suffix in the scheduler name
 4. **Allocation calculation**: Number of allocations is based on job count and resources per node
 5. **Recovery actions**: Only deferred groups (jobs with dependencies) get `on_jobs_ready` recovery

--- a/examples/README.md
+++ b/examples/README.md
@@ -92,9 +92,9 @@ may be available for reference.
 
 ```bash
 # All three formats are supported
-torc workflows create examples/yaml/sample_workflow.yaml
-torc workflows create examples/json/sample_workflow.json5
-torc workflows create examples/kdl/sample_workflow.kdl
+torc create examples/yaml/sample_workflow.yaml
+torc create examples/json/sample_workflow.json5
+torc create examples/kdl/sample_workflow.kdl
 ```
 
 ### Quick execution:

--- a/examples/yaml/resource_monitoring_demo.yaml
+++ b/examples/yaml/resource_monitoring_demo.yaml
@@ -4,7 +4,7 @@
 #
 # To run this workflow:
 # 1. Start the torc server
-# 2. Create the workflow: torc workflows create examples/resource_monitoring_demo.yaml
+# 2. Create the workflow: torc create examples/resource_monitoring_demo.yaml
 # 3. Initialize and start: torc workflows start <workflow_id>
 # 4. Run the job runner: torc-job-runner <workflow_id>
 # 5. Check results with resource metrics: torc results list <workflow_id>

--- a/julia_client/Torc/test/test_workflow.jl
+++ b/julia_client/Torc/test/test_workflow.jl
@@ -114,7 +114,7 @@ end
     output_dir = mktempdir()
     try
         build_workflow(api, workflow)
-        result = run(`torc --url $url workflows run $(workflow.id) --output-dir $output_dir`)
+        result = run(`torc --url $url run $(workflow.id) --output-dir $output_dir`)
         @test result.exitcode == 0
         results, response = APIClient.list_results(api, workflow.id)
         @test response.status == 200
@@ -150,7 +150,7 @@ else
                 has_postprocess = true,
             )
             @test !isempty(jobs)
-            result = run(`torc --url $url workflows run $(workflow.id) --output-dir $output_dir`)
+            result = run(`torc --url $url run $(workflow.id) --output-dir $output_dir`)
             @test result.exitcode == 0
             results, response = APIClient.list_results(api, workflow.id)
             @test response.status == 200

--- a/src/bin/torc-dash.rs
+++ b/src/bin/torc-dash.rs
@@ -29,13 +29,27 @@ use tokio::process::Command;
 use tokio::sync::{Mutex, RwLock};
 use torc::config::TorcConfig;
 use torc::network_utils::find_available_port;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 /// Embedded static assets for the dashboard
 #[derive(Embed)]
 #[folder = "torc-dash/static/"]
 struct Assets;
+
+/// LLM provider type for AI chat
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+enum LlmProvider {
+    /// Anthropic Claude API (direct or via Foundry)
+    #[default]
+    Anthropic,
+    /// OpenAI API (GPT models)
+    OpenAI,
+    /// Ollama (local, OpenAI-compatible)
+    Ollama,
+    /// GitHub Models (Azure inference, OpenAI-compatible)
+    GitHub,
+}
 
 /// Managed server process state
 #[derive(Default)]
@@ -70,19 +84,18 @@ struct AppState {
     torc_mcp_server_bin: String,
     /// Managed server process (if started by torc-dash)
     managed_server: Mutex<ManagedServer>,
-    /// Anthropic API key for AI chat (resolved from direct or Foundry config).
-    /// Wrapped in RwLock so it can be set at runtime via the dashboard UI.
-    anthropic_api_key: RwLock<Option<String>>,
-    /// Base URL for Claude API (e.g. "https://api.anthropic.com/v1" or Foundry URL).
-    /// Wrapped in RwLock so it can be changed at runtime via the dashboard UI.
-    anthropic_base_url: RwLock<String>,
-    /// Auth header name ("x-api-key" for both direct and Foundry).
-    /// Wrapped in RwLock so it can be changed at runtime via the dashboard UI.
-    anthropic_auth_header: RwLock<String>,
+    /// LLM provider type (Anthropic, Ollama, GitHub)
+    llm_provider: RwLock<LlmProvider>,
+    /// API key for AI chat (Anthropic key, GitHub token, or "ollama" for local)
+    llm_api_key: RwLock<Option<String>>,
+    /// Base URL for LLM API
+    llm_base_url: RwLock<String>,
+    /// Auth header name (e.g., "x-api-key", "Authorization")
+    llm_auth_header: RwLock<String>,
+    /// Model to use for AI chat (can be changed at runtime)
+    llm_model: RwLock<String>,
     /// MCP client connection (lazily initialized)
     mcp_client: Mutex<Option<McpClient>>,
-    /// Model to use for AI chat
-    anthropic_model: String,
 }
 
 /// CLI arguments
@@ -171,10 +184,6 @@ struct Cli {
     #[arg(long, env = "ANTHROPIC_AUTH_HEADER")]
     anthropic_auth_header: Option<String>,
 
-    /// Path to torc-mcp-server binary
-    #[arg(long, default_value = "torc-mcp-server", env = "TORC_MCP_SERVER_BIN")]
-    torc_mcp_server_bin: String,
-
     /// Model to use for AI chat (default: claude-sonnet-4-20250514)
     #[arg(
         long,
@@ -182,6 +191,58 @@ struct Cli {
         env = "ANTHROPIC_MODEL"
     )]
     anthropic_model: String,
+
+    /// Ollama base URL for local AI chat (OpenAI-compatible API)
+    #[arg(
+        long,
+        default_value = "http://localhost:11434/v1",
+        env = "OLLAMA_BASE_URL"
+    )]
+    ollama_base_url: String,
+
+    /// Ollama model name (e.g. "llama3.2", "qwen3.5:35b-a3b")
+    #[arg(long, default_value = "llama3.2", env = "OLLAMA_MODEL")]
+    ollama_model: String,
+
+    /// GitHub token for GitHub Models (requires "models:read" scope)
+    #[arg(long, env = "GITHUB_TOKEN")]
+    github_token: Option<String>,
+
+    /// GitHub Models base URL (Azure ML inference endpoint)
+    #[arg(
+        long,
+        default_value = "https://models.inference.ai.azure.com",
+        env = "GITHUB_MODELS_BASE_URL"
+    )]
+    github_models_base_url: String,
+
+    /// GitHub Models model name (e.g. "gpt-4o", "Meta-Llama-3.1-70B-Instruct")
+    #[arg(long, default_value = "gpt-4o", env = "GITHUB_MODELS_MODEL")]
+    github_models_model: String,
+
+    /// OpenAI API key
+    #[arg(long, env = "OPENAI_API_KEY")]
+    openai_api_key: Option<String>,
+
+    /// OpenAI API base URL (for API-compatible services)
+    #[arg(
+        long,
+        default_value = "https://api.openai.com/v1",
+        env = "OPENAI_BASE_URL"
+    )]
+    openai_base_url: String,
+
+    /// OpenAI model name (e.g. "gpt-4o", "gpt-4o-mini", "o1")
+    #[arg(long, default_value = "gpt-4o", env = "OPENAI_MODEL")]
+    openai_model: String,
+
+    /// LLM provider to use: "anthropic", "openai", "ollama", or "github"
+    #[arg(long, default_value = "anthropic", env = "LLM_PROVIDER")]
+    llm_provider: String,
+
+    /// Path to torc-mcp-server binary
+    #[arg(long, default_value = "torc-mcp-server", env = "TORC_MCP_SERVER_BIN")]
+    torc_mcp_server_bin: String,
 }
 
 #[tokio::main]
@@ -453,49 +514,118 @@ async fn main() -> Result<()> {
         .build_async_client()
         .expect("Failed to build HTTP client with TLS config");
 
-    // Resolve Anthropic API configuration: Foundry takes precedence over direct API
-    let (resolved_api_key, mut anthropic_base_url, mut anthropic_auth_header) =
-        if let (Some(foundry_key), Some(foundry_resource)) = (
-            cli.anthropic_foundry_api_key.as_ref(),
-            cli.anthropic_foundry_resource.as_ref(),
-        ) {
-            info!(
-                "AI Chat: using Azure AI Foundry (resource={})",
-                foundry_resource
-            );
-            (
-                Some(foundry_key.clone()),
-                format!(
-                    "https://{}.services.ai.azure.com/anthropic/v1",
-                    foundry_resource
-                ),
-                "x-api-key".to_string(),
-            )
-        } else if let Some(ref api_key) = cli.anthropic_api_key {
-            info!("AI Chat: using direct Anthropic API");
-            (
-                Some(api_key.clone()),
-                "https://api.anthropic.com/v1".to_string(),
-                "x-api-key".to_string(),
-            )
-        } else {
-            info!("AI Chat: disabled (no API key configured)");
-            (
-                None,
-                "https://api.anthropic.com/v1".to_string(),
-                "x-api-key".to_string(),
-            )
+    // Resolve LLM provider configuration based on --llm-provider or available credentials
+    let (llm_provider, llm_api_key, llm_base_url, llm_auth_header, llm_model) =
+        match cli.llm_provider.to_lowercase().as_str() {
+            "ollama" => {
+                info!("AI Chat: using Ollama ({})", cli.ollama_base_url);
+                (
+                    LlmProvider::Ollama,
+                    Some("ollama".to_string()), // Ollama doesn't need auth
+                    cli.ollama_base_url.clone(),
+                    "Authorization".to_string(),
+                    cli.ollama_model.clone(),
+                )
+            }
+            "github" => {
+                if let Some(ref token) = cli.github_token {
+                    info!("AI Chat: using GitHub Models");
+                    (
+                        LlmProvider::GitHub,
+                        Some(token.clone()),
+                        cli.github_models_base_url.clone(),
+                        "Authorization".to_string(),
+                        cli.github_models_model.clone(),
+                    )
+                } else {
+                    info!("AI Chat: GitHub Models selected but no GITHUB_TOKEN configured");
+                    (
+                        LlmProvider::GitHub,
+                        None,
+                        cli.github_models_base_url.clone(),
+                        "Authorization".to_string(),
+                        cli.github_models_model.clone(),
+                    )
+                }
+            }
+            "openai" => {
+                if let Some(ref api_key) = cli.openai_api_key {
+                    info!("AI Chat: using OpenAI API");
+                    (
+                        LlmProvider::OpenAI,
+                        Some(api_key.clone()),
+                        cli.openai_base_url.clone(),
+                        "Authorization".to_string(),
+                        cli.openai_model.clone(),
+                    )
+                } else {
+                    info!("AI Chat: OpenAI selected but no OPENAI_API_KEY configured");
+                    (
+                        LlmProvider::OpenAI,
+                        None,
+                        cli.openai_base_url.clone(),
+                        "Authorization".to_string(),
+                        cli.openai_model.clone(),
+                    )
+                }
+            }
+            _ => {
+                // Default to Anthropic: Foundry takes precedence over direct API
+                if let (Some(foundry_key), Some(foundry_resource)) = (
+                    cli.anthropic_foundry_api_key.as_ref(),
+                    cli.anthropic_foundry_resource.as_ref(),
+                ) {
+                    info!(
+                        "AI Chat: using Azure AI Foundry (resource={})",
+                        foundry_resource
+                    );
+                    let mut base_url = format!(
+                        "https://{}.services.ai.azure.com/anthropic/v1",
+                        foundry_resource
+                    );
+                    if let Some(ref url_override) = cli.anthropic_base_url {
+                        base_url = url_override.clone();
+                    }
+                    let auth_header = cli
+                        .anthropic_auth_header
+                        .clone()
+                        .unwrap_or_else(|| "x-api-key".to_string());
+                    (
+                        LlmProvider::Anthropic,
+                        Some(foundry_key.clone()),
+                        base_url,
+                        auth_header,
+                        cli.anthropic_model.clone(),
+                    )
+                } else if let Some(ref api_key) = cli.anthropic_api_key {
+                    info!("AI Chat: using direct Anthropic API");
+                    let base_url = cli
+                        .anthropic_base_url
+                        .clone()
+                        .unwrap_or_else(|| "https://api.anthropic.com/v1".to_string());
+                    let auth_header = cli
+                        .anthropic_auth_header
+                        .clone()
+                        .unwrap_or_else(|| "x-api-key".to_string());
+                    (
+                        LlmProvider::Anthropic,
+                        Some(api_key.clone()),
+                        base_url,
+                        auth_header,
+                        cli.anthropic_model.clone(),
+                    )
+                } else {
+                    info!("AI Chat: disabled (no API key configured)");
+                    (
+                        LlmProvider::Anthropic,
+                        None,
+                        "https://api.anthropic.com/v1".to_string(),
+                        "x-api-key".to_string(),
+                        cli.anthropic_model.clone(),
+                    )
+                }
+            }
         };
-
-    // Allow explicit overrides for base URL and auth header
-    if let Some(ref url_override) = cli.anthropic_base_url {
-        info!("AI Chat: base URL overridden to {}", url_override);
-        anthropic_base_url = url_override.clone();
-    }
-    if let Some(ref header_override) = cli.anthropic_auth_header {
-        info!("AI Chat: auth header overridden to {}", header_override);
-        anthropic_auth_header = header_override.clone();
-    }
 
     let state = Arc::new(AppState {
         api_url: final_api_url,
@@ -504,11 +634,12 @@ async fn main() -> Result<()> {
         torc_server_bin: torc_server_bin.clone(),
         torc_mcp_server_bin: cli.torc_mcp_server_bin.clone(),
         managed_server: Mutex::new(managed_server),
-        anthropic_api_key: RwLock::new(resolved_api_key),
-        anthropic_base_url: RwLock::new(anthropic_base_url),
-        anthropic_auth_header: RwLock::new(anthropic_auth_header),
+        llm_provider: RwLock::new(llm_provider),
+        llm_api_key: RwLock::new(llm_api_key),
+        llm_base_url: RwLock::new(llm_base_url),
+        llm_auth_header: RwLock::new(llm_auth_header),
+        llm_model: RwLock::new(llm_model),
         mcp_client: Mutex::new(None),
-        anthropic_model: cli.anthropic_model.clone(),
     });
 
     // Build router
@@ -912,7 +1043,7 @@ async fn cli_create_handler(
         // Spec is a file path
         run_torc_command(
             &state.torc_bin,
-            &["-f", "json", "workflows", "create", &req.spec],
+            &["-f", "json", "create", &req.spec],
             &state.api_url,
         )
         .await
@@ -931,7 +1062,7 @@ async fn cli_create_handler(
 
         let result = run_torc_command(
             &state.torc_bin,
-            &["-f", "json", "workflows", "create", &temp_path],
+            &["-f", "json", "create", &temp_path],
             &state.api_url,
         )
         .await;
@@ -1023,21 +1154,34 @@ async fn cli_create_slurm_handler(
     };
 
     let result = if req.is_file {
-        // Spec is a file path
-        let mut args = vec![
-            "-f",
-            "json",
-            "workflows",
-            "create-slurm",
-            "--account",
-            &req.account,
-        ];
+        // Spec is a file path - two-step process: generate schedulers then create
+        // Step 1: Generate Slurm schedulers
+        let slurm_spec_path = format!(
+            "{}_slurm.yaml",
+            req.spec
+                .trim_end_matches(".yaml")
+                .trim_end_matches(".yml")
+                .trim_end_matches(".json")
+                .trim_end_matches(".json5")
+                .trim_end_matches(".kdl")
+        );
+        let mut gen_args = vec!["slurm", "generate", "--account", &req.account];
         if let Some(ref profile) = req.profile {
-            args.push("--hpc-profile");
-            args.push(profile);
+            gen_args.push("--profile");
+            gen_args.push(profile);
         }
-        args.push(&req.spec);
-        run_torc_command(&state.torc_bin, &args, &state.api_url).await
+        gen_args.push("-o");
+        gen_args.push(&slurm_spec_path);
+        gen_args.push(&req.spec);
+
+        let gen_result = run_torc_command(&state.torc_bin, &gen_args, &state.api_url).await;
+        if !gen_result.success {
+            return Json(gen_result);
+        }
+
+        // Step 2: Create the workflow from generated spec
+        let create_args = vec!["-f", "json", "create", &slurm_spec_path];
+        run_torc_command(&state.torc_bin, &create_args, &state.api_url).await
     } else {
         // Spec is inline content - write to current directory with random name
         let unique_id = uuid::Uuid::new_v4();
@@ -1051,21 +1195,27 @@ async fn cli_create_slurm_handler(
             });
         }
 
-        let mut args = vec![
-            "-f",
-            "json",
-            "workflows",
-            "create-slurm",
-            "--account",
-            &req.account,
-        ];
+        // Step 1: Generate Slurm schedulers
+        let slurm_spec_path = format!("{}_slurm", temp_path);
+        let mut gen_args = vec!["slurm", "generate", "--account", &req.account];
         if let Some(ref profile) = req.profile {
-            args.push("--hpc-profile");
-            args.push(profile);
+            gen_args.push("--profile");
+            gen_args.push(profile);
         }
-        args.push(&temp_path);
+        gen_args.push("-o");
+        gen_args.push(&slurm_spec_path);
+        gen_args.push(&temp_path);
 
-        let result = run_torc_command(&state.torc_bin, &args, &state.api_url).await;
+        let gen_result = run_torc_command(&state.torc_bin, &gen_args, &state.api_url).await;
+        if !gen_result.success {
+            // Clean up temp file
+            let _ = tokio::fs::remove_file(&temp_path).await;
+            return Json(gen_result);
+        }
+
+        // Step 2: Create the workflow from generated spec
+        let create_args = vec!["-f", "json", "create", &slurm_spec_path];
+        let result = run_torc_command(&state.torc_bin, &create_args, &state.api_url).await;
 
         // Handle file after creation attempt
         if result.success {
@@ -1138,7 +1288,7 @@ async fn cli_validate_handler(
         // Spec is a file path
         run_torc_command(
             &state.torc_bin,
-            &["-f", "json", "workflows", "create", &req.spec, "--dry-run"],
+            &["-f", "json", "create", &req.spec, "--dry-run"],
             &state.api_url,
         )
         .await
@@ -1158,7 +1308,7 @@ async fn cli_validate_handler(
         }
         let result = run_torc_command(
             &state.torc_bin,
-            &["-f", "json", "workflows", "create", &temp_path, "--dry-run"],
+            &["-f", "json", "create", &temp_path, "--dry-run"],
             &state.api_url,
         )
         .await;
@@ -2839,13 +2989,25 @@ struct ChatStatusResponse {
 }
 
 async fn chat_status_handler(State(state): State<Arc<AppState>>) -> impl IntoResponse {
-    let available = state.anthropic_api_key.read().await.is_some();
+    let provider = *state.llm_provider.read().await;
+    let has_key = state.llm_api_key.read().await.is_some();
+
+    // Ollama doesn't require an API key (local), but others do
+    let available = match provider {
+        LlmProvider::Ollama => true, // Always available (assumes local Ollama is running)
+        _ => has_key,
+    };
+
     let reason = if !available {
-        Some(
-            "No API key configured. Set ANTHROPIC_API_KEY or \
-             ANTHROPIC_FOUNDRY_API_KEY + ANTHROPIC_FOUNDRY_RESOURCE"
-                .to_string(),
-        )
+        let msg = match provider {
+            LlmProvider::Anthropic => {
+                "No API key configured. Set ANTHROPIC_API_KEY or use Azure AI Foundry."
+            }
+            LlmProvider::OpenAI => "No API key configured. Set OPENAI_API_KEY.",
+            LlmProvider::GitHub => "No GitHub token configured. Set GITHUB_TOKEN.",
+            LlmProvider::Ollama => "Ollama should be available locally.",
+        };
+        Some(msg.to_string())
     } else {
         None
     };
@@ -2855,19 +3017,23 @@ async fn chat_status_handler(State(state): State<Arc<AppState>>) -> impl IntoRes
 
 #[derive(Deserialize)]
 struct ConfigureChatRequest {
+    /// API key (or "ollama" for local Ollama, or GitHub token for GitHub Models)
     api_key: String,
-    /// Provider type: "anthropic", "foundry", or "custom"
+    /// Provider type: "anthropic", "foundry", "custom", "ollama", or "github"
     #[serde(default = "default_provider")]
     provider: String,
     /// Azure AI Foundry resource name (required when provider = "foundry")
     #[serde(default)]
     foundry_resource: Option<String>,
-    /// Custom base URL (required when provider = "custom")
+    /// Custom base URL (required when provider = "custom", optional for others)
     #[serde(default)]
     base_url: Option<String>,
-    /// Custom auth header name (optional, defaults to "x-api-key")
+    /// Custom auth header name (optional, defaults to provider-appropriate value)
     #[serde(default)]
     auth_header: Option<String>,
+    /// Model name (optional, defaults to provider-appropriate model)
+    #[serde(default)]
+    model: Option<String>,
 }
 
 fn default_provider() -> String {
@@ -2884,28 +3050,104 @@ async fn configure_chat_handler(
         .map_err(|status| (status, "Cross-origin requests are not allowed"))?;
 
     let key = req.api_key.trim().to_string();
-    if key.is_empty() {
-        return Err((StatusCode::BAD_REQUEST, "API key must not be empty"));
-    }
 
-    let (base_url, auth_header) = match req.provider.as_str() {
+    let (provider, base_url, auth_header, model) = match req.provider.as_str() {
+        "ollama" => {
+            // Ollama doesn't require a real API key
+            let url = req
+                .base_url
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .unwrap_or("http://localhost:11434/v1")
+                .to_string();
+            let model = req
+                .model
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .unwrap_or("llama3.2")
+                .to_string();
+            info!(
+                "AI Chat: configured via dashboard UI as Ollama (url={})",
+                url
+            );
+            (LlmProvider::Ollama, url, "Authorization".to_string(), model)
+        }
+        "github" => {
+            if key.is_empty() {
+                return Err((StatusCode::BAD_REQUEST, "GitHub token is required"));
+            }
+            let url = req
+                .base_url
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .unwrap_or("https://models.inference.ai.azure.com")
+                .to_string();
+            let model = req
+                .model
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .unwrap_or("gpt-4o")
+                .to_string();
+            info!("AI Chat: configured via dashboard UI as GitHub Models");
+            (LlmProvider::GitHub, url, "Authorization".to_string(), model)
+        }
+        "openai" => {
+            if key.is_empty() {
+                return Err((StatusCode::BAD_REQUEST, "OpenAI API key is required"));
+            }
+            let url = req
+                .base_url
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .unwrap_or("https://api.openai.com/v1")
+                .to_string();
+            let model = req
+                .model
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .unwrap_or("gpt-4o")
+                .to_string();
+            info!("AI Chat: configured via dashboard UI as OpenAI");
+            (LlmProvider::OpenAI, url, "Authorization".to_string(), model)
+        }
         "foundry" => {
+            if key.is_empty() {
+                return Err((StatusCode::BAD_REQUEST, "API key must not be empty"));
+            }
             let resource = req
                 .foundry_resource
                 .as_deref()
                 .map(str::trim)
                 .filter(|s| !s.is_empty())
                 .ok_or((StatusCode::BAD_REQUEST, "Foundry resource name is required"))?;
+            let model = req
+                .model
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .unwrap_or("claude-sonnet-4-20250514")
+                .to_string();
             info!(
                 "AI Chat: configured via dashboard UI as Azure AI Foundry (resource={})",
                 resource
             );
             (
+                LlmProvider::Anthropic,
                 format!("https://{}.services.ai.azure.com/anthropic/v1", resource),
                 "x-api-key".to_string(),
+                model,
             )
         }
         "custom" => {
+            if key.is_empty() {
+                return Err((StatusCode::BAD_REQUEST, "API key must not be empty"));
+            }
             let url = req
                 .base_url
                 .as_deref()
@@ -2920,25 +3162,53 @@ async fn configure_chat_handler(
                 .filter(|s| !s.is_empty())
                 .unwrap_or("x-api-key")
                 .to_string();
+            let model = req
+                .model
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .unwrap_or("claude-sonnet-4-20250514")
+                .to_string();
             info!(
                 "AI Chat: configured via dashboard UI as custom endpoint (url={})",
                 url
             );
-            (url, header)
+            (LlmProvider::Anthropic, url, header, model)
         }
         _ => {
             // "anthropic" (direct)
+            if key.is_empty() {
+                return Err((StatusCode::BAD_REQUEST, "API key must not be empty"));
+            }
+            let model = req
+                .model
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .unwrap_or("claude-sonnet-4-20250514")
+                .to_string();
             info!("AI Chat: configured via dashboard UI as direct Anthropic API");
             (
+                LlmProvider::Anthropic,
                 "https://api.anthropic.com/v1".to_string(),
                 "x-api-key".to_string(),
+                model,
             )
         }
     };
 
-    *state.anthropic_api_key.write().await = Some(key);
-    *state.anthropic_base_url.write().await = base_url;
-    *state.anthropic_auth_header.write().await = auth_header;
+    // For Ollama, we use a dummy key
+    let final_key = if provider == LlmProvider::Ollama {
+        Some("ollama".to_string())
+    } else {
+        Some(key)
+    };
+
+    *state.llm_provider.write().await = provider;
+    *state.llm_api_key.write().await = final_key;
+    *state.llm_base_url.write().await = base_url;
+    *state.llm_auth_header.write().await = auth_header;
+    *state.llm_model.write().await = model;
 
     Ok(Json(ChatStatusResponse {
         available: true,
@@ -2987,7 +3257,35 @@ async fn ensure_mcp_client(
         .await
         .map_err(|e| anyhow::anyhow!("Failed to list MCP tools: {}", e))?;
 
-    info!("MCP client connected, discovered {} tools", tools.len());
+    // Estimate token usage for tools (helps debug GitHub Models limits)
+    let openai_tools: Vec<serde_json::Value> = tools
+        .iter()
+        .map(|tool| {
+            serde_json::json!({
+                "type": "function",
+                "function": {
+                    "name": tool.name.as_ref(),
+                    "description": tool.description.as_ref(),
+                    "parameters": tool.schema_as_json_value(),
+                }
+            })
+        })
+        .collect();
+    let tools_json = serde_json::json!(openai_tools);
+    let tools_tokens = estimate_tokens(&tools_json);
+
+    info!(
+        "MCP client connected, discovered {} tools (~{} tokens, {} chars)",
+        tools.len(),
+        tools_tokens,
+        serde_json::to_string(&tools_json)
+            .map(|s| s.len())
+            .unwrap_or(0)
+    );
+
+    if tools_tokens > 6000 {
+        warn!("Tools exceed 6000 tokens - GitHub Models will not be able to use them");
+    }
 
     *guard = Some(McpClient {
         peer: peer.clone(),
@@ -2997,7 +3295,7 @@ async fn ensure_mcp_client(
     Ok((peer, tools))
 }
 
-/// Convert MCP tools to Claude API tool format.
+/// Convert MCP tools to Claude API tool format (Anthropic).
 fn mcp_tools_to_claude_tools(tools: &[rmcp::model::Tool]) -> Vec<serde_json::Value> {
     tools
         .iter()
@@ -3009,6 +3307,244 @@ fn mcp_tools_to_claude_tools(tools: &[rmcp::model::Tool]) -> Vec<serde_json::Val
             })
         })
         .collect()
+}
+
+/// Convert MCP tools to OpenAI function calling format.
+fn mcp_tools_to_openai_tools(tools: &[rmcp::model::Tool]) -> Vec<serde_json::Value> {
+    tools
+        .iter()
+        .map(|tool| {
+            serde_json::json!({
+                "type": "function",
+                "function": {
+                    "name": tool.name.as_ref(),
+                    "description": tool.description.as_ref(),
+                    "parameters": tool.schema_as_json_value(),
+                }
+            })
+        })
+        .collect()
+}
+
+/// Essential tools for providers with limited context (e.g., GitHub Models with 8k limit).
+/// These are the most useful tools for basic workflow management.
+const ESSENTIAL_TOOLS: &[&str] = &[
+    "get_workflow_status",
+    "get_workflow_summary",
+    "list_jobs_by_status",
+    "list_failed_jobs",
+    "get_job_logs",
+    "get_job_details",
+    "recover_workflow",
+    "get_docs",
+    "list_examples",
+    "get_example",
+    "create_workflow",
+];
+
+/// Filter tools to only essential ones for limited-context providers.
+fn filter_essential_tools(tools: &[rmcp::model::Tool]) -> Vec<&rmcp::model::Tool> {
+    tools
+        .iter()
+        .filter(|tool| ESSENTIAL_TOOLS.contains(&tool.name.as_ref()))
+        .collect()
+}
+
+/// Convert MCP tools to OpenAI format, filtered to essential tools only.
+fn mcp_tools_to_openai_tools_filtered(tools: &[rmcp::model::Tool]) -> Vec<serde_json::Value> {
+    filter_essential_tools(tools)
+        .iter()
+        .map(|tool| {
+            serde_json::json!({
+                "type": "function",
+                "function": {
+                    "name": tool.name.as_ref(),
+                    "description": tool.description.as_ref(),
+                    "parameters": tool.schema_as_json_value(),
+                }
+            })
+        })
+        .collect()
+}
+
+/// Convert chat messages to OpenAI format.
+fn messages_to_openai_format(
+    messages: &[serde_json::Value],
+    system_prompt: &str,
+) -> Vec<serde_json::Value> {
+    let mut openai_messages = vec![serde_json::json!({
+        "role": "system",
+        "content": system_prompt,
+    })];
+
+    for msg in messages {
+        let role = msg["role"].as_str().unwrap_or("user");
+
+        // Handle tool results (from previous round)
+        if let Some(content_array) = msg["content"].as_array() {
+            // Check if this is an array of tool_result blocks
+            if content_array
+                .first()
+                .map(|c| c["type"].as_str() == Some("tool_result"))
+                .unwrap_or(false)
+            {
+                // Convert each tool_result to an OpenAI tool message
+                for result in content_array {
+                    if let Some(tool_use_id) = result["tool_use_id"].as_str() {
+                        let content = result["content"].as_str().unwrap_or("");
+                        openai_messages.push(serde_json::json!({
+                            "role": "tool",
+                            "tool_call_id": tool_use_id,
+                            "content": content,
+                        }));
+                    }
+                }
+                continue;
+            }
+
+            // Check if this is an assistant message with tool_use blocks
+            if role == "assistant" {
+                let mut text_content = String::new();
+                let mut tool_calls = Vec::new();
+
+                for block in content_array {
+                    match block["type"].as_str() {
+                        Some("text") => {
+                            if let Some(text) = block["text"].as_str() {
+                                text_content.push_str(text);
+                            }
+                        }
+                        Some("tool_use") => {
+                            tool_calls.push(serde_json::json!({
+                                "id": block["id"],
+                                "type": "function",
+                                "function": {
+                                    "name": block["name"],
+                                    "arguments": serde_json::to_string(&block["input"]).unwrap_or_default(),
+                                }
+                            }));
+                        }
+                        _ => {}
+                    }
+                }
+
+                let mut assistant_msg = serde_json::json!({
+                    "role": "assistant",
+                });
+                if !text_content.is_empty() {
+                    assistant_msg["content"] = serde_json::json!(text_content);
+                }
+                if !tool_calls.is_empty() {
+                    assistant_msg["tool_calls"] = serde_json::json!(tool_calls);
+                }
+                openai_messages.push(assistant_msg);
+                continue;
+            }
+        }
+
+        // Simple text message
+        let content = match &msg["content"] {
+            serde_json::Value::String(s) => s.clone(),
+            serde_json::Value::Array(arr) => {
+                // Extract text from content blocks
+                arr.iter()
+                    .filter_map(|block| block["text"].as_str())
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            }
+            _ => String::new(),
+        };
+
+        openai_messages.push(serde_json::json!({
+            "role": role,
+            "content": content,
+        }));
+    }
+
+    openai_messages
+}
+
+/// Estimate token count for a JSON value.
+/// Uses conservative estimate of ~3 chars per token (JSON has overhead from quotes, braces, etc.)
+fn estimate_tokens(value: &serde_json::Value) -> usize {
+    let json_str = serde_json::to_string(value).unwrap_or_default();
+    // Conservative estimate: ~3 characters per token for JSON content
+    // This accounts for JSON overhead (quotes, braces, colons) and mixed content
+    json_str.len().div_ceil(3)
+}
+
+/// Truncate messages to fit within a token limit, preserving system prompt and recent messages.
+/// Returns truncated messages and whether truncation occurred.
+fn truncate_messages_to_token_limit(
+    messages: Vec<serde_json::Value>,
+    tools: &serde_json::Value,
+    max_tokens: usize,
+) -> (Vec<serde_json::Value>, bool) {
+    // Reserve tokens for tools, model overhead, and response
+    let tools_tokens = estimate_tokens(tools);
+    let overhead = 1000; // Buffer for model name, max_tokens field, request structure, etc.
+    let available_tokens = max_tokens.saturating_sub(tools_tokens + overhead);
+
+    info!(
+        "Token budget: max={}, tools={}, overhead={}, available for messages={}",
+        max_tokens, tools_tokens, overhead, available_tokens
+    );
+
+    // Always keep the system message (first message)
+    if messages.is_empty() {
+        return (messages, false);
+    }
+
+    let system_msg = &messages[0];
+    let system_tokens = estimate_tokens(system_msg);
+
+    info!(
+        "System message tokens: {}, remaining after system: {}",
+        system_tokens,
+        available_tokens.saturating_sub(system_tokens)
+    );
+
+    // If system message alone exceeds limit, truncate it
+    if system_tokens >= available_tokens {
+        warn!(
+            "System message ({} tokens) exceeds available budget ({} tokens), truncating",
+            system_tokens, available_tokens
+        );
+        return (vec![system_msg.clone()], true);
+    }
+
+    let mut remaining_tokens = available_tokens - system_tokens;
+    let mut kept_messages = vec![system_msg.clone()];
+    let mut truncated = false;
+
+    // Process messages from most recent to oldest (skip system message at index 0)
+    let other_messages: Vec<_> = messages[1..].iter().collect();
+    let mut selected_indices = Vec::new();
+
+    for (i, msg) in other_messages.iter().enumerate().rev() {
+        let msg_tokens = estimate_tokens(msg);
+        if msg_tokens <= remaining_tokens {
+            remaining_tokens -= msg_tokens;
+            selected_indices.push(i);
+        } else {
+            truncated = true;
+        }
+    }
+
+    // Reverse to maintain chronological order
+    selected_indices.reverse();
+    for i in selected_indices {
+        kept_messages.push(other_messages[i].clone());
+    }
+
+    info!(
+        "Kept {} of {} messages (truncated={})",
+        kept_messages.len(),
+        messages.len(),
+        truncated
+    );
+
+    (kept_messages, truncated)
 }
 
 /// The system prompt for the AI chat assistant.
@@ -3066,6 +3602,7 @@ fn validate_same_origin(headers: &HeaderMap) -> Result<(), StatusCode> {
 }
 
 /// Chat endpoint: streams SSE events as the AI processes the conversation.
+/// Supports both Anthropic API and OpenAI-compatible APIs (Ollama, GitHub Models).
 async fn chat_handler(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
@@ -3074,16 +3611,18 @@ async fn chat_handler(
     validate_same_origin(&headers)
         .map_err(|status| (status, "Cross-origin requests are not allowed"))?;
 
-    let api_key = match state.anthropic_api_key.read().await.clone() {
+    let provider = *state.llm_provider.read().await;
+    let api_key = match state.llm_api_key.read().await.clone() {
         Some(key) => key,
+        None if provider == LlmProvider::Ollama => "ollama".to_string(),
         None => {
             return Err((StatusCode::SERVICE_UNAVAILABLE, "No API key configured"));
         }
     };
 
-    let model = state.anthropic_model.clone();
-    let messages_url = format!("{}/messages", state.anthropic_base_url.read().await);
-    let auth_header = state.anthropic_auth_header.read().await.clone();
+    let model = state.llm_model.read().await.clone();
+    let base_url = state.llm_base_url.read().await.clone();
+    let auth_header_name = state.llm_auth_header.read().await.clone();
     let workflow_id = req.workflow_id;
     let initial_messages = req.messages;
 
@@ -3101,12 +3640,17 @@ async fn chat_handler(
         }
     };
 
-    let claude_tools = mcp_tools_to_claude_tools(&tools);
     let system_prompt = chat_system_prompt(workflow_id);
     let http_client = state.client.clone();
 
+    // Choose API format based on provider
+    let is_openai_compatible = matches!(
+        provider,
+        LlmProvider::OpenAI | LlmProvider::Ollama | LlmProvider::GitHub
+    );
+
     let stream = async_stream::stream! {
-        // Build the messages for the API
+        // Build the messages for the API (Anthropic format initially)
         let mut messages: Vec<serde_json::Value> = initial_messages
             .iter()
             .map(|m| {
@@ -3129,25 +3673,76 @@ async fn chat_handler(
             }
             round += 1;
 
-            // Build Claude API request
-            let api_body = serde_json::json!({
-                "model": model,
-                "max_tokens": 8192,
-                "system": system_prompt,
-                "messages": messages,
-                "tools": claude_tools,
-            });
+            // Build API request based on provider
+            let (api_url, api_body, auth_header_value) = if is_openai_compatible {
+                // OpenAI-compatible API (Ollama, GitHub Models)
+                let url = format!("{}/chat/completions", base_url);
+                let openai_tools = mcp_tools_to_openai_tools(&tools);
+                let openai_messages = messages_to_openai_format(&messages, &system_prompt);
 
-            // Non-streaming request to Claude API (simpler and more reliable)
-            let response = match http_client
-                .post(&messages_url)
-                .header(&auth_header, &api_key)
-                .header("anthropic-version", "2023-06-01")
-                .header("content-type", "application/json")
-                .json(&api_body)
-                .send()
-                .await
-            {
+                // GitHub Models has a strict 8000 token input limit for gpt-4o
+                // Use filtered essential tools only for GitHub to fit within limit
+                let (final_messages, final_tools, was_truncated) = if provider == LlmProvider::GitHub {
+                    // Use only essential tools for GitHub Models
+                    let filtered_tools = mcp_tools_to_openai_tools_filtered(&tools);
+                    let tools_json = serde_json::json!(&filtered_tools);
+                    let tools_tokens = estimate_tokens(&tools_json);
+
+                    info!(
+                        "GitHub Models: using {} essential tools (~{} tokens)",
+                        filtered_tools.len(),
+                        tools_tokens
+                    );
+
+                    let (msgs, truncated) = truncate_messages_to_token_limit(openai_messages, &tools_json, 6000);
+                    (msgs, filtered_tools, truncated)
+                } else {
+                    (openai_messages, openai_tools.clone(), false)
+                };
+
+                if was_truncated {
+                    info!("Truncated conversation history to fit GitHub Models token limit");
+                }
+
+                let body = serde_json::json!({
+                    "model": model,
+                    "max_tokens": 8192,
+                    "messages": final_messages,
+                    "tools": final_tools,
+                });
+
+                // Both GitHub Models and Ollama use Bearer token format
+                let auth_value = format!("Bearer {}", api_key);
+
+                (url, body, auth_value)
+            } else {
+                // Anthropic API
+                let url = format!("{}/messages", base_url);
+                let claude_tools = mcp_tools_to_claude_tools(&tools);
+
+                let body = serde_json::json!({
+                    "model": model,
+                    "max_tokens": 8192,
+                    "system": system_prompt,
+                    "messages": messages,
+                    "tools": claude_tools,
+                });
+
+                (url, body, api_key.clone())
+            };
+
+            // Make API request
+            let mut request_builder = http_client
+                .post(&api_url)
+                .header(&auth_header_name, &auth_header_value)
+                .header("content-type", "application/json");
+
+            // Add Anthropic-specific header
+            if !is_openai_compatible {
+                request_builder = request_builder.header("anthropic-version", "2023-06-01");
+            }
+
+            let response = match request_builder.json(&api_body).send().await {
                 Ok(resp) => resp,
                 Err(e) => {
                     yield Ok(Event::default()
@@ -3160,9 +3755,15 @@ async fn chat_handler(
             if !response.status().is_success() {
                 let status = response.status();
                 let body = response.text().await.unwrap_or_default();
+                let provider_name = match provider {
+                    LlmProvider::Anthropic => "Claude",
+                    LlmProvider::OpenAI => "OpenAI",
+                    LlmProvider::Ollama => "Ollama",
+                    LlmProvider::GitHub => "GitHub Models",
+                };
                 yield Ok(Event::default()
                     .event("error")
-                    .data(format!("Claude API error ({}): {}", status, body)));
+                    .data(format!("{} API error ({}): {}", provider_name, status, body)));
                 break;
             }
 
@@ -3176,43 +3777,94 @@ async fn chat_handler(
                 }
             };
 
-            let stop_reason = resp_json["stop_reason"].as_str().unwrap_or("end_turn");
-            let content_blocks = resp_json["content"].as_array().cloned().unwrap_or_default();
+            // Parse response based on API format
+            let (text_content, tool_calls, should_continue) = if is_openai_compatible {
+                // OpenAI format response
+                let choice = &resp_json["choices"][0];
+                let message = &choice["message"];
+                let finish_reason = choice["finish_reason"].as_str().unwrap_or("stop");
 
-            // Process content blocks: send text to frontend, collect tool calls
-            let mut text_parts = Vec::new();
-            let mut tool_uses = Vec::new();
+                let text = message["content"].as_str().unwrap_or("").to_string();
+                let tool_calls_arr = message["tool_calls"].as_array().cloned().unwrap_or_default();
 
-            for block in &content_blocks {
-                match block["type"].as_str() {
-                    Some("text") => {
-                        if let Some(text) = block["text"].as_str() {
-                            let text_owned = text.to_string();
-                            // JSON-encode so newlines stay on one SSE data: line
-                            let json_text = serde_json::to_string(&text_owned)
-                                .unwrap_or_else(|_| format!("\"{}\"", text_owned));
-                            yield Ok(Event::default()
-                                .event("text")
-                                .data(json_text));
-                            text_parts.push(text_owned);
+                debug!(
+                    "OpenAI response: finish_reason={}, tool_calls={}, content_len={}",
+                    finish_reason,
+                    tool_calls_arr.len(),
+                    text.len()
+                );
+
+                // Convert OpenAI tool calls to our internal format
+                let tools: Vec<serde_json::Value> = tool_calls_arr
+                    .iter()
+                    .map(|tc| {
+                        let func = &tc["function"];
+                        let args_str = func["arguments"].as_str().unwrap_or("{}");
+                        let input: serde_json::Value = serde_json::from_str(args_str)
+                            .unwrap_or(serde_json::json!({}));
+                        debug!("Tool call: {} with args: {}", func["name"], args_str);
+                        serde_json::json!({
+                            "id": tc["id"],
+                            "name": func["name"],
+                            "input": input,
+                        })
+                    })
+                    .collect();
+
+                // Continue if there are tool calls, regardless of finish_reason
+                // (some models/providers use different finish_reason values)
+                let has_tool_calls = !tools.is_empty();
+                (text, tools, has_tool_calls)
+            } else {
+                // Anthropic format response
+                let stop_reason = resp_json["stop_reason"].as_str().unwrap_or("end_turn");
+                let content_blocks = resp_json["content"].as_array().cloned().unwrap_or_default();
+
+                let mut text_parts = Vec::new();
+                let mut tool_uses = Vec::new();
+
+                for block in &content_blocks {
+                    match block["type"].as_str() {
+                        Some("text") => {
+                            if let Some(text) = block["text"].as_str() {
+                                text_parts.push(text.to_string());
+                            }
                         }
-                    }
-                    Some("tool_use") => {
-                        tool_uses.push(block.clone());
-                        // Notify frontend about tool call
-                        yield Ok(Event::default()
-                            .event("tool_use")
-                            .data(serde_json::json!({
+                        Some("tool_use") => {
+                            tool_uses.push(serde_json::json!({
                                 "id": block["id"],
                                 "name": block["name"],
                                 "input": block["input"],
-                            }).to_string()));
+                            }));
+                        }
+                        _ => {}
                     }
-                    _ => {}
                 }
+
+                (text_parts.join(""), tool_uses, stop_reason == "tool_use")
+            };
+
+            // Send text content to frontend
+            if !text_content.is_empty() {
+                let json_text = serde_json::to_string(&text_content)
+                    .unwrap_or_else(|_| format!("\"{}\"", text_content));
+                yield Ok(Event::default()
+                    .event("text")
+                    .data(json_text));
             }
 
-            if stop_reason != "tool_use" || tool_uses.is_empty() {
+            // Send tool calls to frontend
+            for tool_call in &tool_calls {
+                yield Ok(Event::default()
+                    .event("tool_use")
+                    .data(serde_json::json!({
+                        "id": tool_call["id"],
+                        "name": tool_call["name"],
+                        "input": tool_call["input"],
+                    }).to_string()));
+            }
+
+            if !should_continue || tool_calls.is_empty() {
                 // Done - no more tool calls
                 yield Ok(Event::default()
                     .event("done")
@@ -3222,11 +3874,28 @@ async fn chat_handler(
 
             // Execute tool calls via MCP and build tool results
             let mut tool_results = Vec::new();
+            let mut anthropic_content_blocks: Vec<serde_json::Value> = Vec::new();
 
-            for tool_use in &tool_uses {
-                let tool_name = tool_use["name"].as_str().unwrap_or("");
-                let tool_id = tool_use["id"].as_str().unwrap_or("");
-                let tool_input = tool_use["input"].as_object();
+            // Add text block if present (for Anthropic format)
+            if !text_content.is_empty() {
+                anthropic_content_blocks.push(serde_json::json!({
+                    "type": "text",
+                    "text": text_content,
+                }));
+            }
+
+            for tool_call in &tool_calls {
+                let tool_name = tool_call["name"].as_str().unwrap_or("");
+                let tool_id = tool_call["id"].as_str().unwrap_or("");
+                let tool_input = tool_call["input"].as_object();
+
+                // Add tool_use block for Anthropic format
+                anthropic_content_blocks.push(serde_json::json!({
+                    "type": "tool_use",
+                    "id": tool_id,
+                    "name": tool_name,
+                    "input": tool_call["input"],
+                }));
 
                 let arguments = tool_input.cloned();
 
@@ -3237,10 +3906,7 @@ async fn chat_handler(
                     },
                 );
 
-                match peer
-                    .call_tool(request)
-                    .await
-                {
+                match peer.call_tool(request).await {
                     Ok(result) => {
                         let result_text = extract_tool_result_text(&result);
                         let is_error = result.is_error.unwrap_or(false);
@@ -3285,9 +3951,10 @@ async fn chat_handler(
             }
 
             // Append assistant message and tool results to conversation
+            // We store in Anthropic format internally, convert to OpenAI when needed
             messages.push(serde_json::json!({
                 "role": "assistant",
-                "content": content_blocks,
+                "content": anthropic_content_blocks,
             }));
             messages.push(serde_json::json!({
                 "role": "user",

--- a/src/client/commands/slurm.rs
+++ b/src/client/commands/slurm.rs
@@ -4664,7 +4664,7 @@ fn handle_regenerate(
     };
 
     // Build WorkflowGraph from pending jobs for proper dependency-aware grouping
-    // This aligns with create-slurm's behavior of separating jobs by (rr, has_dependencies)
+    // This aligns with slurm generate's behavior of separating jobs by (rr, has_dependencies)
     let graph = match WorkflowGraph::from_jobs(&pending_jobs, &resource_requirements) {
         Ok(g) => g,
         Err(e) => {

--- a/src/client/job_runner.rs
+++ b/src/client/job_runner.rs
@@ -722,15 +722,23 @@ impl JobRunner {
                         "Failed to check workflow completion after retries: {}",
                         retry_err
                     );
+                    self.kill_running_jobs();
                     return Err(
                         format!("Unable to check workflow completion: {}", retry_err).into(),
                     );
                 }
             }
 
-            self.check_job_status();
-            if self.execution_config.limit_resources() && exec_mode == ExecutionMode::Direct {
-                self.handle_oom_violations();
+            if let Err(e) = self.check_job_status() {
+                self.kill_running_jobs();
+                return Err(e);
+            }
+            if self.execution_config.limit_resources()
+                && exec_mode == ExecutionMode::Direct
+                && let Err(e) = self.handle_oom_violations()
+            {
+                self.kill_running_jobs();
+                return Err(e);
             }
             self.check_and_execute_actions();
 
@@ -853,6 +861,31 @@ impl JobRunner {
         })
     }
 
+    /// Kill all running child processes without making any API calls.
+    ///
+    /// Used when the server is unreachable and we need to exit immediately.
+    /// Jobs are left in their current server-side status (likely "running");
+    /// the server will detect them as stale when the compute node is no longer
+    /// reporting in.
+    fn kill_running_jobs(&mut self) {
+        if self.running_jobs.is_empty() {
+            return;
+        }
+        error!(
+            "Killing {} running job(s) due to unrecoverable API failure workflow_id={}",
+            self.running_jobs.len(),
+            self.workflow_id
+        );
+        for (job_id, async_job) in self.running_jobs.iter_mut() {
+            if let Err(e) = async_job.send_sigkill() {
+                warn!(
+                    "Failed to SIGKILL job workflow_id={} job_id={}: {}",
+                    self.workflow_id, job_id, e
+                );
+            }
+        }
+    }
+
     /// Deactivate the compute node and set its duration.
     fn deactivate_compute_node(&self) {
         let duration_seconds = self.start_instant.elapsed().as_secs_f64();
@@ -920,7 +953,12 @@ impl JobRunner {
             };
         }
         for (job_id, result) in results {
-            self.handle_job_completion(job_id, result);
+            if let Err(e) = self.handle_job_completion(job_id, result) {
+                error!(
+                    "Failed to record canceled job completion workflow_id={} job_id={}: {}",
+                    self.workflow_id, job_id, e
+                );
+            }
         }
     }
 
@@ -1100,12 +1138,17 @@ impl JobRunner {
 
         // Final pass: handle completions (notify server)
         for (job_id, result) in results {
-            self.handle_job_completion(job_id, result);
+            if let Err(e) = self.handle_job_completion(job_id, result) {
+                error!(
+                    "Failed to record terminated job completion workflow_id={} job_id={}: {}",
+                    self.workflow_id, job_id, e
+                );
+            }
         }
     }
 
     /// Check the status of running jobs and remove completed ones.
-    fn check_job_status(&mut self) {
+    fn check_job_status(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         let mut completed_jobs = Vec::new();
         let mut job_results = Vec::new();
 
@@ -1147,8 +1190,9 @@ impl JobRunner {
                 result.status = JobStatus::Failed;
             }
 
-            self.handle_job_completion(job_id, result);
+            self.handle_job_completion(job_id, result)?;
         }
+        Ok(())
     }
 
     /// Handle OOM violations detected by the resource monitor.
@@ -1161,14 +1205,14 @@ impl JobRunner {
     /// 2. Immediately SIGKILLs the violating job (no grace period for OOM)
     /// 3. Waits for the job to exit and collects its result
     /// 4. Reports the job as failed with the configured `oom_exit_code`
-    fn handle_oom_violations(&mut self) {
+    fn handle_oom_violations(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         let violations = match &self.resource_monitor {
             Some(monitor) => monitor.recv_oom_violations(),
-            None => return,
+            None => return Ok(()),
         };
 
         if violations.is_empty() {
-            return;
+            return Ok(());
         }
 
         let oom_exit_code = self.execution_config.oom_exit_code();
@@ -1243,8 +1287,9 @@ impl JobRunner {
 
         // Third pass: handle completions (notify server)
         for (job_id, result) in results {
-            self.handle_job_completion(job_id, result);
+            self.handle_job_completion(job_id, result)?;
         }
+        Ok(())
     }
 
     /// Validate that all expected output files exist and update their st_mtime
@@ -1447,7 +1492,11 @@ impl JobRunner {
         }
     }
 
-    fn handle_job_completion(&mut self, job_id: i64, result: ResultModel) {
+    fn handle_job_completion(
+        &mut self,
+        job_id: i64,
+        result: ResultModel,
+    ) -> Result<(), Box<dyn std::error::Error>> {
         // Take sacct stats now, before the result is sent to the server, so we can backfill
         // resource fields.  For srun-wrapped jobs the sysinfo monitor only sees the srun process
         // (negligible overhead), so sacct provides the authoritative peak memory and CPU data.
@@ -1500,7 +1549,7 @@ impl JobRunner {
                     self.last_job_claimed_time = Some(Instant::now());
                     self.running_jobs.remove(&job_id);
                     self.job_resources.remove(&job_id);
-                    return;
+                    return Ok(());
                 }
                 RecoveryOutcome::NoHandler | RecoveryOutcome::NoMatchingRule => {
                     // Check if workflow has use_pending_failed enabled
@@ -1593,14 +1642,22 @@ impl JobRunner {
             }
             Err(e) => {
                 error!(
-                    "Job complete failed workflow_id={} job_id={} error={}",
+                    "Job complete failed after retries workflow_id={} job_id={} error={}",
                     self.workflow_id, job_id, e
+                );
+                // Clean up local state before propagating the error
+                self.running_jobs.remove(&job_id);
+                self.job_resources.remove(&job_id);
+                self.release_gpu_devices(job_id);
+                return Err(
+                    format!("Unable to record job completion for job {}: {}", job_id, e).into(),
                 );
             }
         }
         self.running_jobs.remove(&job_id);
         self.job_resources.remove(&job_id);
         self.release_gpu_devices(job_id);
+        Ok(())
     }
 
     /// Delete stdio files for a completed job.
@@ -2026,10 +2083,12 @@ impl JobRunner {
                         Ok(rr) => rr,
                         Err(e) => {
                             error!(
-                                "Error getting resource requirements for job {}: {}",
-                                job_id, e
+                                "Failed to get resource requirements after retries \
+                                 workflow_id={} job_id={} rr_id={}: {}",
+                                self.workflow_id, job_id, rr_id, e
                             );
-                            panic!("Failed to get resource requirements");
+                            self.revert_job_to_ready(job_id);
+                            continue;
                         }
                     };
 
@@ -2045,10 +2104,13 @@ impl JobRunner {
                             debug!("Successfully marked job {} as started in database", job_id);
                         }
                         Err(e) => {
-                            panic!(
-                                "Failed to mark job {} as started in database after retries: {}",
-                                job_id, e
+                            error!(
+                                "Failed to mark job as started after retries \
+                                 workflow_id={} job_id={}: {}",
+                                self.workflow_id, job_id, e
                             );
+                            self.revert_job_to_ready(job_id);
+                            continue;
                         }
                     }
 
@@ -2172,10 +2234,12 @@ impl JobRunner {
                         Ok(rr) => rr,
                         Err(e) => {
                             error!(
-                                "Error getting resource requirements for job {}: {}",
-                                job_id, e
+                                "Failed to get resource requirements after retries \
+                                 workflow_id={} job_id={} rr_id={}: {}",
+                                self.workflow_id, job_id, rr_id, e
                             );
-                            panic!("Failed to get resource requirements");
+                            self.revert_job_to_ready(job_id);
+                            continue;
                         }
                     };
 
@@ -2193,10 +2257,11 @@ impl JobRunner {
                         }
                         Err(e) => {
                             error!(
-                                "Failed to mark job {} as started in database after retries: {}",
-                                job_id, e
+                                "Failed to mark job as started after retries \
+                                 workflow_id={} job_id={}: {}",
+                                self.workflow_id, job_id, e
                             );
-                            // Skip this job if we can't mark it as started
+                            self.revert_job_to_ready(job_id);
                             continue;
                         }
                     }
@@ -2251,10 +2316,9 @@ impl JobRunner {
             }
             Err(err) => {
                 error!(
-                    "Job preparation failed workflow_id={} error={}",
+                    "Failed to claim jobs after retries workflow_id={}: {}",
                     self.workflow_id, err
                 );
-                panic!("Failed to prepare jobs for submission after retries");
             }
         }
     }

--- a/src/client/utils.rs
+++ b/src/client/utils.rs
@@ -78,6 +78,31 @@ pub fn shell_command() -> Command {
 ///
 /// # Returns
 /// The result of the API call, or the original error if retries are exhausted
+/// Check whether an error string indicates a transient failure that should be retried.
+///
+/// Retryable errors include:
+/// - Network-level failures (connection refused, DNS, timeout, unreachable)
+/// - HTTP 500/502/503 responses (server crash, gateway error, overloaded)
+/// - Database contention ("database is locked", "busy")
+fn is_retryable_error(error_str: &str) -> bool {
+    let s = error_str.to_lowercase();
+
+    // Network errors
+    s.contains("connection")
+        || s.contains("timeout")
+        || s.contains("network")
+        || s.contains("dns")
+        || s.contains("resolve")
+        || s.contains("unreachable")
+        // HTTP server errors (formatted as "status code 500" by the generated client)
+        || s.contains("status code 500")
+        || s.contains("status code 502")
+        || s.contains("status code 503")
+        // Database contention
+        || s.contains("database is locked")
+        || s.contains("database is busy")
+}
+
 pub fn send_with_retries<T, E, F>(
     config: &Configuration,
     mut api_call: F,
@@ -90,22 +115,13 @@ where
     match api_call() {
         Ok(result) => Ok(result),
         Err(e) => {
-            // Check if this is a network-related error
-            let error_str = e.to_string().to_lowercase();
-            let is_network_error = error_str.contains("connection")
-                || error_str.contains("timeout")
-                || error_str.contains("network")
-                || error_str.contains("dns")
-                || error_str.contains("resolve")
-                || error_str.contains("unreachable");
-
-            if !is_network_error {
-                // Not a network error, return immediately
+            let error_str = e.to_string();
+            if !is_retryable_error(&error_str) {
                 return Err(e);
             }
 
             warn!(
-                "Network error detected: {}. Entering retry loop for up to {} minutes.",
+                "Transient error detected: {}. Entering retry loop for up to {} minutes.",
                 e, wait_for_healthy_database_minutes
             );
 
@@ -123,12 +139,25 @@ where
 
                 thread::sleep(Duration::from_secs(PING_INTERVAL_SECONDS));
 
-                // Try to ping the server
+                // Try to ping the server first to confirm it's reachable
                 match apis::system_api::ping(config) {
                     Ok(_) => {
-                        info!("Server is back online. Retrying original API call.");
-                        // Server is back, retry the original call
-                        return api_call();
+                        info!("Server is responding. Retrying original API call.");
+                        match api_call() {
+                            Ok(result) => return Ok(result),
+                            Err(retry_err) => {
+                                let retry_str = retry_err.to_string();
+                                if is_retryable_error(&retry_str) {
+                                    warn!(
+                                        "Retry attempt failed with transient error: {}. \
+                                         Will keep retrying.",
+                                        retry_err
+                                    );
+                                    continue;
+                                }
+                                return Err(retry_err);
+                            }
+                        }
                     }
                     Err(ping_error) => {
                         debug!(
@@ -411,6 +440,41 @@ mod tests {
         let line = "[invalid timestamp] message";
         let ts = parse_dmesg_timestamp(line);
         assert!(ts.is_none());
+    }
+
+    #[test]
+    fn test_is_retryable_error() {
+        // Network errors
+        assert!(is_retryable_error("connection refused"));
+        assert!(is_retryable_error("Connection reset by peer"));
+        assert!(is_retryable_error("DNS lookup failed"));
+        assert!(is_retryable_error("request timeout"));
+        assert!(is_retryable_error("network is unreachable"));
+
+        // HTTP 5xx from generated client
+        assert!(is_retryable_error(
+            "error in response: status code 500: internal error"
+        ));
+        assert!(is_retryable_error("error in response: status code 502"));
+        assert!(is_retryable_error(
+            "error in response: status code 503: service unavailable"
+        ));
+
+        // Database contention
+        assert!(is_retryable_error("database is locked"));
+        assert!(is_retryable_error("database is busy"));
+
+        // Non-retryable errors
+        assert!(!is_retryable_error(
+            "error in response: status code 404: not found"
+        ));
+        assert!(!is_retryable_error(
+            "error in response: status code 422: validation error"
+        ));
+        assert!(!is_retryable_error("serde: missing field `id`"));
+        assert!(!is_retryable_error(
+            "error in response: status code 403: forbidden"
+        ));
     }
 
     #[test]

--- a/src/mcp_server/server.rs
+++ b/src/mcp_server/server.rs
@@ -448,7 +448,7 @@ AFTER SAVING A SPEC FILE - tell users:
    - LOCAL workflows: "torc run <file>"
    - SLURM workflows (spec saved with workflow_type="slurm"):
      - "torc submit <file>" (uses schedulers already generated in the spec)
-     - Or create and submit separately: "torc workflows create-slurm --account <acct> <file>" then "torc workflows submit <id>"
+     - Or create and submit separately: "torc create <file>" then "torc submit <id>"
 IMPORTANT: Do NOT fabricate CLI commands or options. Only use the exact commands shown above.
 
 WORKFLOW_TYPE: "local" or "slurm" (slurm requires account)

--- a/src/mcp_server/tools.rs
+++ b/src/mcp_server/tools.rs
@@ -569,17 +569,38 @@ pub fn create_workflow(
             )]))
         }
         ("create_workflow", "slurm") => {
-            // Create slurm workflow using CLI: torc workflows create-slurm
-            let mut cmd = Command::new("torc");
-            cmd.args(["-f", "json", "workflows", "create-slurm"]);
-            cmd.args(["--account", account.unwrap()]);
-            cmd.args(["--user", user]);
+            // Create slurm workflow: first generate schedulers, then create
+            // Step 1: Run torc slurm generate to create spec with schedulers
+            let slurm_spec_path = format!("{}_slurm", temp_path.display());
+            let mut gen_cmd = Command::new("torc");
+            gen_cmd.args(["slurm", "generate"]);
+            gen_cmd.args(["--account", account.unwrap()]);
+            gen_cmd.args(["-o", &slurm_spec_path]);
 
             if let Some(profile) = hpc_profile {
-                cmd.args(["--hpc-profile", profile]);
+                gen_cmd.args(["--profile", profile]);
             }
 
-            cmd.arg(temp_path);
+            gen_cmd.arg(temp_path);
+
+            let gen_output = gen_cmd
+                .output()
+                .map_err(|e| internal_error(format!("Failed to run slurm generate: {}", e)))?;
+
+            if !gen_output.status.success() {
+                let stderr = String::from_utf8_lossy(&gen_output.stderr);
+                return Err(internal_error(format!(
+                    "Failed to generate slurm schedulers: {}",
+                    stderr.trim()
+                )));
+            }
+
+            // Step 2: Create the workflow from the generated spec
+            let mut cmd = Command::new("torc");
+            cmd.args(["-f", "json", "create"]);
+            cmd.args(["--user", user]);
+
+            cmd.arg(&slurm_spec_path);
 
             let output = cmd
                 .output()

--- a/tests/workflows/README.md
+++ b/tests/workflows/README.md
@@ -111,7 +111,7 @@ resolution, job claiming, and completion processing under heavy concurrent acces
 torc run tests/workflows/scale_test/workflow.yaml --num-parallel-processes 16
 
 # Or with multiple independent runners for maximum contention
-torc workflows create tests/workflows/scale_test/workflow.yaml
+torc create tests/workflows/scale_test/workflow.yaml
 for i in $(seq 1 16); do
   torc run <workflow_id> &
 done

--- a/tests/workflows/database_contention_test/README.md
+++ b/tests/workflows/database_contention_test/README.md
@@ -33,7 +33,7 @@ DATABASE_URL=sqlite:db/sqlite/dev.db cargo run --bin torc-server -- run
 export TORC_API_URL="http://localhost:8080/torc-service/v1"
 
 # Create and run the workflow
-torc workflows create tests/workflows/database_contention_test/workflow.yaml
+torc create tests/workflows/database_contention_test/workflow.yaml
 torc run <workflow_id>
 
 # Monitor with TUI

--- a/tests/workflows/database_contention_test/workflow.yaml
+++ b/tests/workflows/database_contention_test/workflow.yaml
@@ -13,12 +13,12 @@ description: |
     the background unblocking thread processing completions
 
   Run with:
-    torc workflows create tests/workflows/database_contention_test/workflow.yaml
-    torc workflows run <workflow_id>
+    torc create tests/workflows/database_contention_test/workflow.yaml
+    torc run <workflow_id>
 
   Or for Slurm:
-    torc workflows create-slurm --account <account> tests/workflows/database_contention_test/workflow.yaml
-    torc workflows submit <workflow_id>
+    torc create tests/workflows/database_contention_test/workflow.yaml
+    torc submit <workflow_id>
 
 jobs:
   # ═══════════════════════════════════════════════════════════════════════════

--- a/tests/workflows/oom_auto_recovery_test/workflow.yaml
+++ b/tests/workflows/oom_auto_recovery_test/workflow.yaml
@@ -8,7 +8,7 @@
 # - This will cause OOM failures since the jobs only request 10GB
 #
 # Test procedure:
-# 1. Submit the workflow: torc submit-slurm --account <account> workflow.yaml
+# 1. Submit the workflow: torc submit workflow.yaml
 # 2. Watch with auto-recover: torc watch <workflow_id> --recover
 # 3. Jobs will fail with OOM, watcher increases memory (10GB -> 15GB -> 22GB -> 33GB)
 # 4. Eventually jobs get enough memory and succeed

--- a/tests/workflows/scale_test/README.md
+++ b/tests/workflows/scale_test/README.md
@@ -53,7 +53,7 @@ contention (the point of the test) and better simulates a real multi-node deploy
 #### Step 1: Create the Workflow
 
 ```bash
-torc workflows create tests/workflows/scale_test/workflow.yaml
+torc create tests/workflows/scale_test/workflow.yaml
 ```
 
 Note the workflow ID from the output.

--- a/tests/workflows/timeout_auto_recovery_test/workflow.yaml
+++ b/tests/workflows/timeout_auto_recovery_test/workflow.yaml
@@ -9,7 +9,7 @@
 # - Slurm scheduler with 8 minute walltime
 #
 # Test procedure:
-# 1. Submit the workflow: torc submit-slurm --account <account> workflow.yaml
+# 1. Submit the workflow: torc submit workflow.yaml
 # 2. Watch with auto-recover: torc watch <workflow_id> --recover
 # 3. job_slow will be killed by Slurm at ~8 minutes (walltime exceeded)
 # 4. Watcher detects timeout and increases runtime (5min -> 7.5min -> 11.25min)

--- a/torc-dash/static/index.html
+++ b/torc-dash/static/index.html
@@ -501,18 +501,37 @@
                                 <label for="chat-provider-select">Provider</label>
                                 <select id="chat-provider-select" class="chat-setup-select">
                                     <option value="anthropic">Anthropic (Direct API)</option>
+                                    <option value="openai">OpenAI</option>
                                     <option value="foundry">Azure AI Foundry</option>
+                                    <option value="ollama">Ollama (Local)</option>
+                                    <option value="github">GitHub Models</option>
                                     <option value="custom">Custom Endpoint</option>
                                 </select>
                             </div>
-                            <div class="chat-setup-field">
+                            <div class="chat-setup-field" id="chat-api-key-field">
                                 <label for="chat-api-key-input">API Key</label>
                                 <input type="password" id="chat-api-key-input" class="chat-input" placeholder="sk-ant-..." aria-label="API key">
+                            </div>
+                            <div class="chat-setup-field" id="chat-model-field" style="display:none">
+                                <label for="chat-model-input">Model</label>
+                                <input type="text" id="chat-model-input" class="chat-input" placeholder="llama3.2" aria-label="Model name">
                             </div>
                             <div class="chat-setup-field" id="chat-foundry-field" style="display:none">
                                 <label for="chat-foundry-resource">Foundry Resource Name</label>
                                 <input type="text" id="chat-foundry-resource" class="chat-input" placeholder="my-resource" aria-label="Azure AI Foundry resource name">
                                 <small>URL: https://{resource}.services.ai.azure.com/anthropic/v1</small>
+                            </div>
+                            <div class="chat-setup-field" id="chat-openai-url-field" style="display:none">
+                                <label for="chat-openai-base-url">API URL <small>(optional, for compatible services)</small></label>
+                                <input type="text" id="chat-openai-base-url" class="chat-input" placeholder="https://api.openai.com/v1" aria-label="OpenAI base URL">
+                            </div>
+                            <div class="chat-setup-field" id="chat-ollama-url-field" style="display:none">
+                                <label for="chat-ollama-base-url">Ollama URL <small>(optional)</small></label>
+                                <input type="text" id="chat-ollama-base-url" class="chat-input" placeholder="http://localhost:11434/v1" aria-label="Ollama base URL">
+                            </div>
+                            <div class="chat-setup-field" id="chat-github-url-field" style="display:none">
+                                <label for="chat-github-base-url">GitHub Models URL <small>(optional)</small></label>
+                                <input type="text" id="chat-github-base-url" class="chat-input" placeholder="https://models.inference.ai.azure.com" aria-label="GitHub Models base URL">
                             </div>
                             <div class="chat-setup-field" id="chat-custom-url-field" style="display:none">
                                 <label for="chat-custom-base-url">Base URL</label>

--- a/torc-dash/static/js/app-chat.js
+++ b/torc-dash/static/js/app-chat.js
@@ -66,25 +66,53 @@ Object.assign(TorcDashboard.prototype, {
 
     updateProviderFields() {
         const provider = document.getElementById('chat-provider-select')?.value || 'anthropic';
+        const apiKeyField = document.getElementById('chat-api-key-field');
+        const apiKeyInput = document.getElementById('chat-api-key-input');
+        const modelField = document.getElementById('chat-model-field');
+        const modelInput = document.getElementById('chat-model-input');
         const foundryField = document.getElementById('chat-foundry-field');
+        const openaiUrlField = document.getElementById('chat-openai-url-field');
+        const ollamaUrlField = document.getElementById('chat-ollama-url-field');
+        const githubUrlField = document.getElementById('chat-github-url-field');
         const customUrlField = document.getElementById('chat-custom-url-field');
         const customHeaderField = document.getElementById('chat-custom-header-field');
-        const apiKeyInput = document.getElementById('chat-api-key-input');
 
         // Hide all provider-specific fields
         if (foundryField) foundryField.style.display = 'none';
+        if (openaiUrlField) openaiUrlField.style.display = 'none';
+        if (ollamaUrlField) ollamaUrlField.style.display = 'none';
+        if (githubUrlField) githubUrlField.style.display = 'none';
         if (customUrlField) customUrlField.style.display = 'none';
         if (customHeaderField) customHeaderField.style.display = 'none';
+        if (modelField) modelField.style.display = 'none';
+        if (apiKeyField) apiKeyField.style.display = '';
 
         // Show fields for selected provider and update placeholder
         if (provider === 'foundry') {
             if (foundryField) foundryField.style.display = '';
             if (apiKeyInput) apiKeyInput.placeholder = 'Foundry API key';
+        } else if (provider === 'openai') {
+            if (apiKeyInput) apiKeyInput.placeholder = 'sk-... (OpenAI API key)';
+            if (openaiUrlField) openaiUrlField.style.display = '';
+            if (modelField) modelField.style.display = '';
+            if (modelInput) modelInput.placeholder = 'gpt-4o';
+        } else if (provider === 'ollama') {
+            // Ollama doesn't need an API key
+            if (apiKeyField) apiKeyField.style.display = 'none';
+            if (ollamaUrlField) ollamaUrlField.style.display = '';
+            if (modelField) modelField.style.display = '';
+            if (modelInput) modelInput.placeholder = 'llama3.2';
+        } else if (provider === 'github') {
+            if (apiKeyInput) apiKeyInput.placeholder = 'ghp_... (GitHub token)';
+            if (githubUrlField) githubUrlField.style.display = '';
+            if (modelField) modelField.style.display = '';
+            if (modelInput) modelInput.placeholder = 'gpt-4o';
         } else if (provider === 'custom') {
             if (customUrlField) customUrlField.style.display = '';
             if (customHeaderField) customHeaderField.style.display = '';
             if (apiKeyInput) apiKeyInput.placeholder = 'API key';
         } else {
+            // anthropic
             if (apiKeyInput) apiKeyInput.placeholder = 'sk-ant-...';
         }
     },
@@ -133,19 +161,26 @@ Object.assign(TorcDashboard.prototype, {
         const input = document.getElementById('chat-api-key-input');
         const errorEl = document.getElementById('chat-setup-error');
         const submitBtn = document.getElementById('chat-api-key-submit');
-        if (!input) return;
 
-        const key = input.value.trim();
-        if (!key) {
+        const provider = document.getElementById('chat-provider-select')?.value || 'anthropic';
+        const key = input?.value?.trim() || '';
+
+        // Validate API key (not required for Ollama)
+        if (provider !== 'ollama' && !key) {
             if (errorEl) {
-                errorEl.textContent = 'Please enter an API key.';
+                const keyName = provider === 'github' ? 'GitHub token' : 'API key';
+                errorEl.textContent = `Please enter ${keyName}.`;
                 errorEl.style.display = '';
             }
             return;
         }
 
-        const provider = document.getElementById('chat-provider-select')?.value || 'anthropic';
-        const body = { api_key: key, provider };
+        const body = { api_key: provider === 'ollama' ? 'ollama' : key, provider };
+
+        // Get model if specified
+        const modelInput = document.getElementById('chat-model-input');
+        const model = modelInput?.value?.trim();
+        if (model) body.model = model;
 
         if (provider === 'foundry') {
             body.foundry_resource = document.getElementById('chat-foundry-resource')?.value?.trim() || '';
@@ -156,6 +191,15 @@ Object.assign(TorcDashboard.prototype, {
                 }
                 return;
             }
+        } else if (provider === 'openai') {
+            const baseUrl = document.getElementById('chat-openai-base-url')?.value?.trim();
+            if (baseUrl) body.base_url = baseUrl;
+        } else if (provider === 'ollama') {
+            const baseUrl = document.getElementById('chat-ollama-base-url')?.value?.trim();
+            if (baseUrl) body.base_url = baseUrl;
+        } else if (provider === 'github') {
+            const baseUrl = document.getElementById('chat-github-base-url')?.value?.trim();
+            if (baseUrl) body.base_url = baseUrl;
         } else if (provider === 'custom') {
             body.base_url = document.getElementById('chat-custom-base-url')?.value?.trim() || '';
             if (!body.base_url) {
@@ -181,11 +225,12 @@ Object.assign(TorcDashboard.prototype, {
 
             if (!response.ok) {
                 const text = await response.text();
-                throw new Error(text || 'Failed to configure API key');
+                throw new Error(text || 'Failed to configure provider');
             }
 
-            // Clear the input and show the chat
-            input.value = '';
+            // Clear the inputs and show the chat
+            if (input) input.value = '';
+            if (modelInput) modelInput.value = '';
             this.hideChatSetup();
         } catch (e) {
             if (errorEl) {


### PR DESCRIPTION
This fixes issues seen by a user where an overloaded torc-server (running on a login node experiencing Lustre filesystem delays) caused a torc job_runner to exit. This changes the runner to retry those failures for up to 20 minutes.

It also fixes cases where we were still using old CLI syntax, mostly in the docs.