### PR TITLE
Add Summary detail pane for TUI workflows

### DIFF
--- a/src/tui/api.rs
+++ b/src/tui/api.rs
@@ -3,8 +3,8 @@ use crate::client::apis::configuration::{BasicAuth, Configuration, TlsConfig};
 use crate::client::config::TorcConfig;
 use crate::client::workflow_spec::WorkflowSpec;
 use crate::models::{
-    ComputeNodeModel, FileModel, JobDependencyModel, JobModel, JobStatus, ResultModel,
-    ScheduledComputeNodesModel, SlurmStatsModel, WorkflowActionModel, WorkflowModel,
+    ComputeNodeModel, FileModel, IsCompleteResponse, JobDependencyModel, JobModel, JobStatus,
+    ResultModel, ScheduledComputeNodesModel, SlurmStatsModel, WorkflowActionModel, WorkflowModel,
 };
 use anyhow::{Context, Result};
 
@@ -102,6 +102,16 @@ impl TorcClient {
         .context("Failed to list workflows")?;
 
         Ok(response.items)
+    }
+
+    pub fn get_workflow(&self, workflow_id: i64) -> Result<WorkflowModel> {
+        apis::workflows_api::get_workflow(&self.config, workflow_id)
+            .context("Failed to get workflow")
+    }
+
+    pub fn is_workflow_complete(&self, workflow_id: i64) -> Result<IsCompleteResponse> {
+        apis::workflows_api::is_workflow_complete(&self.config, workflow_id)
+            .context("Failed to check workflow completion")
     }
 
     pub fn list_jobs(&self, workflow_id: i64) -> Result<Vec<JobModel>> {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -260,6 +260,7 @@ pub struct App {
     pub workflows_state: TableState,
     pub jobs: Vec<JobModel>,
     pub jobs_all: Vec<JobModel>,
+    pub jobs_workflow_id: Option<i64>,
     pub jobs_state: TableState,
     pub files: Vec<FileModel>,
     pub files_all: Vec<FileModel>,
@@ -367,6 +368,7 @@ impl App {
             workflows_state: TableState::default(),
             jobs: Vec::new(),
             jobs_all: Vec::new(),
+            jobs_workflow_id: None,
             jobs_state: TableState::default(),
             files: Vec::new(),
             files_all: Vec::new(),
@@ -551,11 +553,10 @@ impl App {
 
                 match self.detail_view {
                     DetailViewType::Summary => {
-                        // Always re-fetch: jobs_all may be cached from a
-                        // previously selected workflow, so reusing it here
-                        // would render that workflow's counts under this
-                        // workflow's header.
-                        self.jobs_all = self.client.list_jobs(workflow_id)?;
+                        if self.jobs_workflow_id != Some(workflow_id) {
+                            self.jobs_all = self.client.list_jobs(workflow_id)?;
+                            self.jobs_workflow_id = Some(workflow_id);
+                        }
                         self.jobs = self.jobs_all.clone();
                         let workflow = self.client.get_workflow(workflow_id)?;
                         let completion = self.client.is_workflow_complete(workflow_id)?;
@@ -580,6 +581,7 @@ impl App {
                     }
                     DetailViewType::Jobs => {
                         self.jobs_all = self.client.list_jobs(workflow_id)?;
+                        self.jobs_workflow_id = Some(workflow_id);
                         self.jobs = self.jobs_all.clone();
                         if !self.jobs.is_empty() {
                             self.jobs_state.select(Some(0));
@@ -639,12 +641,11 @@ impl App {
                         self.rebuild_exec_time_map();
                     }
                     DetailViewType::Dag => {
-                        // Load jobs if not already loaded
-                        if self.jobs_all.is_empty() {
+                        if self.jobs_workflow_id != Some(workflow_id) {
                             self.jobs_all = self.client.list_jobs(workflow_id)?;
+                            self.jobs_workflow_id = Some(workflow_id);
                             self.jobs = self.jobs_all.clone();
                         }
-                        // Build the DAG
                         self.build_dag_from_jobs();
                     }
                 }
@@ -684,6 +685,12 @@ impl App {
     }
 
     pub fn start_filter(&mut self) {
+        if self.get_filter_columns().is_empty() {
+            self.set_status(StatusMessage::info(
+                "Filtering is not supported in this view",
+            ));
+            return;
+        }
         self.focus = Focus::FilterInput;
         self.filter_input.clear();
         self.filter_column_index = 0;
@@ -710,11 +717,19 @@ impl App {
 
     pub fn next_filter_column(&mut self) {
         let columns = self.get_filter_columns();
+        if columns.is_empty() {
+            self.filter_column_index = 0;
+            return;
+        }
         self.filter_column_index = (self.filter_column_index + 1) % columns.len();
     }
 
     pub fn prev_filter_column(&mut self) {
         let columns = self.get_filter_columns();
+        if columns.is_empty() {
+            self.filter_column_index = 0;
+            return;
+        }
         if self.filter_column_index == 0 {
             self.filter_column_index = columns.len() - 1;
         } else {
@@ -738,6 +753,10 @@ impl App {
         }
 
         let columns = self.get_filter_columns();
+        if columns.is_empty() {
+            self.focus = Focus::Details;
+            return;
+        }
         let column = columns[self.filter_column_index].to_string();
         let value = self.filter_input.clone().to_lowercase();
 
@@ -1120,6 +1139,7 @@ impl App {
                 // Refresh jobs for the current workflow
                 if let Ok(jobs) = self.client.list_jobs(workflow_id) {
                     self.jobs_all = jobs.clone();
+                    self.jobs_workflow_id = Some(workflow_id);
                     self.jobs = jobs;
                     if !self.jobs.is_empty() {
                         self.jobs_state.select(Some(0));

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -29,6 +29,7 @@ use super::dag::{DagLayout, JobNode};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum DetailViewType {
+    Summary,
     Jobs,
     Files,
     Events,
@@ -161,6 +162,7 @@ pub enum PendingAction {
 impl DetailViewType {
     pub fn as_str(&self) -> &str {
         match self {
+            Self::Summary => "◆ Summary",
             Self::Jobs => "▶ Jobs",
             Self::Files => "◫ Files",
             Self::Events => "⚡ Events",
@@ -174,6 +176,7 @@ impl DetailViewType {
 
     pub fn all() -> Vec<Self> {
         vec![
+            Self::Summary,
             Self::Jobs,
             Self::Files,
             Self::Events,
@@ -187,6 +190,7 @@ impl DetailViewType {
 
     pub fn next(&self) -> Self {
         match self {
+            Self::Summary => Self::Jobs,
             Self::Jobs => Self::Files,
             Self::Files => Self::Events,
             Self::Events => Self::Results,
@@ -194,13 +198,14 @@ impl DetailViewType {
             Self::ComputeNodes => Self::ScheduledNodes,
             Self::ScheduledNodes => Self::SlurmStats,
             Self::SlurmStats => Self::Dag,
-            Self::Dag => Self::Jobs,
+            Self::Dag => Self::Summary,
         }
     }
 
     pub fn previous(&self) -> Self {
         match self {
-            Self::Jobs => Self::Dag,
+            Self::Summary => Self::Dag,
+            Self::Jobs => Self::Summary,
             Self::Files => Self::Jobs,
             Self::Events => Self::Files,
             Self::Results => Self::Events,
@@ -227,6 +232,23 @@ pub enum Focus {
 pub struct Filter {
     pub column: String,
     pub value: String,
+}
+
+/// Aggregated high-level information about a single workflow, computed from
+/// list_jobs + get_workflow + is_workflow_complete and rendered by the
+/// Summary detail view.
+#[derive(Debug, Clone)]
+pub struct WorkflowSummary {
+    pub workflow_id: i64,
+    pub workflow_name: String,
+    pub workflow_user: String,
+    pub description: Option<String>,
+    pub is_complete: bool,
+    pub is_canceled: bool,
+    pub needs_completion_script: bool,
+    pub total_jobs: usize,
+    /// Counts indexed by `JobStatus as usize` (0 = Uninitialized .. 10 = PendingFailed).
+    pub counts: [usize; 11],
 }
 
 pub struct App {
@@ -260,6 +282,7 @@ pub struct App {
     pub slurm_stats_all: Vec<SlurmStatsModel>,
     pub slurm_stats_state: TableState,
     pub dag: Option<DagLayout>,
+    pub summary: Option<WorkflowSummary>,
     pub detail_view: DetailViewType,
     pub selected_workflow_id: Option<i64>,
     pub focus: Focus,
@@ -366,7 +389,8 @@ impl App {
             slurm_stats_all: Vec::new(),
             slurm_stats_state: TableState::default(),
             dag: None,
-            detail_view: DetailViewType::Jobs,
+            summary: None,
+            detail_view: DetailViewType::Summary,
             selected_workflow_id: None,
             focus: Focus::Workflows,
             previous_focus: Focus::Workflows,
@@ -454,7 +478,7 @@ impl App {
                     DetailViewType::SlurmStats => {
                         (&mut self.slurm_stats_state, self.slurm_stats.len())
                     }
-                    DetailViewType::Dag => return, // DAG view doesn't support table navigation
+                    DetailViewType::Summary | DetailViewType::Dag => return, // No table to navigate
                 };
                 if len > 0 {
                     state.select(Some(
@@ -499,7 +523,7 @@ impl App {
                     DetailViewType::SlurmStats => {
                         (&mut self.slurm_stats_state, self.slurm_stats.len())
                     }
-                    DetailViewType::Dag => return, // DAG view doesn't support table navigation
+                    DetailViewType::Summary | DetailViewType::Dag => return, // No table to navigate
                 };
                 if len > 0 {
                     state.select(Some(
@@ -526,6 +550,34 @@ impl App {
                 self.filter = None;
 
                 match self.detail_view {
+                    DetailViewType::Summary => {
+                        // Always re-fetch: jobs_all may be cached from a
+                        // previously selected workflow, so reusing it here
+                        // would render that workflow's counts under this
+                        // workflow's header.
+                        self.jobs_all = self.client.list_jobs(workflow_id)?;
+                        self.jobs = self.jobs_all.clone();
+                        let workflow = self.client.get_workflow(workflow_id)?;
+                        let completion = self.client.is_workflow_complete(workflow_id)?;
+
+                        let mut counts = [0usize; 11];
+                        for job in &self.jobs_all {
+                            if let Some(s) = &job.status {
+                                counts[*s as usize] += 1;
+                            }
+                        }
+                        self.summary = Some(WorkflowSummary {
+                            workflow_id,
+                            workflow_name: workflow.name,
+                            workflow_user: workflow.user,
+                            description: workflow.description,
+                            is_complete: completion.is_complete,
+                            is_canceled: completion.is_canceled,
+                            needs_completion_script: completion.needs_to_run_completion_script,
+                            total_jobs: self.jobs_all.len(),
+                            counts,
+                        });
+                    }
                     DetailViewType::Jobs => {
                         self.jobs_all = self.client.list_jobs(workflow_id)?;
                         self.jobs = self.jobs_all.clone();
@@ -644,6 +696,7 @@ impl App {
 
     pub fn get_filter_columns(&self) -> Vec<&str> {
         match self.detail_view {
+            DetailViewType::Summary => vec![], // Summary view doesn't support filtering
             DetailViewType::Jobs => vec!["Status", "Name", "Command"],
             DetailViewType::Files => vec!["Name", "Path"],
             DetailViewType::Events => vec!["Event Type", "Data"],
@@ -834,8 +887,8 @@ impl App {
                     self.slurm_stats_state.select(None);
                 }
             }
-            DetailViewType::Dag => {
-                // DAG view doesn't support filtering
+            DetailViewType::Summary | DetailViewType::Dag => {
+                // Summary and DAG views don't support filtering
             }
         }
 
@@ -887,8 +940,8 @@ impl App {
                     self.slurm_stats_state.select(Some(0));
                 }
             }
-            DetailViewType::Dag => {
-                // DAG view doesn't support filtering
+            DetailViewType::Summary | DetailViewType::Dag => {
+                // Summary and DAG views don't support filtering
             }
         }
     }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -10,6 +10,8 @@ use ratatui::{
     widgets::{Block, Borders, Cell, Paragraph, Row, Table, Tabs, Wrap},
 };
 
+use crate::models::JobStatus;
+
 use super::app::{App, DetailViewType, Focus, PopupType, WorkflowSummary};
 use super::components::HelpPopup;
 
@@ -492,21 +494,33 @@ const STATUS_LABELS: [&str; 11] = [
     "PendingFailed",
 ];
 
-/// Color for a status, indexed by `JobStatus as usize`. Mirrors the scheme
-/// used by `draw_jobs_table` so the Summary view matches.
-fn status_color_idx(idx: usize) -> Color {
-    match idx {
-        5 => Color::Green,       // Completed
-        4 => Color::Yellow,      // Running
-        6 | 10 => Color::Red,    // Failed, PendingFailed
-        7 | 8 => Color::Magenta, // Canceled, Terminated
-        2 => Color::Cyan,        // Ready
-        1 => Color::DarkGray,    // Blocked
-        3 => Color::Blue,        // Pending
-        9 => Color::DarkGray,    // Disabled
-        _ => Color::White,       // Uninitialized + fallback
+fn status_color(status: JobStatus) -> Color {
+    match status {
+        JobStatus::Completed => Color::Green,
+        JobStatus::Running => Color::Yellow,
+        JobStatus::Failed | JobStatus::PendingFailed => Color::Red,
+        JobStatus::Canceled | JobStatus::Terminated => Color::Magenta,
+        JobStatus::Ready => Color::Cyan,
+        JobStatus::Blocked | JobStatus::Disabled => Color::DarkGray,
+        JobStatus::Pending => Color::Blue,
+        JobStatus::Uninitialized => Color::White,
     }
 }
+
+/// Order of `JobStatus` variants. Indices match `JobStatus as usize`.
+const STATUS_BY_INDEX: [JobStatus; 11] = [
+    JobStatus::Uninitialized,
+    JobStatus::Blocked,
+    JobStatus::Ready,
+    JobStatus::Pending,
+    JobStatus::Running,
+    JobStatus::Completed,
+    JobStatus::Failed,
+    JobStatus::Canceled,
+    JobStatus::Terminated,
+    JobStatus::Disabled,
+    JobStatus::PendingFailed,
+];
 
 /// Compute the high-level status badge text and color for a workflow summary.
 fn summary_badge(s: &WorkflowSummary) -> (&'static str, Color) {
@@ -662,7 +676,7 @@ fn draw_summary(f: &mut Frame, area: Rect, app: &mut App) {
             let filled = ((pct / 100.0) * bar_width as f64).round() as usize;
             let bar: String =
                 "█".repeat(filled.min(bar_width)) + &"░".repeat(bar_width.saturating_sub(filled));
-            let color = status_color_idx(idx);
+            let color = status_color(STATUS_BY_INDEX[idx]);
             Row::new(vec![
                 Cell::from(Span::styled(STATUS_LABELS[idx], Style::default().fg(color))),
                 Cell::from(count.to_string()),
@@ -713,22 +727,9 @@ fn draw_jobs_table(f: &mut Frame, area: Rect, app: &mut App) {
     let rows = app.jobs.iter().map(|job| {
         let id = job.id.map(|i| i.to_string()).unwrap_or_default();
         let name = job.name.clone();
-        let status_str = job
-            .status
-            .as_ref()
-            .map(|s| format!("{:?}", s))
-            .unwrap_or_default();
-
-        // Color the status based on its value
-        let status_color = match status_str.as_str() {
-            "Completed" => Color::Green,
-            "Running" => Color::Yellow,
-            "Failed" => Color::Red,
-            "Canceled" | "Terminated" => Color::Magenta,
-            "Ready" => Color::Cyan,
-            "Blocked" => Color::DarkGray,
-            "Pending" | "Scheduled" => Color::Blue,
-            _ => Color::White,
+        let (status_str, color) = match job.status {
+            Some(s) => (format!("{:?}", s), status_color(s)),
+            None => (String::new(), Color::White),
         };
 
         let command = job.command.clone();
@@ -736,7 +737,7 @@ fn draw_jobs_table(f: &mut Frame, area: Rect, app: &mut App) {
         Row::new(vec![
             Cell::from(id),
             Cell::from(name),
-            Cell::from(Span::styled(status_str, Style::default().fg(status_color))),
+            Cell::from(Span::styled(status_str, Style::default().fg(color))),
             Cell::from(command),
         ])
     });

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -7,10 +7,10 @@ use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Cell, Row, Table, Tabs},
+    widgets::{Block, Borders, Cell, Paragraph, Row, Table, Tabs, Wrap},
 };
 
-use super::app::{App, DetailViewType, Focus, PopupType};
+use super::app::{App, DetailViewType, Focus, PopupType, WorkflowSummary};
 use super::components::HelpPopup;
 
 /// Format a timestamp (milliseconds since epoch) as a human-readable local time string
@@ -433,14 +433,15 @@ fn draw_tabs(f: &mut Frame, area: Rect, app: &App) {
     let titles: Vec<&str> = all_types.iter().map(|t| t.as_str()).collect();
 
     let selected = match app.detail_view {
-        DetailViewType::Jobs => 0,
-        DetailViewType::Files => 1,
-        DetailViewType::Events => 2,
-        DetailViewType::Results => 3,
-        DetailViewType::ComputeNodes => 4,
-        DetailViewType::ScheduledNodes => 5,
-        DetailViewType::SlurmStats => 6,
-        DetailViewType::Dag => 7,
+        DetailViewType::Summary => 0,
+        DetailViewType::Jobs => 1,
+        DetailViewType::Files => 2,
+        DetailViewType::Events => 3,
+        DetailViewType::Results => 4,
+        DetailViewType::ComputeNodes => 5,
+        DetailViewType::ScheduledNodes => 6,
+        DetailViewType::SlurmStats => 7,
+        DetailViewType::Dag => 8,
     };
 
     let tabs = Tabs::new(titles)
@@ -464,6 +465,7 @@ fn draw_tabs(f: &mut Frame, area: Rect, app: &App) {
 
 fn draw_detail_table(f: &mut Frame, area: Rect, app: &mut App) {
     match app.detail_view {
+        DetailViewType::Summary => draw_summary(f, area, app),
         DetailViewType::Jobs => draw_jobs_table(f, area, app),
         DetailViewType::Files => draw_files_table(f, area, app),
         DetailViewType::Events => draw_events_table(f, area, app),
@@ -473,6 +475,227 @@ fn draw_detail_table(f: &mut Frame, area: Rect, app: &mut App) {
         DetailViewType::SlurmStats => draw_slurm_stats_table(f, area, app),
         DetailViewType::Dag => draw_dag(f, area, app),
     }
+}
+
+/// Status display label indexed by `JobStatus as usize`.
+const STATUS_LABELS: [&str; 11] = [
+    "Uninitialized",
+    "Blocked",
+    "Ready",
+    "Pending",
+    "Running",
+    "Completed",
+    "Failed",
+    "Canceled",
+    "Terminated",
+    "Disabled",
+    "PendingFailed",
+];
+
+/// Color for a status, indexed by `JobStatus as usize`. Mirrors the scheme
+/// used by `draw_jobs_table` so the Summary view matches.
+fn status_color_idx(idx: usize) -> Color {
+    match idx {
+        5 => Color::Green,       // Completed
+        4 => Color::Yellow,      // Running
+        6 | 10 => Color::Red,    // Failed, PendingFailed
+        7 | 8 => Color::Magenta, // Canceled, Terminated
+        2 => Color::Cyan,        // Ready
+        1 => Color::DarkGray,    // Blocked
+        3 => Color::Blue,        // Pending
+        9 => Color::DarkGray,    // Disabled
+        _ => Color::White,       // Uninitialized + fallback
+    }
+}
+
+/// Compute the high-level status badge text and color for a workflow summary.
+fn summary_badge(s: &WorkflowSummary) -> (&'static str, Color) {
+    const FAILED: usize = 6;
+    const TERMINATED: usize = 8;
+    const PENDING_FAILED: usize = 10;
+    const RUNNING: usize = 4;
+    const PENDING: usize = 3;
+
+    if s.is_canceled {
+        ("CANCELED", Color::Magenta)
+    } else if s.is_complete {
+        if s.counts[FAILED] > 0 || s.counts[TERMINATED] > 0 || s.counts[PENDING_FAILED] > 0 {
+            ("COMPLETED WITH FAILURES", Color::Red)
+        } else {
+            ("COMPLETED", Color::Green)
+        }
+    } else if s.counts[RUNNING] > 0 || s.counts[PENDING] > 0 {
+        ("RUNNING", Color::Yellow)
+    } else {
+        ("READY", Color::Cyan)
+    }
+}
+
+fn draw_summary(f: &mut Frame, area: Rect, app: &mut App) {
+    let is_focused = app.focus == Focus::Details;
+    let (title, border_style) = if is_focused {
+        (
+            Line::from(vec![
+                Span::styled("◆ ", Style::default().fg(Color::Green)),
+                Span::styled("Summary", Style::default().fg(Color::White)),
+            ]),
+            Style::default().fg(Color::Green),
+        )
+    } else {
+        (
+            Line::from(vec![
+                Span::styled("◆ ", Style::default().fg(Color::Cyan)),
+                Span::styled("Summary", Style::default().fg(Color::White)),
+            ]),
+            Style::default().fg(Color::DarkGray),
+        )
+    };
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(title)
+        .border_style(border_style);
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let Some(summary) = app.summary.clone() else {
+        let p = Paragraph::new(Line::from(Span::styled(
+            "Loading summary…",
+            Style::default().fg(Color::DarkGray),
+        )));
+        f.render_widget(p, inner);
+        return;
+    };
+
+    // Vertical layout: header (3) | progress line (1) | status table (flex) | description (3)
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .margin(1)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Length(1),
+            Constraint::Min(3),
+            Constraint::Length(3),
+        ])
+        .split(inner);
+
+    // --- Header: name / id / user / badge ---
+    let (badge_text, badge_color) = summary_badge(&summary);
+    let mut badge_suffix = String::new();
+    if summary.needs_completion_script {
+        badge_suffix.push_str(" (completion script pending)");
+    }
+
+    let header_lines = vec![
+        Line::from(vec![
+            Span::styled(
+                summary.workflow_name.clone(),
+                Style::default()
+                    .fg(Color::White)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                format!("  #{}  ", summary.workflow_id),
+                Style::default().fg(Color::DarkGray),
+            ),
+            Span::styled(
+                format!("user: {}", summary.workflow_user),
+                Style::default().fg(Color::DarkGray),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("Status: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                badge_text,
+                Style::default()
+                    .fg(badge_color)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(badge_suffix, Style::default().fg(Color::DarkGray)),
+        ]),
+    ];
+    f.render_widget(Paragraph::new(header_lines), chunks[0]);
+
+    // --- Progress line ---
+    let completed = summary.counts[5]; // Completed
+    let progress_ratio = if summary.total_jobs == 0 {
+        0.0
+    } else {
+        completed as f64 / summary.total_jobs as f64
+    };
+    let progress_line = Line::from(vec![
+        Span::styled("Progress: ", Style::default().fg(Color::DarkGray)),
+        Span::styled(
+            format!(
+                "{} / {} jobs ({:.1}%)",
+                completed,
+                summary.total_jobs,
+                progress_ratio * 100.0
+            ),
+            Style::default()
+                .fg(badge_color)
+                .add_modifier(Modifier::BOLD),
+        ),
+    ]);
+    f.render_widget(Paragraph::new(progress_line), chunks[1]);
+
+    // --- Per-status counts table (skip rows with count 0) ---
+    let header_style = Style::default()
+        .fg(Color::Yellow)
+        .add_modifier(Modifier::BOLD);
+    let header = Row::new(vec!["Status", "Count", "Share"])
+        .style(header_style)
+        .bottom_margin(1);
+
+    let rows: Vec<Row> = summary
+        .counts
+        .iter()
+        .enumerate()
+        .filter(|(_, c)| **c > 0)
+        .map(|(idx, count)| {
+            let pct = if summary.total_jobs == 0 {
+                0.0
+            } else {
+                (*count as f64 / summary.total_jobs as f64) * 100.0
+            };
+            let bar_width = 20usize;
+            let filled = ((pct / 100.0) * bar_width as f64).round() as usize;
+            let bar: String =
+                "█".repeat(filled.min(bar_width)) + &"░".repeat(bar_width.saturating_sub(filled));
+            let color = status_color_idx(idx);
+            Row::new(vec![
+                Cell::from(Span::styled(STATUS_LABELS[idx], Style::default().fg(color))),
+                Cell::from(count.to_string()),
+                Cell::from(Span::styled(
+                    format!("{}  {:>5.1}%", bar, pct),
+                    Style::default().fg(color),
+                )),
+            ])
+        })
+        .collect();
+
+    let counts_table = Table::new(
+        rows,
+        [
+            Constraint::Length(16),
+            Constraint::Length(8),
+            Constraint::Percentage(100),
+        ],
+    )
+    .header(header);
+    f.render_widget(counts_table, chunks[2]);
+
+    // --- Description (optional) ---
+    let desc_text = summary.description.unwrap_or_else(|| "—".to_string());
+    let desc = Paragraph::new(vec![
+        Line::from(Span::styled(
+            "Description",
+            Style::default().fg(Color::Yellow),
+        )),
+        Line::from(Span::styled(desc_text, Style::default().fg(Color::White))),
+    ])
+    .wrap(Wrap { trim: true });
+    f.render_widget(desc, chunks[3]);
 }
 
 fn draw_jobs_table(f: &mut Frame, area: Rect, app: &mut App) {

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -558,7 +558,7 @@ fn draw_summary(f: &mut Frame, area: Rect, app: &mut App) {
     let inner = block.inner(area);
     f.render_widget(block, area);
 
-    let Some(summary) = app.summary.clone() else {
+    let Some(summary) = app.summary.as_ref() else {
         let p = Paragraph::new(Line::from(Span::styled(
             "Loading summary…",
             Style::default().fg(Color::DarkGray),
@@ -580,7 +580,7 @@ fn draw_summary(f: &mut Frame, area: Rect, app: &mut App) {
         .split(inner);
 
     // --- Header: name / id / user / badge ---
-    let (badge_text, badge_color) = summary_badge(&summary);
+    let (badge_text, badge_color) = summary_badge(summary);
     let mut badge_suffix = String::new();
     if summary.needs_completion_script {
         badge_suffix.push_str(" (completion script pending)");
@@ -686,7 +686,7 @@ fn draw_summary(f: &mut Frame, area: Rect, app: &mut App) {
     f.render_widget(counts_table, chunks[2]);
 
     // --- Description (optional) ---
-    let desc_text = summary.description.unwrap_or_else(|| "—".to_string());
+    let desc_text = summary.description.as_deref().unwrap_or("—");
     let desc = Paragraph::new(vec![
         Line::from(Span::styled(
             "Description",


### PR DESCRIPTION
I have some torc workflows with thousands of jobs and while `torc status` works well for giving a high level overview of how many jobs have completed and how many still need to be run, I found myself wanting this information in the TUI as well. This is a proposal to include a new Summary pane that breaks down the jobs by status and gives an overall level of progress:

<img width="859" height="499" alt="image" src="https://github.com/user-attachments/assets/0e744f5f-b42f-4587-9a03-7a59da954cad" />
