### PR TITLE
Use BEGIN IMMEDIATE for read-then-write transactions

### DIFF
--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -106,6 +106,26 @@ pub fn validate_env_map(
     Ok(())
 }
 
+/// Begin a SQLite transaction with `BEGIN IMMEDIATE`, taking the write lock up front.
+///
+/// In WAL mode, `pool.begin()` issues plain `BEGIN` (= `BEGIN DEFERRED`), which only
+/// takes the database write lock when the first write statement runs. If a `SELECT`
+/// runs first inside the transaction, the connection acquires a WAL read snapshot,
+/// and a subsequent `INSERT`/`UPDATE`/`DELETE` can fail with `SQLITE_BUSY_SNAPSHOT`
+/// (extended code 517) the moment any other connection commits in between. The
+/// connection's `busy_timeout` does **not** retry `SQLITE_BUSY_SNAPSHOT` -- it
+/// returns immediately.
+///
+/// `BEGIN IMMEDIATE` takes the write lock up front, so the full `busy_timeout`
+/// applies to lock acquisition and the snapshot-conflict path is impossible. Use
+/// this helper for any handler that mixes reads and writes inside a single
+/// transaction.
+pub async fn begin_immediate(
+    pool: &SqlitePool,
+) -> Result<sqlx::Transaction<'static, sqlx::Sqlite>, sqlx::Error> {
+    pool.begin_with("BEGIN IMMEDIATE").await
+}
+
 /// Escape SQL LIKE wildcard characters in user input.
 /// Escapes `%`, `_`, and `\` with a backslash prefix.
 pub fn escape_like_pattern(input: &str) -> String {

--- a/src/server/api/jobs.rs
+++ b/src/server/api/jobs.rs
@@ -22,8 +22,9 @@ use crate::server::api_responses::{
 use crate::models::{self as models, JobStatus};
 
 use super::{
-    ApiContext, MAX_RECORD_TRANSFER_COUNT, SqlQueryBuilder, database_error_with_msg,
-    deserialize_env_map, normalize_env_map, serialize_env_map, validate_env_map,
+    ApiContext, MAX_RECORD_TRANSFER_COUNT, SqlQueryBuilder, begin_immediate,
+    database_error_with_msg, deserialize_env_map, normalize_env_map, serialize_env_map,
+    validate_env_map,
 };
 
 /// Trait defining job-related API operations
@@ -617,9 +618,10 @@ impl JobsApiImpl {
 
         let uninitialized_status = JobStatus::Uninitialized.to_int();
 
-        // Begin a transaction with immediate lock to ensure atomicity
-        // SQLx automatically uses BEGIN IMMEDIATE for SQLite when the first write occurs
-        let mut tx = match self.context.pool.begin().await {
+        // Acquire the SQLite write lock up front. We read `workflow_id` before
+        // the recursive UPDATE, which would risk SQLITE_BUSY_SNAPSHOT under
+        // BEGIN DEFERRED if another writer commits in between.
+        let mut tx = match begin_immediate(&self.context.pool).await {
             Ok(tx) => tx,
             Err(e) => {
                 error!("Failed to begin transaction for completion reversal: {}", e);
@@ -710,7 +712,7 @@ impl JobsApiImpl {
                     "Database error during completion reversal for job {}: {}",
                     job_id, e
                 );
-                // Transaction will be automatically rolled back when tx is dropped
+                // Transaction is rolled back automatically when `tx` is dropped.
                 Err(ApiError("Database error".to_string()))
             }
         }
@@ -1193,8 +1195,10 @@ where
         let status_int = status.to_int();
         job.status = Some(status);
 
-        // Begin a transaction to ensure job and all relationships are created atomically
-        let mut tx = match self.context.pool.begin().await {
+        // Acquire the SQLite write lock up front. `fetch_workflow_env` reads
+        // before the INSERT, which would risk SQLITE_BUSY_SNAPSHOT under
+        // BEGIN DEFERRED if another writer commits in between.
+        let mut tx = match begin_immediate(&self.context.pool).await {
             Ok(tx) => tx,
             Err(e) => {
                 return Err(database_error_with_msg(e, "Failed to begin transaction"));
@@ -1395,8 +1399,10 @@ where
 
         let mut added_jobs = Vec::new();
 
-        // Use a transaction for all operations to ensure consistency
-        let mut transaction = match self.context.pool.begin().await {
+        // Acquire the SQLite write lock up front. `fetch_workflow_env` reads
+        // before the per-job INSERTs, which would risk SQLITE_BUSY_SNAPSHOT
+        // under BEGIN DEFERRED if another writer commits in between.
+        let mut transaction = match begin_immediate(&self.context.pool).await {
             Ok(tx) => tx,
             Err(e) => return Err(database_error_with_msg(e, "Failed to begin transaction")),
         };


### PR DESCRIPTION
## Summary
- `pool.begin()` issues `BEGIN DEFERRED`, which only takes the SQLite write lock when the first write runs. Handlers that `SELECT` first acquire a WAL read snapshot, and a later `INSERT`/`UPDATE`/`DELETE` can fail immediately with `SQLITE_BUSY_SNAPSHOT` (extended code 517) if another connection commits in between. `busy_timeout` does **not** retry 517.
- Add a `begin_immediate` helper in `src/server/api.rs` that wraps `Pool::begin_with("BEGIN IMMEDIATE")`, so the write lock is acquired up front and the busy timeout applies normally.
- Convert the three read-then-write handlers in `src/server/api/jobs.rs`: completion-reversal, single-job add, and multi-job add.

The helper returns a real `sqlx::Transaction<'static, Sqlite>`, so existing call-site ergonomics (`&mut *tx`, rollback-on-drop) are unchanged.

## Follow-up (out of scope here)
- `retry_job` (jobs.rs:~2916) hand-rolls the same `pool.acquire()` + raw `BEGIN IMMEDIATE` pattern with manual `ROLLBACK` calls everywhere; it could be migrated to `begin_immediate` and shed a lot of boilerplate.
- Other `pool.begin()` call sites in `workflows.rs` and `results.rs` should be audited for the same read-then-write pattern.

## Test plan
- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all --all-targets --all-features -- -D warnings`
- [x] `dprint check`
- [x] `cargo nextest run --lib` (274 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)