### PR TITLE
Add in-memory database with SIGUSR1 snapshots and --in-memory standalone

### DIFF
--- a/docs/src/core/how-to/run-inline-commands.md
+++ b/docs/src/core/how-to/run-inline-commands.md
@@ -147,6 +147,32 @@ torc -s exec -n hparam-sweep --description "LR sweep over ResNet50" \
 
 For the full reference, run `torc exec --help`.
 
+## Running on HPC Compute Nodes (In-Memory Mode)
+
+On HPC login or compute nodes where the shared filesystem (Lustre, GPFS, NFS) is intermittently
+slow, the standalone server's writes to `./torc_output/torc.db` can stall request handlers and slow
+the workflow as a whole. Add `--in-memory` to keep the database entirely in RAM and snapshot to disk
+only at the end:
+
+```console
+torc -s --in-memory exec -C commands.txt -j 32
+```
+
+The behavior is identical from the user's perspective — `torc_output/torc.db` is created and
+`torc -s results list` works as usual — but during the run, no SQLite traffic touches the shared
+filesystem.
+
+For longer-running workflows where losing recent state on parent-process death would be costly, add
+periodic snapshots:
+
+```console
+torc -s --in-memory --snapshot-interval-seconds 600 exec -C commands.txt -j 32
+```
+
+See
+[In-Memory Database with Snapshots](../../specialized/admin/server-deployment.md#in-memory-database-with-snapshots-advanced)
+for the full reference.
+
 ## When to Use `torc run` Instead
 
 `torc exec` is designed for ad-hoc commands. If you already have a workflow spec file (with

--- a/docs/src/specialized/admin/server-deployment.md
+++ b/docs/src/specialized/admin/server-deployment.md
@@ -137,6 +137,10 @@ RUST_LOG=debug torc-server run --log-dir /var/log/torc
 - `TORC_LOG_DIR`: Default log directory
 - `RUST_LOG`: Default log level
 - `TORC_MAX_REQUEST_BODY_MB`: Override the bulk job upload request-body limit in MiB
+- `TORC_SERVER_SNAPSHOT_PATH`: Snapshot output path for in-memory mode (default
+  `./torc-server-snapshot.db`). See
+  [In-Memory Database with Snapshots](#in-memory-database-with-snapshots-advanced).
+- `TORC_SERVER_SNAPSHOT_KEEP`: Number of snapshots to retain (default `5`, minimum `1`)
 
 Example:
 
@@ -182,6 +186,160 @@ kill $(cat /var/run/torc-server.pid)
 # Or forcefully
 kill -9 $(cat /var/run/torc-server.pid)
 ```
+
+## In-Memory Database with Snapshots (Advanced)
+
+Torc-server supports running entirely from a SQLite in-memory database, with on-demand snapshots to
+disk for persistence. This mode is intended for **HPC login and compute nodes where shared
+filesystems (Lustre, GPFS, NFS) are intermittently slow**. SQLite running against a stalled shared
+filesystem can hang request handlers for tens of seconds; running in memory eliminates that failure
+mode entirely.
+
+This is an advanced feature. The trade-off is straightforward: the database lives in RAM, and any
+data not yet snapshotted is lost if the process dies. Use it when you understand that trade-off and
+want to opt into it explicitly.
+
+### Starting the Server In-Memory
+
+Pass `:memory:` as the database path:
+
+```bash
+torc-server run -d ":memory:" -p 8080
+```
+
+On startup the server logs a confirmation message describing the snapshot configuration. Internally
+the server uses SQLite shared-cache memory mode so all pool connections share a single database;
+this is handled automatically — you only need to pass `:memory:`.
+
+### Persisting State with SIGUSR1
+
+To snapshot the in-memory database to disk, send `SIGUSR1` to the server process:
+
+```bash
+kill -USR1 $(pgrep -f 'torc-server run')
+```
+
+The server uses SQLite's [`VACUUM INTO`](https://sqlite.org/lang_vacuum.html#vacuuminto) to write a
+consistent point-in-time copy without blocking writers. The snapshot is written to a `.tmp` sibling
+first and then atomically renamed into place, so an interrupted snapshot can never corrupt a prior
+one.
+
+This works the same way for on-disk databases — you can use it as a hot-backup mechanism even when
+not running in memory.
+
+### Snapshot Rotation
+
+By default the server keeps **5 snapshots**, with the canonical path always pointing at the newest:
+
+```text
+./torc-server-snapshot.db      # newest
+./torc-server-snapshot.db.1    # previous
+./torc-server-snapshot.db.2
+./torc-server-snapshot.db.3
+./torc-server-snapshot.db.4    # oldest
+```
+
+On each `SIGUSR1`, older snapshots are shifted down (`.1` → `.2`, etc.), the oldest is dropped, and
+the freshly-written snapshot is renamed into the canonical path. If `TORC_SERVER_SNAPSHOT_KEEP=1`,
+no rotation happens — each snapshot simply overwrites the previous one.
+
+### Configuration
+
+Two environment variables control snapshot behavior:
+
+| Variable                    | Default                     | Description                                                                                     |
+| --------------------------- | --------------------------- | ----------------------------------------------------------------------------------------------- |
+| `TORC_SERVER_SNAPSHOT_PATH` | `./torc-server-snapshot.db` | Output path for the canonical (newest) snapshot. Relative paths resolve against the launch CWD. |
+| `TORC_SERVER_SNAPSHOT_KEEP` | `5`                         | Total snapshots retained (canonical + rotated). Minimum `1`.                                    |
+
+```bash
+export TORC_SERVER_SNAPSHOT_PATH=/scratch/$USER/torc-snapshots/torc.db
+export TORC_SERVER_SNAPSHOT_KEEP=10
+torc-server run -d ":memory:" -p 8080
+```
+
+Pick a snapshot path on **fast local storage** (e.g. `/tmp`, `/scratch`) — writing snapshots to the
+same slow shared filesystem that motivated in-memory mode in the first place defeats the purpose.
+
+### Standalone Mode (`torc --standalone --in-memory`)
+
+For ad-hoc workflows on HPC compute / login nodes, the easier entry point is the standalone client
+flag — you do not need to manage `torc-server` directly. Both `exec` (inline commands) and `run`
+(workflow spec files) support `--in-memory`:
+
+```bash
+# Inline commands
+torc -s --in-memory exec -C commands.txt -j 8
+
+# Workflow specification file
+torc -s --in-memory run workflow.yaml
+```
+
+This launches an ephemeral in-memory `torc-server`, runs the workflow against it, and snapshots the
+final database to `./torc_output/torc.db` (or wherever `--db` points) right before shutdown. After
+the command returns, the workflow is queryable like any other:
+
+```bash
+torc -s results list
+torc -s workflows list
+torc tui --standalone
+```
+
+`--in-memory` is restricted to `exec` and `run` — commands that _create_ workflow state in the same
+invocation. It is rejected for read-only commands like `results list` or `workflows list` because
+those would snapshot an empty database over your existing `torc_output/torc.db` and destroy prior
+data.
+
+Add `--snapshot-interval-seconds <N>` to also snapshot periodically while the workflow is running.
+Each snapshot briefly serializes against writes (milliseconds for small DBs, seconds for very large
+ones), so prefer larger values — `600` (10 minutes) is a sensible default for high-throughput
+workloads:
+
+```bash
+torc -s --in-memory --snapshot-interval-seconds 600 run workflow.yaml
+```
+
+If the parent process is killed unexpectedly, only state since the last snapshot is lost. Users who
+need stronger durability should not opt into `--in-memory` in the first place.
+
+### Restarting from a Snapshot
+
+A snapshot file is a normal SQLite database. To resume from one, copy it into place and start the
+server pointing at it:
+
+```bash
+cp /scratch/$USER/torc-snapshots/torc.db /tmp/torc-resume.db
+torc-server run -d /tmp/torc-resume.db -p 8080
+```
+
+If you want to keep running in memory but seed from a prior snapshot, that's not currently supported
+— the in-memory database always starts empty.
+
+### When to Use This
+
+Good fits:
+
+- **HPC login/compute nodes** with slow or unreliable shared filesystems
+- **Short-lived workflow runs** where you can afford to take a snapshot at the end
+- **Performance-sensitive scenarios** where you want to eliminate disk I/O from the hot path
+
+Poor fits:
+
+- Long-running production servers (use a regular on-disk database with backups)
+- Multi-day workflows where losing recent state on process death would be costly
+- Deployments without operator access to send signals (signals are local-only; there is no remote
+  snapshot endpoint)
+
+### Operational Notes
+
+- **Snapshots are signal-driven, not automatic.** Schedule them via cron, a sidecar, or
+  workflow-completion hooks if you want periodic captures.
+- **The snapshot completes on the server's signal-handler task**, so it does not block HTTP request
+  handlers. A snapshot of a small database typically completes in milliseconds; large databases
+  scale linearly with size.
+- **`SIGUSR1` is Unix-only.** This feature is not available on Windows.
+- **Process death loses unsaved data.** Always snapshot before stopping the server if you care about
+  the current state. `SIGTERM`/`SIGINT` (graceful shutdown) does **not** automatically snapshot.
 
 ## Complete Example: Production Deployment
 

--- a/slurm-tests/run_all.sh
+++ b/slurm-tests/run_all.sh
@@ -158,6 +158,7 @@ ALL_WORKFLOW_NAMES=(
   timeout_detection
   srun_termination_signal
   sync_status
+  in_memory_exec
 )
 
 WORKFLOW_NAMES=()

--- a/slurm-tests/scripts/in_memory_exec.sh
+++ b/slurm-tests/scripts/in_memory_exec.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# in_memory_exec.sh — Drive `torc -s --in-memory exec` on a Slurm compute node.
+#
+# Exercises the in-memory standalone database with periodic snapshots
+# (the example from docs/src/core/how-to/run-inline-commands.md). Verifies
+# that the snapshotted on-disk torc.db contains every subjob in the
+# completed state after the standalone server exits.
+
+set -Eeuo pipefail
+
+JOB_COUNT="${IN_MEMORY_JOB_COUNT:-12}"
+PARALLELISM="${IN_MEMORY_PARALLELISM:-4}"
+SNAPSHOT_INTERVAL="${IN_MEMORY_SNAPSHOT_INTERVAL:-5}"
+PER_JOB_SLEEP="${IN_MEMORY_PER_JOB_SLEEP:-3}"
+
+WORKDIR="${SLURM_SUBMIT_DIR:-$PWD}/in_memory_exec_run_${SLURM_JOB_ID:-local}"
+rm -rf "$WORKDIR"
+mkdir -p "$WORKDIR"
+cd "$WORKDIR"
+
+echo "in_memory_exec: host=$(hostname) workdir=$WORKDIR"
+echo "  jobs=$JOB_COUNT parallelism=$PARALLELISM snapshot-interval=${SNAPSHOT_INTERVAL}s sleep=${PER_JOB_SLEEP}s"
+
+if ! command -v torc >/dev/null 2>&1; then
+  echo "ERROR: torc not on PATH on $(hostname)" >&2
+  exit 1
+fi
+
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  echo "ERROR: sqlite3 not on PATH on $(hostname)" >&2
+  exit 1
+fi
+
+COMMANDS_FILE="$WORKDIR/commands.txt"
+: > "$COMMANDS_FILE"
+for i in $(seq 1 "$JOB_COUNT"); do
+  # shellcheck disable=SC2016  # $(hostname) is intentionally evaluated when the subjob runs.
+  printf 'bash -c "echo subjob %d on \\$(hostname); sleep %d"\n' \
+    "$i" "$PER_JOB_SLEEP" >> "$COMMANDS_FILE"
+done
+echo "Wrote $JOB_COUNT commands to $COMMANDS_FILE"
+
+# Run from a clean output dir so the standalone server's torc.db lives here.
+OUTPUT_DIR="$WORKDIR/torc_output"
+rm -rf "$OUTPUT_DIR"
+
+set +e
+torc -s --in-memory --snapshot-interval-seconds "$SNAPSHOT_INTERVAL" \
+  exec \
+  -n in_memory_exec_smoke \
+  --description "Slurm in-memory exec smoke test" \
+  -C "$COMMANDS_FILE" \
+  -j "$PARALLELISM" \
+  -o "$OUTPUT_DIR"
+exec_rc=$?
+set -e
+
+echo "torc exec exit code: $exec_rc"
+if [ "$exec_rc" -ne 0 ]; then
+  echo "ERROR: torc -s --in-memory exec failed" >&2
+  exit "$exec_rc"
+fi
+
+DB_PATH="$OUTPUT_DIR/torc.db"
+if [ ! -f "$DB_PATH" ]; then
+  echo "ERROR: expected snapshotted DB at $DB_PATH was not created" >&2
+  exit 1
+fi
+echo "Snapshotted DB exists: $DB_PATH ($(stat -c%s "$DB_PATH" 2>/dev/null \
+  || stat -f%z "$DB_PATH") bytes)"
+
+# Validate every subjob completed (status=5) in the on-disk DB.
+total=$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM job;")
+completed=$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM job WHERE status = 5;")
+echo "DB job counts: total=$total completed=$completed"
+
+if [ "$total" -ne "$JOB_COUNT" ]; then
+  echo "ERROR: expected $JOB_COUNT jobs in DB, found $total" >&2
+  exit 1
+fi
+
+if [ "$completed" -ne "$JOB_COUNT" ]; then
+  echo "ERROR: expected all $JOB_COUNT jobs completed, found $completed" >&2
+  sqlite3 "$DB_PATH" "SELECT id, name, status FROM job;" >&2 || true
+  exit 1
+fi
+
+echo "in_memory_exec: all $JOB_COUNT subjobs completed successfully"

--- a/slurm-tests/tests/test_in_memory_exec.sh
+++ b/slurm-tests/tests/test_in_memory_exec.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# shellcheck disable=SC2034  # CURRENT_TEST, CURRENT_WF_ID used by sourced test_framework.sh
+# Test: in_memory_exec
+#
+# Verifies:
+#   - Parent (centralized) workflow with the single driver job completes
+#   - The driver job exits 0 (it self-validates the standalone in-memory DB)
+#   - Driver stdout reports the all-subjobs-completed sentinel, confirming
+#     the snapshotted torc.db on the compute node had every subjob in
+#     status=completed.
+
+run_test_in_memory_exec() {
+    local wf_id="$1"
+    CURRENT_TEST="in_memory_exec"
+    CURRENT_WF_ID="$wf_id"
+    echo ""
+    echo "── Test: in_memory_exec (workflow $wf_id) ──"
+
+    assert_workflow_complete "$wf_id"
+    assert_all_jobs_completed "$wf_id" 1
+    assert_return_code "$wf_id" "in_memory_exec" "0"
+
+    local job_id stdout
+    job_id=$(get_job_id "$wf_id" "in_memory_exec")
+    stdout=$(get_job_stdout "$wf_id" "$job_id")
+    assert_contains "$stdout" "all" "driver script reported all subjobs completed"
+    assert_contains "$stdout" "subjobs completed successfully" \
+        "driver script printed completion sentinel"
+    assert_contains "$stdout" "Snapshotted DB exists" \
+        "driver script confirmed on-disk snapshot was created"
+}

--- a/slurm-tests/workflows/dogfood_parent.yaml
+++ b/slurm-tests/workflows/dogfood_parent.yaml
@@ -90,3 +90,9 @@ jobs:
     command: >-
       bash slurm-tests/scripts/run_child_test.sh
       sync_status PLACEHOLDER_ACCOUNT PLACEHOLDER_PARTITION
+
+  - name: in_memory_exec
+    resource_requirements: parent_resources
+    command: >-
+      bash slurm-tests/scripts/run_child_test.sh
+      in_memory_exec PLACEHOLDER_ACCOUNT PLACEHOLDER_PARTITION

--- a/slurm-tests/workflows/in_memory_exec.yaml
+++ b/slurm-tests/workflows/in_memory_exec.yaml
@@ -1,0 +1,41 @@
+# Test: In-Memory Exec
+#
+# Single allocation, single job that runs `torc -s --in-memory exec` with a
+# small `--snapshot-interval-seconds` so periodic snapshots fire during the
+# inner run. The driver script (scripts/in_memory_exec.sh) builds a
+# commands.txt file, invokes the standalone in-memory server on the compute
+# node, and asserts that the resulting on-disk torc.db contains every
+# subjob in the completed state. Mirrors the example in
+# docs/src/core/how-to/run-inline-commands.md.
+
+name: in_memory_exec
+description: Smoke test for `torc -s --in-memory exec` with periodic snapshots on a Slurm node
+project: slurm-tests
+execution_config:
+  mode: direct
+
+resource_requirements:
+  - name: in_memory_resources
+    num_cpus: 4
+    num_nodes: 1
+    memory: 2g
+    runtime: PT5M
+
+jobs:
+  - name: in_memory_exec
+    command: bash slurm-tests/scripts/in_memory_exec.sh
+    resource_requirements: in_memory_resources
+
+slurm_schedulers:
+  - name: in_memory_scheduler
+    account: PLACEHOLDER_ACCOUNT
+    partition: PLACEHOLDER_PARTITION
+    nodes: 1
+    walltime: "00:10:00"
+
+actions:
+  - trigger_type: "on_workflow_start"
+    action_type: "schedule_nodes"
+    scheduler: "in_memory_scheduler"
+    scheduler_type: "slurm"
+    num_allocations: 1

--- a/src/bin/torc-server.rs
+++ b/src/bin/torc-server.rs
@@ -415,23 +415,26 @@ fn run_server(cli_config: ServerConfig) -> Result<()> {
         env::var("DATABASE_URL").expect("DATABASE_URL must be set or --database must be provided")
     };
 
-    // Detect `:memory:` from the *pre-rewrite* URL via exact match. Substring
-    // matching on the post-rewrite URL would false-positive on on-disk paths
-    // that happen to contain `:memory:` (colons are legal in Unix filenames).
-    // Two forms to accept:
+    // Detect supported SQLite in-memory URLs:
     //  - `sqlite::memory:` is what our own `-d :memory:` produces via the
     //    `format!("sqlite:{}", ...)` above, and is also the canonical sqlx
     //    URL form for in-memory.
     //  - `:memory:` is the bare SQLite spelling, which users naturally type
     //    when setting `DATABASE_URL` directly.
-    let in_memory = matches!(database_url.as_str(), ":memory:" | "sqlite::memory:");
-
+    //  - Any URL containing `file::memory:` is the shared-cache in-memory
+    //    SQLite URI form. We rewrite bare `:memory:` to one of these below,
+    //    but a power user can also supply it directly (e.g.
+    //    `sqlite:file::memory:?cache=shared`); without this branch they'd
+    //    miss `min_connections(1)` and the pool could drop the only
+    //    connection and destroy their data between requests.
     // A bare `:memory:` URI gives each pool connection its own private database,
     // which silently breaks data sharing across connections and prevents
-    // VACUUM INTO snapshots from observing any data. Rewrite to shared-cache
-    // memory mode so all pool connections see the same database. Snapshots
-    // (SIGUSR1) are how results are persisted in this mode.
-    let database_url = if in_memory {
+    // VACUUM INTO snapshots from observing any data. Only the bare forms get
+    // rewritten — a user who supplied an explicit shared-cache URI should
+    // have it preserved verbatim.
+    let needs_rewrite = matches!(database_url.as_str(), ":memory:" | "sqlite::memory:");
+    let in_memory = needs_rewrite || database_url.contains("file::memory:");
+    let database_url = if needs_rewrite {
         info!(
             "Using shared-cache in-memory database. Send SIGUSR1 to the server \
              to snapshot the database to disk. Configure with \

--- a/src/bin/torc-server.rs
+++ b/src/bin/torc-server.rs
@@ -440,15 +440,23 @@ fn run_server(cli_config: ServerConfig) -> Result<()> {
         .build()?;
 
     runtime.block_on(async {
-        // Configure SQLite connection with WAL journal mode for better concurrency
-        // and foreign key constraints enabled
+        // Configure SQLite connection. On-disk databases use WAL for
+        // concurrency; in-memory databases use Memory journal mode (WAL is
+        // silently ignored for `:memory:` and would mislead operators
+        // reading the startup log).
+        let journal_mode = if in_memory {
+            SqliteJournalMode::Memory
+        } else {
+            SqliteJournalMode::Wal
+        };
         let connect_options = SqliteConnectOptions::from_str(&database_url)?
-            .journal_mode(SqliteJournalMode::Wal)
+            .journal_mode(journal_mode)
             .foreign_keys(true)
             .create_if_missing(true)
             .busy_timeout(std::time::Duration::from_secs(45))
             // NORMAL synchronous is safe with WAL and avoids fsync on every commit,
-            // reducing latency for concurrent claim/complete operations
+            // reducing latency for concurrent claim/complete operations.
+            // For in-memory mode this pragma is harmless (no fsync to elide).
             .pragma("synchronous", "NORMAL")
             // 16MB page cache (default is 2MB)
             .pragma("cache_size", "-16000");
@@ -473,7 +481,10 @@ fn run_server(cli_config: ServerConfig) -> Result<()> {
             version, git_hash
         );
         info!("Connected to database: {}", database_url);
-        info!("Database configured with WAL journal mode and foreign key constraints");
+        info!(
+            "Database configured with {} journal mode and foreign key constraints",
+            if in_memory { "Memory" } else { "WAL" }
+        );
 
         // Run embedded migrations
         info!("Running database migrations...");

--- a/src/bin/torc-server.rs
+++ b/src/bin/torc-server.rs
@@ -415,12 +415,22 @@ fn run_server(cli_config: ServerConfig) -> Result<()> {
         env::var("DATABASE_URL").expect("DATABASE_URL must be set or --database must be provided")
     };
 
+    // Detect `:memory:` from the *pre-rewrite* URL via exact match. Substring
+    // matching on the post-rewrite URL would false-positive on on-disk paths
+    // that happen to contain `:memory:` (colons are legal in Unix filenames).
+    // Accept the bare form (`:memory:`) too, since that is what users naturally
+    // type when setting `DATABASE_URL` directly.
+    let in_memory = matches!(
+        database_url.as_str(),
+        ":memory:" | "sqlite::memory:" | "sqlite::memory"
+    );
+
     // A bare `:memory:` URI gives each pool connection its own private database,
     // which silently breaks data sharing across connections and prevents
     // VACUUM INTO snapshots from observing any data. Rewrite to shared-cache
     // memory mode so all pool connections see the same database. Snapshots
     // (SIGUSR1) are how results are persisted in this mode.
-    let database_url = if database_url == "sqlite::memory:" || database_url == "sqlite::memory" {
+    let database_url = if in_memory {
         info!(
             "Using shared-cache in-memory database. Send SIGUSR1 to the server \
              to snapshot the database to disk. Configure with \
@@ -431,7 +441,6 @@ fn run_server(cli_config: ServerConfig) -> Result<()> {
     } else {
         database_url
     };
-    let in_memory = database_url.contains(":memory:");
 
     // Build Tokio runtime with user-specified thread count
     let runtime = tokio::runtime::Builder::new_multi_thread()

--- a/src/bin/torc-server.rs
+++ b/src/bin/torc-server.rs
@@ -418,12 +418,13 @@ fn run_server(cli_config: ServerConfig) -> Result<()> {
     // Detect `:memory:` from the *pre-rewrite* URL via exact match. Substring
     // matching on the post-rewrite URL would false-positive on on-disk paths
     // that happen to contain `:memory:` (colons are legal in Unix filenames).
-    // Accept the bare form (`:memory:`) too, since that is what users naturally
-    // type when setting `DATABASE_URL` directly.
-    let in_memory = matches!(
-        database_url.as_str(),
-        ":memory:" | "sqlite::memory:" | "sqlite::memory"
-    );
+    // Two forms to accept:
+    //  - `sqlite::memory:` is what our own `-d :memory:` produces via the
+    //    `format!("sqlite:{}", ...)` above, and is also the canonical sqlx
+    //    URL form for in-memory.
+    //  - `:memory:` is the bare SQLite spelling, which users naturally type
+    //    when setting `DATABASE_URL` directly.
+    let in_memory = matches!(database_url.as_str(), ":memory:" | "sqlite::memory:");
 
     // A bare `:memory:` URI gives each pool connection its own private database,
     // which silently breaks data sharing across connections and prevents

--- a/src/bin/torc-server.rs
+++ b/src/bin/torc-server.rs
@@ -415,6 +415,24 @@ fn run_server(cli_config: ServerConfig) -> Result<()> {
         env::var("DATABASE_URL").expect("DATABASE_URL must be set or --database must be provided")
     };
 
+    // A bare `:memory:` URI gives each pool connection its own private database,
+    // which silently breaks data sharing across connections and prevents
+    // VACUUM INTO snapshots from observing any data. Rewrite to shared-cache
+    // memory mode so all pool connections see the same database. Snapshots
+    // (SIGUSR1) are how results are persisted in this mode.
+    let database_url = if database_url == "sqlite::memory:" || database_url == "sqlite::memory" {
+        info!(
+            "Using shared-cache in-memory database. Send SIGUSR1 to the server \
+             to snapshot the database to disk. Configure with \
+             TORC_SERVER_SNAPSHOT_PATH (default ./torc-server-snapshot.db) and \
+             TORC_SERVER_SNAPSHOT_KEEP (default 5)."
+        );
+        "sqlite:file::memory:?cache=shared".to_string()
+    } else {
+        database_url
+    };
+    let in_memory = database_url.contains(":memory:");
+
     // Build Tokio runtime with user-specified thread count
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(config.threads as usize)
@@ -440,10 +458,13 @@ fn run_server(cli_config: ServerConfig) -> Result<()> {
         // - The background unblock task (1 connection)
         // - Concurrent read queries while write transactions hold connections
         let max_connections = config.threads.max(2) + 2;
-        let pool = SqlitePoolOptions::new()
-            .max_connections(max_connections)
-            .connect_with(connect_options)
-            .await?;
+        let mut pool_options = SqlitePoolOptions::new().max_connections(max_connections);
+        if in_memory {
+            // Shared-cache in-memory databases are destroyed when the last
+            // connection closes, so keep at least one connection alive.
+            pool_options = pool_options.min_connections(1);
+        }
+        let pool = pool_options.connect_with(connect_options).await?;
 
         let version = env!("CARGO_PKG_VERSION");
         let git_hash = env!("GIT_HASH");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -129,8 +129,28 @@ pub struct Cli {
     #[arg(short = 's', long)]
     pub standalone: bool,
     /// SQLite database path for standalone mode. Defaults to `./torc_output/torc.db`.
+    ///
+    /// With `--in-memory`, this becomes the *snapshot* destination for the
+    /// in-memory database rather than the live database file.
     #[arg(long, value_name = "PATH")]
     pub db: Option<PathBuf>,
+    /// Run the standalone server with an in-memory SQLite database (Unix only).
+    ///
+    /// The database lives in RAM for the lifetime of the command and is
+    /// snapshotted to `--db` (default `./torc_output/torc.db`) right before
+    /// shutdown, so the workflow remains queryable afterwards. Useful on HPC
+    /// compute / login nodes where shared filesystems (Lustre, GPFS, NFS) are
+    /// intermittently slow. Trade-off: if the parent process is killed
+    /// unexpectedly, any state since the last snapshot is lost.
+    #[arg(long, requires = "standalone")]
+    pub in_memory: bool,
+    /// Periodically snapshot the in-memory database while the command runs.
+    ///
+    /// Only meaningful with `--in-memory`. The snapshot briefly serializes
+    /// against writes (milliseconds for small DBs, seconds for very large
+    /// ones), so prefer larger intervals for high-throughput scenarios.
+    #[arg(long, value_name = "SECONDS", requires = "in_memory")]
+    pub snapshot_interval_seconds: Option<u64>,
     /// Path to the torc-server binary used in standalone mode.
     #[arg(
         long,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -149,7 +149,12 @@ pub struct Cli {
     /// Only meaningful with `--in-memory`. The snapshot briefly serializes
     /// against writes (milliseconds for small DBs, seconds for very large
     /// ones), so prefer larger intervals for high-throughput scenarios.
-    #[arg(long, value_name = "SECONDS", requires = "in_memory")]
+    #[arg(
+        long,
+        value_name = "SECONDS",
+        requires = "in_memory",
+        value_parser = clap::value_parser!(u64).range(1..)
+    )]
     pub snapshot_interval_seconds: Option<u64>,
     /// Path to the torc-server binary used in standalone mode.
     #[arg(

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,8 +156,12 @@ impl Drop for StandaloneServer {
                         // reasonable in-memory database.
                         match rx.recv_timeout(Duration::from_secs(5)) {
                             Ok(()) => {}
-                            Err(_) => eprintln!(
+                            Err(mpsc::RecvTimeoutError::Timeout) => eprintln!(
                                 "warning: timed out waiting for final snapshot to {}",
+                                self.db_path.display()
+                            ),
+                            Err(mpsc::RecvTimeoutError::Disconnected) => eprintln!(
+                                "warning: server exited before confirming final snapshot to {}",
                                 self.db_path.display()
                             ),
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,6 +94,7 @@ struct StandaloneServer {
     /// and unlocks the SIGUSR1 path.
     in_memory: bool,
     /// Receiver for `TORC_SNAPSHOT_DONE=<path>` lines from the child's stdout.
+    /// Bounded (capacity 1) so periodic-snapshot notifications can't pile up.
     /// `None` outside in-memory mode.
     snapshot_done_rx: Option<mpsc::Receiver<()>>,
     /// Sender that, when dropped, signals the periodic-snapshot thread to
@@ -140,6 +141,13 @@ impl Drop for StandaloneServer {
         // This is what makes the user-facing contract "when the command
         // returns, the workflow is queryable from --db" hold.
         if self.in_memory {
+            // Drain any pending notifications from periodic snapshots before
+            // requesting the final one — otherwise `recv_timeout` below could
+            // return immediately on a stale notification and proceed to
+            // shutdown before the *final* snapshot has actually completed.
+            if let Some(rx) = &self.snapshot_done_rx {
+                while rx.try_recv().is_ok() {}
+            }
             match self.send_sigusr1() {
                 Ok(()) => {
                     if let Some(rx) = &self.snapshot_done_rx {
@@ -322,8 +330,14 @@ fn start_standalone_server(opts: StandaloneOptions) -> Result<StandaloneServer, 
     // lines onto `snapshot_done_tx` so the parent can synchronize on snapshot
     // completion (final snapshot during Drop, or for tests).
     let (tx, rx) = mpsc::channel::<Result<String, std::io::Error>>();
+    // Bounded `sync_channel(1)` plus `try_send` gives drop-on-full semantics:
+    // if the parent hasn't yet consumed the previous snapshot notification (it
+    // only does so during Drop), additional notifications from periodic
+    // snapshots are silently dropped rather than accumulating unboundedly.
+    // The parent drains the channel before requesting the final snapshot, so
+    // it never waits on a stale notification.
     let (snapshot_done_tx, snapshot_done_rx) = if opts.in_memory {
-        let (s, r) = mpsc::channel::<()>();
+        let (s, r) = mpsc::sync_channel::<()>(1);
         (Some(s), Some(r))
     } else {
         (None, None)
@@ -336,7 +350,7 @@ fn start_standalone_server(opts: StandaloneOptions) -> Result<StandaloneServer, 
                 Ok(line) => {
                     if line.trim().starts_with("TORC_SNAPSHOT_DONE=") {
                         if let Some(s) = &snapshot_done_tx {
-                            let _ = s.send(());
+                            let _ = s.try_send(());
                         }
                         // Don't forward to stderr — internal sync line.
                         continue;

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,10 +90,75 @@ struct StandaloneServer {
     // path. Stored as Option so `Drop::drop` can move it out and close it
     // before waiting.
     stdin: Option<std::process::ChildStdin>,
+    /// True when launched with `--in-memory`. Drives final-snapshot behavior
+    /// and unlocks the SIGUSR1 path.
+    in_memory: bool,
+    /// Receiver for `TORC_SNAPSHOT_DONE=<path>` lines from the child's stdout.
+    /// `None` outside in-memory mode.
+    snapshot_done_rx: Option<mpsc::Receiver<()>>,
+    /// Sender that, when dropped, signals the periodic-snapshot thread to
+    /// stop. `None` if no periodic thread was spawned.
+    periodic_stop_tx: Option<mpsc::Sender<()>>,
+    /// Join handle for the periodic-snapshot thread, taken in `Drop`.
+    periodic_handle: Option<thread::JoinHandle<()>>,
+}
+
+impl StandaloneServer {
+    /// Send `SIGUSR1` to the child process to trigger a snapshot.
+    /// No-op on non-Unix; relies on the child being addressable by its PID.
+    #[cfg(unix)]
+    fn send_sigusr1(&self) -> std::io::Result<()> {
+        let pid = self.child.id() as libc::pid_t;
+        let rc = unsafe { libc::kill(pid, libc::SIGUSR1) };
+        if rc == 0 {
+            Ok(())
+        } else {
+            Err(std::io::Error::last_os_error())
+        }
+    }
+
+    #[cfg(not(unix))]
+    fn send_sigusr1(&self) -> std::io::Result<()> {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "SIGUSR1 snapshots are only supported on Unix",
+        ))
+    }
 }
 
 impl Drop for StandaloneServer {
     fn drop(&mut self) {
+        // Stop the periodic-snapshot thread first so we don't race a tick
+        // against the final snapshot.
+        drop(self.periodic_stop_tx.take());
+        if let Some(h) = self.periodic_handle.take() {
+            let _ = h.join();
+        }
+
+        // For --in-memory mode, request a final snapshot and wait for the
+        // server to confirm it landed on disk before we shut things down.
+        // This is what makes the user-facing contract "when the command
+        // returns, the workflow is queryable from --db" hold.
+        if self.in_memory {
+            match self.send_sigusr1() {
+                Ok(()) => {
+                    if let Some(rx) = &self.snapshot_done_rx {
+                        // Cap the wait so a stuck server can't hang shutdown
+                        // indefinitely. Five seconds is enough for any
+                        // reasonable in-memory database.
+                        match rx.recv_timeout(Duration::from_secs(5)) {
+                            Ok(()) => {}
+                            Err(_) => eprintln!(
+                                "warning: timed out waiting for final snapshot to {}",
+                                self.db_path.display()
+                            ),
+                        }
+                    }
+                }
+                Err(e) => eprintln!("warning: failed to request final snapshot: {}", e),
+            }
+        }
+
         // Close our end of the child's stdin pipe. The server is running with
         // `--shutdown-on-stdin-eof`, so this alone should cause it to drain
         // connections and exit on its own — a hard kill risks interrupting an
@@ -123,14 +188,54 @@ impl Drop for StandaloneServer {
     }
 }
 
+/// Send `SIGUSR1` every `interval` until the stop channel is closed.
+/// Used by `--snapshot-interval-seconds` to drive periodic snapshots from the
+/// parent without touching the server-side scheduler.
+#[cfg(unix)]
+fn periodic_snapshot_loop(pid: u32, interval: Duration, stop: mpsc::Receiver<()>) {
+    loop {
+        match stop.recv_timeout(interval) {
+            Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => return,
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                let rc = unsafe { libc::kill(pid as libc::pid_t, libc::SIGUSR1) };
+                if rc != 0 {
+                    eprintln!(
+                        "warning: periodic snapshot SIGUSR1 failed: {}",
+                        std::io::Error::last_os_error()
+                    );
+                    return;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn periodic_snapshot_loop(_pid: u32, _interval: Duration, _stop: mpsc::Receiver<()>) {}
+
+/// Options for the standalone server spawn.
+struct StandaloneOptions {
+    server_bin: String,
+    /// On-disk path. In normal mode this is the live database; in `--in-memory`
+    /// mode this is the snapshot destination.
+    db: Option<std::path::PathBuf>,
+    in_memory: bool,
+    /// When `Some(secs)`, parent-side timer that sends SIGUSR1 every `secs`.
+    /// Only honored when `in_memory` is true.
+    snapshot_interval_seconds: Option<u64>,
+}
+
 /// Spawn a torc-server subprocess bound to 127.0.0.1 on an auto-assigned port,
 /// backed by the given SQLite database (default: `./torc_output/torc.db`).
 /// Waits up to 15 seconds for the server to print its `TORC_SERVER_PORT=<port>` line.
-fn start_standalone_server(
-    server_bin: &str,
-    db: Option<std::path::PathBuf>,
-) -> Result<StandaloneServer, String> {
-    let db_path = db.unwrap_or_else(|| std::path::PathBuf::from("torc_output/torc.db"));
+fn start_standalone_server(opts: StandaloneOptions) -> Result<StandaloneServer, String> {
+    if opts.in_memory && !cfg!(unix) {
+        return Err("--in-memory is only supported on Unix systems".to_string());
+    }
+
+    let db_path = opts
+        .db
+        .unwrap_or_else(|| std::path::PathBuf::from("torc_output/torc.db"));
     if let Some(parent) = db_path.parent()
         && !parent.as_os_str().is_empty()
     {
@@ -143,7 +248,18 @@ fn start_standalone_server(
         })?;
     }
 
-    let mut child = std::process::Command::new(server_bin)
+    // In --in-memory mode the server's `--database` argument becomes literal
+    // `:memory:` and the on-disk path is wired through as the snapshot
+    // destination via env. Default to `KEEP=1` so users see one canonical
+    // file at the path they expect, not rotated `.1`/`.2` siblings.
+    let database_arg = if opts.in_memory {
+        ":memory:".to_string()
+    } else {
+        db_path.display().to_string()
+    };
+
+    let mut command = std::process::Command::new(&opts.server_bin);
+    command
         .args([
             "run",
             "--host",
@@ -151,19 +267,28 @@ fn start_standalone_server(
             "--port",
             "0",
             "--database",
-            &db_path.display().to_string(),
+            &database_arg,
             "--shutdown-on-stdin-eof",
         ])
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .spawn()
-        .map_err(|e| {
-            format!(
-                "failed to spawn '{}': {}. Set --torc-server-bin or TORC_SERVER_BIN.",
-                server_bin, e
-            )
-        })?;
+        .stderr(std::process::Stdio::piped());
+
+    if opts.in_memory {
+        command.env("TORC_SERVER_SNAPSHOT_PATH", &db_path);
+        // Only set KEEP=1 if the user hasn't already overridden it, so power
+        // users can opt into rotation by exporting the env var themselves.
+        if std::env::var_os("TORC_SERVER_SNAPSHOT_KEEP").is_none() {
+            command.env("TORC_SERVER_SNAPSHOT_KEEP", "1");
+        }
+    }
+
+    let mut child = command.spawn().map_err(|e| {
+        format!(
+            "failed to spawn '{}': {}. Set --torc-server-bin or TORC_SERVER_BIN.",
+            opts.server_bin, e
+        )
+    })?;
 
     let child_stdin = child
         .stdin
@@ -192,13 +317,30 @@ fn start_standalone_server(
     // forwarded over `tx` so we can enforce a timeout on the startup handshake.
     // After the receiver is dropped (port found), the thread keeps draining stdout
     // for the lifetime of the child so the pipe buffer can't fill and block it.
+    //
+    // For --in-memory mode we additionally route `TORC_SNAPSHOT_DONE=<path>`
+    // lines onto `snapshot_done_tx` so the parent can synchronize on snapshot
+    // completion (final snapshot during Drop, or for tests).
     let (tx, rx) = mpsc::channel::<Result<String, std::io::Error>>();
+    let (snapshot_done_tx, snapshot_done_rx) = if opts.in_memory {
+        let (s, r) = mpsc::channel::<()>();
+        (Some(s), Some(r))
+    } else {
+        (None, None)
+    };
     thread::spawn(move || {
         let reader = BufReader::new(stdout);
         let mut tx = Some(tx);
         for line in reader.lines() {
             match line {
                 Ok(line) => {
+                    if line.trim().starts_with("TORC_SNAPSHOT_DONE=") {
+                        if let Some(s) = &snapshot_done_tx {
+                            let _ = s.send(());
+                        }
+                        // Don't forward to stderr — internal sync line.
+                        continue;
+                    }
                     if let Some(sender) = tx.as_ref() {
                         if sender.send(Ok(line.clone())).is_ok() {
                             continue;
@@ -238,11 +380,33 @@ fn start_standalone_server(
                     // systems where `localhost` resolves to `::1` first but the server
                     // is only bound to v4, connections would fail.
                     let api_url = format!("http://127.0.0.1:{}/torc-service/v1", port);
+                    let pid = child.id();
+
+                    // Spawn the periodic-snapshot thread if requested. Park it
+                    // on a stop channel with timeout so Drop can stop it
+                    // before the final synchronous snapshot.
+                    let (periodic_stop_tx, periodic_handle) = if opts.in_memory
+                        && let Some(secs) = opts.snapshot_interval_seconds
+                        && secs > 0
+                    {
+                        let (stop_tx, stop_rx) = mpsc::channel::<()>();
+                        let interval = Duration::from_secs(secs);
+                        let h =
+                            thread::spawn(move || periodic_snapshot_loop(pid, interval, stop_rx));
+                        (Some(stop_tx), Some(h))
+                    } else {
+                        (None, None)
+                    };
+
                     return Ok(StandaloneServer {
                         child,
                         api_url,
                         db_path,
                         stdin: Some(child_stdin),
+                        in_memory: opts.in_memory,
+                        snapshot_done_rx,
+                        periodic_stop_tx,
+                        periodic_handle,
                     });
                 }
                 // Other lines are passed through to stderr so users see startup logs.
@@ -383,6 +547,18 @@ fn main() {
             | Commands::Exec { dry_run: true, .. }
     );
 
+    // --in-memory snapshots the empty DB over the on-disk path on exit, which
+    // would destroy prior data for any command that doesn't create workflow
+    // state in the same invocation (e.g. `results list`, `workflows list`).
+    // Restrict it to commands that produce the data they're snapshotting.
+    if cli.in_memory && !matches!(cli.command, Commands::Exec { .. } | Commands::Run { .. }) {
+        eprintln!(
+            "Error: --in-memory is only supported with `exec` and `run`. \
+             Other commands would snapshot an empty database over your existing data."
+        );
+        std::process::exit(1);
+    }
+
     // Spawn an ephemeral torc-server when --standalone is set. The guard's Drop
     // terminates the subprocess on normal exit of this function.
     let _standalone_server = if cli.standalone {
@@ -390,7 +566,12 @@ fn main() {
             eprintln!("--standalone has no effect for this command; ignoring.");
             None
         } else {
-            match start_standalone_server(&cli.torc_server_bin, cli.db.clone()) {
+            match start_standalone_server(StandaloneOptions {
+                server_bin: cli.torc_server_bin.clone(),
+                db: cli.db.clone(),
+                in_memory: cli.in_memory,
+                snapshot_interval_seconds: cli.snapshot_interval_seconds,
+            }) {
                 Ok(server) => {
                     url = server.api_url.clone();
                     config.base_path = url.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -405,7 +405,6 @@ fn start_standalone_server(opts: StandaloneOptions) -> Result<StandaloneServer, 
                     // before the final synchronous snapshot.
                     let (periodic_stop_tx, periodic_handle) = if opts.in_memory
                         && let Some(secs) = opts.snapshot_interval_seconds
-                        && secs > 0
                     {
                         let (stop_tx, stop_rx) = mpsc::channel::<()>();
                         let interval = Duration::from_secs(secs);

--- a/src/server/http_server/bootstrap.rs
+++ b/src/server/http_server/bootstrap.rs
@@ -78,8 +78,11 @@ const DEFAULT_SNAPSHOT_KEEP: usize = 5;
 
 #[derive(Clone)]
 struct SnapshotConfig {
-    /// Absolute path to the canonical (newest) snapshot. Older snapshots are
-    /// kept alongside as `<base>.1`, `<base>.2`, … up to `keep - 1`.
+    /// Path to the canonical (newest) snapshot. If configured as relative,
+    /// `from_env()` resolves it against the startup CWD when possible; if
+    /// `current_dir()` itself fails (rare) it remains relative. Older
+    /// snapshots are kept alongside as `<base>.1`, `<base>.2`, … up to
+    /// `keep - 1`.
     base: std::path::PathBuf,
     /// Total snapshots to retain (canonical + rotated). Always >= 1.
     keep: usize,

--- a/src/server/http_server/bootstrap.rs
+++ b/src/server/http_server/bootstrap.rs
@@ -71,6 +71,158 @@ pub(super) async fn sync_admin_group(
     Ok(())
 }
 
+/// Default base path for snapshots when `TORC_SERVER_SNAPSHOT_PATH` is unset.
+const DEFAULT_SNAPSHOT_PATH: &str = "torc-server-snapshot.db";
+/// Default number of snapshots to keep when `TORC_SERVER_SNAPSHOT_KEEP` is unset.
+const DEFAULT_SNAPSHOT_KEEP: usize = 5;
+
+#[derive(Clone)]
+struct SnapshotConfig {
+    /// Absolute path to the canonical (newest) snapshot. Older snapshots are
+    /// kept alongside as `<base>.1`, `<base>.2`, … up to `keep - 1`.
+    base: std::path::PathBuf,
+    /// Total snapshots to retain (canonical + rotated). Always >= 1.
+    keep: usize,
+}
+
+impl SnapshotConfig {
+    fn from_env() -> Self {
+        let base_raw = std::env::var("TORC_SERVER_SNAPSHOT_PATH")
+            .unwrap_or_else(|_| DEFAULT_SNAPSHOT_PATH.to_string());
+        let base = std::path::PathBuf::from(&base_raw);
+        // Resolve relative paths once, at startup, against the launch CWD so
+        // the SQLite worker thread doesn't resolve them against something else.
+        let base = if base.is_absolute() {
+            base
+        } else {
+            std::env::current_dir()
+                .map(|c| c.join(&base))
+                .unwrap_or(base)
+        };
+
+        let keep = std::env::var("TORC_SERVER_SNAPSHOT_KEEP")
+            .ok()
+            .and_then(|s| s.parse::<usize>().ok())
+            .map(|n| n.max(1))
+            .unwrap_or(DEFAULT_SNAPSHOT_KEEP);
+
+        Self { base, keep }
+    }
+
+    fn tmp_path(&self) -> std::path::PathBuf {
+        let mut p = self.base.clone().into_os_string();
+        p.push(".tmp");
+        p.into()
+    }
+
+    /// Path for the `n`th rotated snapshot (n >= 1). `.1` is the
+    /// most recently rotated (i.e., the previous canonical).
+    fn rotated_path(&self, n: usize) -> std::path::PathBuf {
+        let mut p = self.base.clone().into_os_string();
+        p.push(format!(".{}", n));
+        p.into()
+    }
+}
+
+/// Listen for SIGUSR1 and snapshot the database via SQLite's `VACUUM INTO`.
+/// Works for both on-disk and `:memory:` databases and is the persistence
+/// mechanism for in-memory deployments (e.g. HPC login/compute nodes where
+/// Lustre is unreliable).
+///
+/// Snapshots are written to a `.tmp` sibling first and then atomically renamed
+/// into place, so a failed or interrupted snapshot never corrupts a prior one.
+/// Older snapshots are rotated to `<base>.1`, `<base>.2`, … so the canonical
+/// path always points at the newest snapshot.
+///
+/// Configured via env vars: `TORC_SERVER_SNAPSHOT_PATH` (default
+/// `./torc-server-snapshot.db`) and `TORC_SERVER_SNAPSHOT_KEEP` (default 5,
+/// minimum 1).
+#[cfg(unix)]
+async fn snapshot_on_sigusr1(pool: SqlitePool) {
+    use tokio::signal::unix::{SignalKind, signal};
+    let mut sig = match signal(SignalKind::user_defined1()) {
+        Ok(s) => s,
+        Err(e) => {
+            error!("Failed to install SIGUSR1 handler: {}", e);
+            return;
+        }
+    };
+    let cfg = SnapshotConfig::from_env();
+    info!(
+        "SIGUSR1 handler installed: send SIGUSR1 to snapshot the database to {} (keeping {} total)",
+        cfg.base.display(),
+        cfg.keep
+    );
+    while sig.recv().await.is_some() {
+        snapshot_once(&pool, &cfg).await;
+    }
+}
+
+#[cfg(unix)]
+async fn snapshot_once(pool: &SqlitePool, cfg: &SnapshotConfig) {
+    let tmp = cfg.tmp_path();
+    info!(
+        "Received SIGUSR1, snapshotting database to {}",
+        cfg.base.display()
+    );
+    let _ = tokio::fs::remove_file(&tmp).await;
+    // Inline the path (single-quote-escaped) since parameter binding for
+    // VACUUM INTO has been unreliable across SQLite versions.
+    let escaped = tmp.to_string_lossy().replace('\'', "''");
+    let sql = format!("VACUUM INTO '{}'", escaped);
+    if let Err(e) = sqlx::query(&sql).execute(pool).await {
+        error!("Failed to snapshot database: {}", e);
+        let _ = tokio::fs::remove_file(&tmp).await;
+        return;
+    }
+    if let Err(e) = rotate_and_promote(cfg, &tmp).await {
+        error!("Failed to rotate snapshots: {}", e);
+        let _ = tokio::fs::remove_file(&tmp).await;
+        return;
+    }
+    info!("Database snapshot written to {}", cfg.base.display());
+    // Emit a machine-readable line on stdout so a parent process (e.g. `torc
+    // --standalone --in-memory`) can synchronize on snapshot completion. This
+    // is a stable contract — do not change without updating the parent-side
+    // reader in `src/main.rs`. Flush explicitly because stdout is block-
+    // buffered when piped, and the parent is waiting on this exact line.
+    use std::io::Write;
+    println!("TORC_SNAPSHOT_DONE={}", cfg.base.display());
+    let _ = std::io::stdout().flush();
+}
+
+/// Rotate `<base>.{n-1}` → `<base>.{n}` for n down to 1, drop anything beyond
+/// `keep - 1`, then move the freshly-written `tmp` file into the canonical
+/// path. Each step is best-effort — a missing source is fine, since rotation
+/// runs on every snapshot but earlier slots may not exist yet.
+#[cfg(unix)]
+async fn rotate_and_promote(cfg: &SnapshotConfig, tmp: &std::path::Path) -> std::io::Result<()> {
+    if cfg.keep > 1 {
+        // Drop the oldest if it would push us over the limit. With `keep`
+        // total slots, we retain `.1 ..= .{keep - 1}` plus the canonical.
+        let oldest = cfg.rotated_path(cfg.keep - 1);
+        let _ = tokio::fs::remove_file(&oldest).await;
+        // Shift `.{n-1}` → `.{n}` from oldest to newest so we never clobber.
+        for n in (2..cfg.keep).rev() {
+            let from = cfg.rotated_path(n - 1);
+            let to = cfg.rotated_path(n);
+            match tokio::fs::rename(&from, &to).await {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => return Err(e),
+            }
+        }
+        // Demote the previous canonical to `.1`.
+        let demoted = cfg.rotated_path(1);
+        match tokio::fs::rename(&cfg.base, &demoted).await {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e),
+        }
+    }
+    tokio::fs::rename(tmp, &cfg.base).await
+}
+
 /// Build the shutdown future for the server. Resolves when any of the configured
 /// triggers fires: Ctrl+C, or (when `shutdown_on_stdin_eof` is true) EOF on stdin.
 /// The stdin-EOF trigger is used by `torc --standalone` to tie the server's
@@ -180,6 +332,14 @@ pub(super) async fn create_server(
         )
         .await;
     });
+
+    #[cfg(unix)]
+    {
+        let snapshot_pool = pool.clone();
+        tokio::spawn(async move {
+            snapshot_on_sigusr1(snapshot_pool).await;
+        });
+    }
 
     #[cfg(feature = "openapi-codegen")]
     let app = crate::server::live_router::app_router(LiveRouterState {

--- a/src/server/http_server/bootstrap.rs
+++ b/src/server/http_server/bootstrap.rs
@@ -140,16 +140,25 @@ impl SnapshotConfig {
 /// Configured via env vars: `TORC_SERVER_SNAPSHOT_PATH` (default
 /// `./torc-server-snapshot.db`) and `TORC_SERVER_SNAPSHOT_KEEP` (default 5,
 /// minimum 1).
+/// Replace the kernel-default SIGUSR1 disposition (which is "terminate the
+/// process") with a tokio-managed signal stream. Must be called *before* the
+/// server advertises readiness on stdout, so a parent that races between
+/// `TORC_SERVER_PORT=` and the snapshot loop can't accidentally kill the
+/// server with SIGUSR1.
 #[cfg(unix)]
-async fn snapshot_on_sigusr1(pool: SqlitePool) {
+fn register_sigusr1() -> Option<tokio::signal::unix::Signal> {
     use tokio::signal::unix::{SignalKind, signal};
-    let mut sig = match signal(SignalKind::user_defined1()) {
-        Ok(s) => s,
+    match signal(SignalKind::user_defined1()) {
+        Ok(s) => Some(s),
         Err(e) => {
             error!("Failed to install SIGUSR1 handler: {}", e);
-            return;
+            None
         }
-    };
+    }
+}
+
+#[cfg(unix)]
+async fn snapshot_on_sigusr1(pool: SqlitePool, mut sig: tokio::signal::unix::Signal) {
     let cfg = SnapshotConfig::from_env();
     info!(
         "SIGUSR1 handler installed: send SIGUSR1 to snapshot the database to {} (keeping {} total)",
@@ -168,6 +177,17 @@ async fn snapshot_once(pool: &SqlitePool, cfg: &SnapshotConfig) {
         "Received SIGUSR1, snapshotting database to {}",
         cfg.base.display()
     );
+    if let Some(parent) = cfg.base.parent()
+        && !parent.as_os_str().is_empty()
+        && let Err(e) = tokio::fs::create_dir_all(parent).await
+    {
+        error!(
+            "Failed to create snapshot directory {}: {}",
+            parent.display(),
+            e
+        );
+        return;
+    }
     let _ = tokio::fs::remove_file(&tmp).await;
     // Inline the path (single-quote-escaped) since parameter binding for
     // VACUUM INTO has been unreliable across SQLite versions.
@@ -328,6 +348,12 @@ pub(super) async fn create_server(
         .expect("Failed to get local address");
     let actual_port = actual_addr.port();
 
+    // Register the SIGUSR1 handler *before* advertising readiness so a parent
+    // that races between `TORC_SERVER_PORT=` and snapshot-loop spawn can't
+    // accidentally kill the server (default SIGUSR1 disposition is terminate).
+    #[cfg(unix)]
+    let sigusr1 = register_sigusr1();
+
     println!("TORC_SERVER_PORT={}", actual_port);
 
     if let Err(e) = sync_admin_group(&pool, &admin_users).await {
@@ -368,10 +394,10 @@ pub(super) async fn create_server(
     });
 
     #[cfg(unix)]
-    {
+    if let Some(sig) = sigusr1 {
         let snapshot_pool = pool.clone();
         tokio::spawn(async move {
-            snapshot_on_sigusr1(snapshot_pool).await;
+            snapshot_on_sigusr1(snapshot_pool, sig).await;
         });
     }
 

--- a/src/server/http_server/bootstrap.rs
+++ b/src/server/http_server/bootstrap.rs
@@ -197,6 +197,7 @@ async fn snapshot_once(pool: &SqlitePool, cfg: &SnapshotConfig) {
 /// runs on every snapshot but earlier slots may not exist yet.
 #[cfg(unix)]
 async fn rotate_and_promote(cfg: &SnapshotConfig, tmp: &std::path::Path) -> std::io::Result<()> {
+    let mut demoted_canonical = false;
     if cfg.keep > 1 {
         // Drop the oldest if it would push us over the limit. With `keep`
         // total slots, we retain `.1 ..= .{keep - 1}` plus the canonical.
@@ -215,12 +216,29 @@ async fn rotate_and_promote(cfg: &SnapshotConfig, tmp: &std::path::Path) -> std:
         // Demote the previous canonical to `.1`.
         let demoted = cfg.rotated_path(1);
         match tokio::fs::rename(&cfg.base, &demoted).await {
-            Ok(()) => {}
+            Ok(()) => demoted_canonical = true,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
             Err(e) => return Err(e),
         }
     }
-    tokio::fs::rename(tmp, &cfg.base).await
+    // Final promotion. If this fails, roll back the canonical demotion so
+    // the canonical path keeps pointing at a valid snapshot rather than
+    // disappearing on a transient FS error (out of space, permissions, etc.).
+    if let Err(e) = tokio::fs::rename(tmp, &cfg.base).await {
+        if demoted_canonical {
+            let demoted = cfg.rotated_path(1);
+            if let Err(re) = tokio::fs::rename(&demoted, &cfg.base).await {
+                error!(
+                    "snapshot promotion failed and rollback also failed; \
+                     canonical snapshot may be missing — recover from {}: {}",
+                    demoted.display(),
+                    re
+                );
+            }
+        }
+        return Err(e);
+    }
+    Ok(())
 }
 
 /// Build the shutdown future for the server. Resolves when any of the configured

--- a/src/server/http_server/bootstrap.rs
+++ b/src/server/http_server/bootstrap.rs
@@ -189,9 +189,22 @@ async fn snapshot_once(pool: &SqlitePool, cfg: &SnapshotConfig) {
     // is a stable contract — do not change without updating the parent-side
     // reader in `src/main.rs`. Flush explicitly because stdout is block-
     // buffered when piped, and the parent is waiting on this exact line.
-    use std::io::Write;
-    println!("TORC_SNAPSHOT_DONE={}", cfg.base.display());
-    let _ = std::io::stdout().flush();
+    // Run in spawn_blocking so a slow/backpressured stdout pipe can't park a
+    // Tokio worker thread.
+    let line = format!("TORC_SNAPSHOT_DONE={}", cfg.base.display());
+    let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        use std::io::Write;
+        let stdout = std::io::stdout();
+        let mut handle = stdout.lock();
+        writeln!(handle, "{}", line)?;
+        handle.flush()
+    })
+    .await;
+    match join {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => error!("Failed to write snapshot completion line: {}", e),
+        Err(e) => error!("snapshot stdout-notify task panicked: {}", e),
+    }
 }
 
 /// Rotate `<base>.{n-1}` → `<base>.{n}` for n down to 1, drop anything beyond

--- a/tests/test_standalone.rs
+++ b/tests/test_standalone.rs
@@ -324,3 +324,155 @@ fn non_standalone_does_not_start_server() {
     // The command itself is expected to fail (unreachable URL); we only care that
     // the standalone code path was not triggered.
 }
+
+/// Helper: run `torc -s --in-memory --db <db> <args>` and return the output.
+/// The standalone helper hard-codes the flag order, so we build the command
+/// manually here to inject `--in-memory` ahead of the subcommand.
+#[cfg(unix)]
+fn run_torc_in_memory(
+    work_dir: &std::path::Path,
+    db_path: &std::path::Path,
+    extra_args: &[&str],
+    args: &[&str],
+) -> std::process::Output {
+    let server_bin = torc_server_binary_path();
+    assert!(
+        server_bin.exists(),
+        "torc-server binary missing at {:?}",
+        server_bin
+    );
+
+    let target_debug = std::env::current_dir().expect("cwd").join("target/debug");
+    let existing = std::env::var_os("PATH").unwrap_or_default();
+    let mut entries: Vec<std::path::PathBuf> = vec![target_debug];
+    entries.extend(std::env::split_paths(&existing));
+    let path_var = std::env::join_paths(entries).expect("join PATH entries");
+
+    let mut cmd = Command::new(torc_binary_path());
+    cmd.current_dir(work_dir)
+        .arg("-s")
+        .arg("--in-memory")
+        .args(["--torc-server-bin", server_bin.to_str().unwrap()])
+        .args(["--db", db_path.to_str().unwrap()])
+        .args(extra_args)
+        .args(args)
+        .env_remove("TORC_API_URL")
+        .env("RUST_LOG", "warn")
+        .env("PATH", path_var);
+    cmd.output().expect("failed to spawn torc")
+}
+
+#[cfg(unix)]
+#[test]
+fn standalone_in_memory_snapshot_is_queryable() {
+    ensure_test_binaries_built();
+
+    let work = TempDir::new().expect("tempdir");
+    let db = work.path().join("snap.db");
+
+    // `--in-memory` runs the server entirely in RAM, then snapshots to `--db`
+    // right before shutdown. After the command returns, the snapshot file
+    // must exist and contain the workflow we just created.
+    let out = run_torc_in_memory(work.path(), &db, &[], &["exec", "-c", "echo in-mem-ok"]);
+    assert!(
+        out.status.success(),
+        "torc -s --in-memory exec failed (status {:?}):\n--- stdout ---\n{}\n--- stderr ---\n{}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        db.exists(),
+        "snapshot DB at {:?} should exist after --in-memory exec returns",
+        db
+    );
+    // No timeout warning — drop+drain logic should land the final snapshot
+    // synchronously.
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("timed out waiting for final snapshot"),
+        "final snapshot timed out unexpectedly; stderr:\n{}",
+        stderr
+    );
+
+    // Verify the workflow is readable from the snapshot via a fresh
+    // standalone invocation (now without --in-memory; just on-disk against
+    // the snapshot file).
+    let listed = run_torc_standalone_ok(work.path(), &db, &["-f", "json", "workflows", "list"]);
+    let stdout = String::from_utf8_lossy(&listed.stdout).to_string();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("workflows list JSON parse failed: {}\n---\n{}", e, stdout));
+    let items = parsed
+        .get("workflows")
+        .and_then(|v| v.as_array())
+        .unwrap_or_else(|| panic!("expected workflows[] in list response: {}", stdout));
+    assert!(
+        !items.is_empty(),
+        "expected ≥1 workflow in --in-memory snapshot DB; got {}",
+        stdout
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn standalone_in_memory_periodic_snapshot_lands_before_exit() {
+    ensure_test_binaries_built();
+
+    let work = TempDir::new().expect("tempdir");
+    let db = work.path().join("periodic-snap.db");
+
+    // Run a workflow that sleeps long enough for at least one periodic
+    // snapshot to fire mid-run, then verify the final snapshot is intact
+    // and contains the completed job.
+    let out = run_torc_in_memory(
+        work.path(),
+        &db,
+        &["--snapshot-interval-seconds", "1"],
+        &["exec", "-c", "sleep 3 && echo periodic-ok"],
+    );
+    assert!(
+        out.status.success(),
+        "torc -s --in-memory --snapshot-interval-seconds 1 exec failed:\n--- stderr ---\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(db.exists(), "snapshot DB at {:?} should exist", db);
+
+    let listed = run_torc_standalone_ok(work.path(), &db, &["-f", "json", "workflows", "list"]);
+    let stdout = String::from_utf8_lossy(&listed.stdout);
+    assert!(
+        stdout.contains("\"workflows\""),
+        "expected workflows list response; got {}",
+        stdout
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn standalone_in_memory_rejected_for_read_only_command() {
+    ensure_test_binaries_built();
+
+    let work = TempDir::new().expect("tempdir");
+    let db = work.path().join("readonly.db");
+
+    // `--in-memory` should be refused for commands that don't create
+    // workflow state — otherwise the empty in-memory DB would snapshot
+    // over an existing torc.db and destroy prior data.
+    let out = run_torc_in_memory(work.path(), &db, &[], &["workflows", "list"]);
+    assert!(
+        !out.status.success(),
+        "--in-memory + workflows list should fail; stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("--in-memory is only supported with"),
+        "stderr should explain the restriction; got:\n{}",
+        stderr
+    );
+    assert!(
+        !db.exists(),
+        "rejected --in-memory must not create the snapshot file; got {:?}",
+        db
+    );
+}

--- a/tests/test_standalone.rs
+++ b/tests/test_standalone.rs
@@ -423,12 +423,13 @@ fn standalone_in_memory_periodic_snapshot_lands_before_exit() {
 
     // Run a workflow that sleeps long enough for at least one periodic
     // snapshot to fire mid-run, then verify the final snapshot is intact
-    // and contains the completed job.
+    // and contains the completed job. 1.5 s vs the 1 s interval gives one
+    // guaranteed tick without paying for a full multi-second sleep on CI.
     let out = run_torc_in_memory(
         work.path(),
         &db,
         &["--snapshot-interval-seconds", "1"],
-        &["exec", "-c", "sleep 3 && echo periodic-ok"],
+        &["exec", "-c", "sleep 1.5 && echo periodic-ok"],
     );
     assert!(
         out.status.success(),


### PR DESCRIPTION
Lets torc-server run entirely from a SQLite in-memory database with on-demand snapshots to disk via SIGUSR1. Targets HPC login/compute nodes where shared filesystems (Lustre, GPFS, NFS) are intermittently slow and stall request handlers.

Server side:
- bootstrap.rs spawns a snapshot task that listens for SIGUSR1 and runs `VACUUM INTO` to a `.tmp` sibling, rotates older snapshots (`<base>.1`, `.2`, …), then atomically renames into place. Configurable via `TORC_SERVER_SNAPSHOT_PATH` and `TORC_SERVER_SNAPSHOT_KEEP` (default 5, min 1).
- torc-server.rs auto-rewrites bare `:memory:` to `sqlite:file::memory:?cache=shared` and sets `min_connections(1)`, fixing a latent bug where pool connections were each getting private in-memory databases.
- After each snapshot the server prints `TORC_SNAPSHOT_DONE=<path>` on stdout (flushed) so a parent process can synchronize on snapshot completion.

Client side:
- New global flags `--in-memory` (Unix only, requires `--standalone`) and `--snapshot-interval-seconds <N>` (requires `--in-memory`).
- `start_standalone_server` swaps `--database <path>` for `--database :memory:`, sets `TORC_SERVER_SNAPSHOT_PATH` to the on-disk path, and defaults `TORC_SERVER_SNAPSHOT_KEEP=1` so users see one canonical file at the path they expect.
- Stdout drain thread routes `TORC_SNAPSHOT_DONE` lines to a channel the parent waits on. `Drop` sends a final SIGUSR1 and waits up to 5 s for confirmation before stdin-EOF shutdown, so when the command returns, the workflow is queryable.
- Periodic-snapshot thread parks on a stop-mpsc with timeout, sending SIGUSR1 each tick until Drop stops it (avoids racing the final snapshot).
- `--in-memory` is restricted to `exec` and `run` — read-only commands like `results list` would otherwise snapshot an empty DB over existing data.

Docs cover both the low-level server operation and the standalone client mode for HPC use cases.