### PR TITLE
Fix SQLITE_BUSY_SNAPSHOT in completion and unblock paths

### DIFF
--- a/src/client/utils.rs
+++ b/src/client/utils.rs
@@ -111,9 +111,16 @@ fn is_retryable_error(error_str: &str) -> bool {
         || s.contains("unreachable")
         // HTTP server errors (formatted as "status code NNN" by the generated client)
         || is_5xx_response_error(&s)
-        // Database contention
-        || s.contains("database is locked")
-        || s.contains("database is busy")
+        // Database contention (server may surface this via database_lock_aware_error)
+        || is_database_lock_error(&s)
+}
+
+/// Check whether an error string indicates SQLite lock contention on the server.
+/// Lock errors typically clear in milliseconds, so the caller can retry quickly
+/// instead of falling back to the slow ping-and-wait path used for outages.
+fn is_database_lock_error(error_str: &str) -> bool {
+    let s = error_str.to_ascii_lowercase();
+    s.contains("database is locked") || s.contains("database is busy") || s.contains("sqlite_busy")
 }
 
 fn is_5xx_response_error(s: &str) -> bool {
@@ -140,61 +147,95 @@ where
     F: FnMut() -> Result<T, E>,
     E: std::fmt::Display,
 {
-    match api_call() {
-        Ok(result) => Ok(result),
-        Err(e) => {
-            let error_str = e.to_string();
-            if !is_retryable_error(&error_str) {
-                return Err(e);
-            }
+    // Fast-retry phase for SQLite lock contention. Lock errors typically clear in
+    // milliseconds; the slow ping-and-wait loop below assumes the server is down
+    // and would waste throughput by sleeping 30s before each retry. We try a few
+    // times with short exponential backoff before falling through.
+    const FAST_RETRY_ATTEMPTS: u32 = 6;
+    const FAST_RETRY_INITIAL_MS: u64 = 50;
+    const FAST_RETRY_MAX_MS: u64 = 2000;
 
-            warn!(
-                "Transient error detected: {}. Entering retry loop for up to {} minutes.",
-                e, wait_for_healthy_database_minutes
-            );
+    let mut e = match api_call() {
+        Ok(result) => return Ok(result),
+        Err(e) => e,
+    };
 
-            let start_time = Instant::now();
-            let timeout_duration = Duration::from_secs(wait_for_healthy_database_minutes * 60);
-
-            loop {
-                if start_time.elapsed() >= timeout_duration {
-                    error!(
-                        "Retry timeout exceeded ({} minutes). Giving up.",
-                        wait_for_healthy_database_minutes
+    if is_database_lock_error(&e.to_string()) {
+        let mut delay_ms = FAST_RETRY_INITIAL_MS;
+        for attempt in 1..=FAST_RETRY_ATTEMPTS {
+            thread::sleep(Duration::from_millis(delay_ms));
+            match api_call() {
+                Ok(result) => {
+                    debug!(
+                        "Recovered from database lock after {} fast retries",
+                        attempt
                     );
-                    return Err(e);
+                    return Ok(result);
                 }
+                Err(retry_err) => {
+                    if !is_database_lock_error(&retry_err.to_string()) {
+                        // Different error class; stop fast-retrying and let the
+                        // generic path handle it.
+                        e = retry_err;
+                        break;
+                    }
+                    e = retry_err;
+                    delay_ms = (delay_ms.saturating_mul(2)).min(FAST_RETRY_MAX_MS);
+                }
+            }
+        }
+    }
 
-                thread::sleep(Duration::from_secs(PING_INTERVAL_SECONDS));
+    let error_str = e.to_string();
+    if !is_retryable_error(&error_str) {
+        return Err(e);
+    }
 
-                // Try to ping the server first to confirm it's reachable
-                match apis::system_api::ping(config) {
-                    Ok(_) => {
-                        info!("Server is responding. Retrying original API call.");
-                        match api_call() {
-                            Ok(result) => return Ok(result),
-                            Err(retry_err) => {
-                                let retry_str = retry_err.to_string();
-                                if is_retryable_error(&retry_str) {
-                                    warn!(
-                                        "Retry attempt failed with transient error: {}. \
-                                         Will keep retrying.",
-                                        retry_err
-                                    );
-                                    continue;
-                                }
-                                return Err(retry_err);
-                            }
+    warn!(
+        "Transient error detected: {}. Entering retry loop for up to {} minutes.",
+        e, wait_for_healthy_database_minutes
+    );
+
+    let start_time = Instant::now();
+    let timeout_duration = Duration::from_secs(wait_for_healthy_database_minutes * 60);
+
+    loop {
+        if start_time.elapsed() >= timeout_duration {
+            error!(
+                "Retry timeout exceeded ({} minutes). Giving up.",
+                wait_for_healthy_database_minutes
+            );
+            return Err(e);
+        }
+
+        thread::sleep(Duration::from_secs(PING_INTERVAL_SECONDS));
+
+        // Try to ping the server first to confirm it's reachable
+        match apis::system_api::ping(config) {
+            Ok(_) => {
+                info!("Server is responding. Retrying original API call.");
+                match api_call() {
+                    Ok(result) => return Ok(result),
+                    Err(retry_err) => {
+                        let retry_str = retry_err.to_string();
+                        if is_retryable_error(&retry_str) {
+                            warn!(
+                                "Retry attempt failed with transient error: {}. \
+                                 Will keep retrying.",
+                                retry_err
+                            );
+                            continue;
                         }
-                    }
-                    Err(ping_error) => {
-                        debug!(
-                            "Server still unreachable: {}. Continuing to wait...",
-                            ping_error
-                        );
-                        continue;
+                        return Err(retry_err);
                     }
                 }
+            }
+            Err(ping_error) => {
+                debug!(
+                    "Server still unreachable: {}. Continuing to wait...",
+                    ping_error
+                );
+                continue;
             }
         }
     }
@@ -506,6 +547,10 @@ mod tests {
         // Database contention
         assert!(is_retryable_error("database is locked"));
         assert!(is_retryable_error("database is busy"));
+        assert!(is_retryable_error(
+            "Failed to create result record: database is locked"
+        ));
+        assert!(is_retryable_error("SQLITE_BUSY: snapshot conflict"));
 
         // Non-retryable errors
         // reqwest builder errors are deterministic (invalid URL, etc.)
@@ -522,6 +567,22 @@ mod tests {
         assert!(!is_retryable_error(
             "error in response: status code 403: forbidden"
         ));
+    }
+
+    #[test]
+    fn test_is_database_lock_error() {
+        assert!(is_database_lock_error("database is locked"));
+        assert!(is_database_lock_error("Database Is Locked"));
+        assert!(is_database_lock_error("database is busy"));
+        assert!(is_database_lock_error("SQLITE_BUSY: snapshot conflict"));
+        assert!(is_database_lock_error(
+            "Failed to create result record: database is locked"
+        ));
+        assert!(!is_database_lock_error(
+            "error in response: status code 500: internal error"
+        ));
+        assert!(!is_database_lock_error("connection refused"));
+        assert!(!is_database_lock_error("timeout"));
     }
 
     #[test]

--- a/src/server/http_server/jobs_transport.rs
+++ b/src/server/http_server/jobs_transport.rs
@@ -1,5 +1,7 @@
 use super::*;
-use crate::server::api::{EventsApi, JobsApi, ResultsApi, WorkflowsApi, database_error_with_msg};
+use crate::server::api::{
+    EventsApi, JobsApi, ResultsApi, WorkflowsApi, begin_immediate, database_lock_aware_error,
+};
 
 const RESOURCE_CLAIM_ORDER_BY: &str = "\
     ORDER BY \
@@ -1233,10 +1235,9 @@ where
                 )));
             }
             Err(e) => {
-                return Err(CompletionMutationError::Transport(database_error_with_msg(
-                    e,
-                    "Failed to fetch job for completion",
-                )));
+                return Err(CompletionMutationError::Transport(
+                    database_lock_aware_error(e, "Failed to fetch job for completion"),
+                ));
             }
         };
 
@@ -1336,7 +1337,7 @@ where
         .fetch_optional(&mut **tx)
         .await
         .map_err(|e| {
-            CompletionMutationError::Transport(database_error_with_msg(
+            CompletionMutationError::Transport(database_lock_aware_error(
                 e,
                 "Failed to fetch workflow run_id",
             ))
@@ -1421,7 +1422,7 @@ where
         .fetch_one(&mut **tx)
         .await
         .map_err(|e| {
-            CompletionMutationError::Transport(database_error_with_msg(
+            CompletionMutationError::Transport(database_lock_aware_error(
                 e,
                 "Failed to create result record",
             ))
@@ -1440,7 +1441,7 @@ where
         .execute(&mut **tx)
         .await
         .map_err(|e| {
-            CompletionMutationError::Transport(database_error_with_msg(
+            CompletionMutationError::Transport(database_lock_aware_error(
                 e,
                 "Failed to create workflow_result record",
             ))
@@ -1466,14 +1467,14 @@ where
         )
         .execute(&mut **tx)
         .await
-        .map_err(|e| CompletionMutationError::Transport(database_error_with_msg(e, "Failed to update job status")))?;
+        .map_err(|e| CompletionMutationError::Transport(database_lock_aware_error(e, "Failed to update job status")))?;
 
         if update_result.rows_affected() == 0 {
             let current = sqlx::query_scalar!("SELECT status FROM job WHERE id = ?", id)
                 .fetch_optional(&mut **tx)
                 .await
                 .map_err(|e| {
-                    CompletionMutationError::Transport(database_error_with_msg(
+                    CompletionMutationError::Transport(database_lock_aware_error(
                         e,
                         "Failed to re-check job status",
                     ))
@@ -1654,8 +1655,12 @@ where
         let mut completed = Vec::new();
         let mut errors = Vec::new();
         let mut completion_records = Vec::new();
-        let mut tx = self.pool.begin().await.map_err(|e| {
-            database_error_with_msg(e, "Failed to begin batch completion transaction")
+        // Use BEGIN IMMEDIATE: apply_job_completion_state_tx reads from `job` before
+        // writing, and a deferred transaction's read snapshot can be invalidated by a
+        // concurrent committer, surfacing SQLITE_BUSY_SNAPSHOT (517) which busy_timeout
+        // does not retry. See server/api.rs::begin_immediate.
+        let mut tx = begin_immediate(&self.pool).await.map_err(|e| {
+            database_lock_aware_error(e, "Failed to begin batch completion transaction")
         })?;
 
         for entry in body.completions {
@@ -1695,7 +1700,7 @@ where
         }
 
         tx.commit().await.map_err(|e| {
-            database_error_with_msg(e, "Failed to commit batch completion transaction")
+            database_lock_aware_error(e, "Failed to commit batch completion transaction")
         })?;
 
         if !completion_records.is_empty() {

--- a/src/server/http_server/lifecycle_support.rs
+++ b/src/server/http_server/lifecycle_support.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::server::api::{database_error_with_msg, database_lock_aware_error};
+use crate::server::api::{begin_immediate, database_error_with_msg, database_lock_aware_error};
 
 impl<C> Server<C> {
     pub(super) async fn manage_job_status_change(
@@ -396,7 +396,11 @@ impl<C> Server<C> {
 
         let uninitialized_status = models::JobStatus::Uninitialized.to_int();
 
-        let mut tx = match self.pool.begin().await {
+        // BEGIN IMMEDIATE: the first statement on this tx is a SELECT, which would
+        // acquire a WAL read snapshot under BEGIN DEFERRED and then risk
+        // SQLITE_BUSY_SNAPSHOT (517) on the recursive UPDATE that follows.
+        // See server/api.rs::begin_immediate.
+        let mut tx = match begin_immediate(&self.pool).await {
             Ok(tx) => tx,
             Err(e) => {
                 error!("Failed to begin transaction for completion reversal: {}", e);

--- a/src/server/http_server/unblock_processing.rs
+++ b/src/server/http_server/unblock_processing.rs
@@ -1,6 +1,6 @@
 use super::Server;
 use crate::models;
-use crate::server::api::database_lock_aware_error;
+use crate::server::api::{begin_immediate, database_lock_aware_error};
 use crate::server::transport_types::context_types::{ApiError, EmptyContext, Has, XSpanIdString};
 use log::{debug, error, info};
 use std::sync::atomic::Ordering;
@@ -144,7 +144,11 @@ where
     let canceled_status = models::JobStatus::Canceled.to_int();
     let terminated_status = models::JobStatus::Terminated.to_int();
 
-    let mut tx = match server.pool.begin().await {
+    // BEGIN IMMEDIATE: the first statement on this tx is a SELECT, which would
+    // acquire a WAL read snapshot under BEGIN DEFERRED and then risk
+    // SQLITE_BUSY_SNAPSHOT (517) on the subsequent UPDATEs. busy_timeout does
+    // not retry that error. See server/api.rs::begin_immediate.
+    let mut tx = match begin_immediate(&server.pool).await {
         Ok(tx) => tx,
         Err(e) => {
             debug!(


### PR DESCRIPTION
The v0.24.1 deadlock fix in batch_complete_jobs (#287) moved the per-job SELECT inside the same transaction as its writes. With pool.begin() issuing BEGIN DEFERRED, that SELECT now acquires a WAL read snapshot, so the subsequent UPDATE/INSERT in the same tx can fail immediately with SQLITE_BUSY_SNAPSHOT (517) when another connection commits in between. busy_timeout does not retry that error. Two other handlers had the same shape: process_workflow_unblocks_inner (masked by its own retry loop) and update_jobs_from_completion_reversal.

Server changes:
- transport_batch_complete_jobs, process_workflow_unblocks_inner, and update_jobs_from_completion_reversal now use begin_immediate so the write lock is acquired up front and busy_timeout applies.
- In-tx error sites in apply_job_completion_state_tx and the begin/ commit wrappers in transport_batch_complete_jobs now use database_lock_aware_error so lock contention propagates to the client and logs at debug instead of error.

Client changes:
- send_with_retries now does a fast-retry phase for database lock errors (up to 6 attempts, 50ms->2s exponential backoff) before falling through to the existing 30s ping-and-wait loop, which stays as the right behavior for genuine outages. Previously a transient lock error cost ~30s of throughput per occurrence because the loop unconditionally slept PING_INTERVAL_SECONDS before retrying.
- New is_database_lock_error helper, also matched by is_retryable_error so the lock substring (now propagated by the server) reliably enters the retry path.