### PR TITLE
Retry server errors in job_runner

### DIFF
--- a/src/client/utils.rs
+++ b/src/client/utils.rs
@@ -81,14 +81,21 @@ pub fn shell_command() -> Command {
 /// Check whether an error string indicates a transient failure that should be retried.
 ///
 /// Retryable errors include:
+/// - Any `apis::Error::Reqwest` variant (matched via the "error in reqwest" prefix
+///   produced by `apis::Error::Display`). This covers connect, send-request, and
+///   response-read failures whose inner cause is not exposed by reqwest's top-level
+///   `Display`.
 /// - Network-level failures (connection refused, DNS, timeout, unreachable)
 /// - HTTP 500/502/503 responses (server crash, gateway error, overloaded)
 /// - Database contention ("database is locked", "busy")
 fn is_retryable_error(error_str: &str) -> bool {
     let s = error_str.to_lowercase();
 
-    // Network errors
-    s.contains("connection")
+    // Any reqwest-layer failure is transient: connect, send, body read, TLS, etc.
+    // apis::Error::Display emits "error in reqwest: ..." for every Error::Reqwest.
+    s.contains("error in reqwest")
+        // Network errors
+        || s.contains("connection")
         || s.contains("timeout")
         || s.contains("network")
         || s.contains("dns")
@@ -450,6 +457,15 @@ mod tests {
         assert!(is_retryable_error("DNS lookup failed"));
         assert!(is_retryable_error("request timeout"));
         assert!(is_retryable_error("network is unreachable"));
+
+        // Any apis::Error::Reqwest variant (surfaces as "error in reqwest: ...")
+        assert!(is_retryable_error(
+            "error in reqwest: error sending request for url \
+             (http://127.0.0.1:39195/torc-service/v1/workflows/1/is_complete)"
+        ));
+        assert!(is_retryable_error(
+            "error in reqwest: error decoding response body"
+        ));
 
         // HTTP 5xx from generated client
         assert!(is_retryable_error(

--- a/src/client/utils.rs
+++ b/src/client/utils.rs
@@ -81,17 +81,25 @@ pub fn shell_command() -> Command {
 /// Check whether an error string indicates a transient failure that should be retried.
 ///
 /// Retryable errors include:
-/// - Any `apis::Error::Reqwest` variant (matched via the "error in reqwest" prefix
+/// - Most `apis::Error::Reqwest` variants (matched via the "error in reqwest" prefix
 ///   produced by `apis::Error::Display`). This covers connect, send-request, and
 ///   response-read failures whose inner cause is not exposed by reqwest's top-level
-///   `Display`.
+///   `Display`. Reqwest *builder* errors (invalid URL, misconfigured client) are
+///   excluded — they are deterministic and retrying will not help.
 /// - Network-level failures (connection refused, DNS, timeout, unreachable)
 /// - HTTP 500/502/503 responses (server crash, gateway error, overloaded)
 /// - Database contention ("database is locked", "busy")
 fn is_retryable_error(error_str: &str) -> bool {
     let s = error_str.to_lowercase();
 
-    // Any reqwest-layer failure is transient: connect, send, body read, TLS, etc.
+    // reqwest::Error with Kind::Builder (e.g. invalid URL, bad base_path) is
+    // deterministic. It surfaces as "error in reqwest: builder error: ..." and
+    // must not enter the retry loop.
+    if s.contains("builder error") {
+        return false;
+    }
+
+    // Any other reqwest-layer failure is transient: connect, send, body read, TLS, etc.
     // apis::Error::Display emits "error in reqwest: ..." for every Error::Reqwest.
     s.contains("error in reqwest")
         // Network errors
@@ -481,6 +489,10 @@ mod tests {
         assert!(is_retryable_error("database is busy"));
 
         // Non-retryable errors
+        // reqwest builder errors are deterministic (invalid URL, etc.)
+        assert!(!is_retryable_error(
+            "error in reqwest: builder error: relative URL without a base"
+        ));
         assert!(!is_retryable_error(
             "error in response: status code 404: not found"
         ));

--- a/src/client/utils.rs
+++ b/src/client/utils.rs
@@ -87,7 +87,7 @@ pub fn shell_command() -> Command {
 ///   `Display`. Reqwest *builder* errors (invalid URL, misconfigured client) are
 ///   excluded — they are deterministic and retrying will not help.
 /// - Network-level failures (connection refused, DNS, timeout, unreachable)
-/// - HTTP 500/502/503 responses (server crash, gateway error, overloaded)
+/// - HTTP 5xx responses (server crash, gateway error, overloaded)
 /// - Database contention ("database is locked", "busy")
 fn is_retryable_error(error_str: &str) -> bool {
     let s = error_str.to_lowercase();
@@ -109,13 +109,25 @@ fn is_retryable_error(error_str: &str) -> bool {
         || s.contains("dns")
         || s.contains("resolve")
         || s.contains("unreachable")
-        // HTTP server errors (formatted as "status code 500" by the generated client)
-        || s.contains("status code 500")
-        || s.contains("status code 502")
-        || s.contains("status code 503")
+        // HTTP server errors (formatted as "status code NNN" by the generated client)
+        || is_5xx_response_error(&s)
         // Database contention
         || s.contains("database is locked")
         || s.contains("database is busy")
+}
+
+fn is_5xx_response_error(s: &str) -> bool {
+    let Some(start) = s.find("status code ") else {
+        return false;
+    };
+    let status_start = start + "status code ".len();
+    let Some(status) = s.get(status_start..status_start + 3) else {
+        return false;
+    };
+
+    status
+        .parse::<u16>()
+        .is_ok_and(|code| (500..600).contains(&code))
 }
 
 pub fn send_with_retries<T, E, F>(
@@ -482,6 +494,12 @@ mod tests {
         assert!(is_retryable_error("error in response: status code 502"));
         assert!(is_retryable_error(
             "error in response: status code 503: service unavailable"
+        ));
+        assert!(is_retryable_error(
+            "error in response: status code 504: gateway timeout"
+        ));
+        assert!(is_retryable_error(
+            "error in response: status code 599: network connect timeout"
         ));
 
         // Database contention

--- a/src/client/utils.rs
+++ b/src/client/utils.rs
@@ -81,7 +81,7 @@ pub fn shell_command() -> Command {
 /// Check whether an error string indicates a transient failure that should be retried.
 ///
 /// Retryable errors include:
-/// - Most `apis::Error::Reqwest` variants (matched via the "error in reqwest" prefix
+/// - Most `apis::Error::Reqwest` variants (matched via the "error in reqwest" substring
 ///   produced by `apis::Error::Display`). This covers connect, send-request, and
 ///   response-read failures whose inner cause is not exposed by reqwest's top-level
 ///   `Display`. Reqwest *builder* errors (invalid URL, misconfigured client) are
@@ -90,7 +90,7 @@ pub fn shell_command() -> Command {
 /// - HTTP 5xx responses (server crash, gateway error, overloaded)
 /// - Database contention ("database is locked", "busy")
 fn is_retryable_error(error_str: &str) -> bool {
-    let s = error_str.to_lowercase();
+    let s = error_str.to_ascii_lowercase();
 
     // reqwest::Error with Kind::Builder (e.g. invalid URL, bad base_path) is
     // deterministic. It surfaces as "error in reqwest: builder error: ..." and
@@ -121,11 +121,12 @@ fn is_5xx_response_error(s: &str) -> bool {
         return false;
     };
     let status_start = start + "status code ".len();
-    let Some(status) = s.get(status_start..status_start + 3) else {
-        return false;
-    };
+    let digits: String = s[status_start..]
+        .chars()
+        .take_while(|c| c.is_ascii_digit())
+        .collect();
 
-    status
+    digits
         .parse::<u16>()
         .is_ok_and(|code| (500..600).contains(&code))
 }


### PR DESCRIPTION
A user experienced a workflow failure when running `torc -s exec`. The server failed to respond to an is_complete API command. The job_runner skipped the retry, killed all running jobs, and exited. The server was at fault and we aren't sure why. Our est guess is that the Lustre filesystem was slow because "slow statement" messages in the server log.

This commit causes all network errors to be retried for up to 20 minutes.