### PR TITLE
Add recover and dry-run actions to the TUI

### DIFF
--- a/docs/src/core/monitoring/tui.md
+++ b/docs/src/core/monitoring/tui.md
@@ -97,7 +97,9 @@ Select a workflow and use these keys:
 | `C` | Cancel        | Cancel running workflow                                 |
 | `d` | Delete        | Delete workflow (destructive!)                          |
 
-All destructive actions show a confirmation dialog.
+Most destructive actions show a yes/no confirmation dialog. Recovery (`V`) is gated by the
+multiplier prompt modal instead — pressing Enter in that modal both applies the multipliers and
+confirms the recovery (Esc cancels).
 
 ### Recovery Prompt
 

--- a/docs/src/core/monitoring/tui.md
+++ b/docs/src/core/monitoring/tui.md
@@ -91,10 +91,20 @@ Select a workflow and use these keys:
 | `R` | Reset         | Reset all job statuses                                  |
 | `x` | Run           | Run workflow locally (shows real-time output)           |
 | `s` | Submit        | Submit to HPC scheduler (Slurm)                         |
+| `W` | Watch         | Watch workflow with auto-recovery (live output)         |
+| `V` | Recover       | One-shot recovery: bump resources and resubmit failures |
+| `v` | Recover (dry) | Preview recovery without applying changes               |
 | `C` | Cancel        | Cancel running workflow                                 |
 | `d` | Delete        | Delete workflow (destructive!)                          |
 
 All destructive actions show a confirmation dialog.
+
+### Recovery Prompt
+
+Pressing `V` or `v` opens a small modal that pre-fills the default `--memory-multiplier` (1.5) and
+`--runtime-multiplier` (1.4). Tab switches between the two fields, Enter applies them and launches
+the recovery (Esc cancels). The modal accepts only digits and a single decimal point; invalid input
+is reported inline.
 
 ### Handling Existing Output Files
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -150,6 +150,18 @@ where
                         }
                         _ => {}
                     },
+                    Some(PopupType::RecoverPrompt { .. }) => match key.code {
+                        KeyCode::Esc => app.recover_prompt_cancel(),
+                        KeyCode::Tab | KeyCode::BackTab | KeyCode::Up | KeyCode::Down => {
+                            app.recover_prompt_toggle_field();
+                        }
+                        KeyCode::Backspace => app.recover_prompt_backspace(),
+                        KeyCode::Enter => {
+                            let _ = app.recover_prompt_submit();
+                        }
+                        KeyCode::Char(c) => app.recover_prompt_add_char(c),
+                        _ => {}
+                    },
                     Some(PopupType::JobDetails(_)) => match key.code {
                         KeyCode::Char('q') | KeyCode::Esc => app.close_popup(),
                         KeyCode::Char('l') => {
@@ -480,8 +492,8 @@ where
                     KeyCode::Char(c) => app.add_output_dir_char(c),
                     _ => {}
                 },
-                Focus::Popup => {
-                    // Handled above
+                Focus::Popup | Focus::RecoverPrompt => {
+                    // Handled above (popup-specific match)
                 }
                 Focus::Workflows | Focus::Details => match key.code {
                     KeyCode::Char('q') => return Ok(()),
@@ -572,6 +584,12 @@ where
                     }
                     KeyCode::Char('W') => {
                         app.request_workflow_action(WorkflowAction::Watch);
+                    }
+                    KeyCode::Char('V') => {
+                        app.request_workflow_action(WorkflowAction::Recover);
+                    }
+                    KeyCode::Char('v') => {
+                        app.request_workflow_action(WorkflowAction::RecoverDryRun);
                     }
                     // Server management
                     KeyCode::Char('S') => {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -23,7 +23,7 @@ use crate::client::config::TorcConfig;
 use super::api::TorcClient;
 use super::components::{
     ConfirmationDialog, ErrorDialog, FileViewer, JobDetailsPopup, LogViewer, ProcessViewer,
-    StatusMessage,
+    RecoverPromptDialog, StatusMessage,
 };
 use super::dag::{DagLayout, JobNode};
 
@@ -50,8 +50,10 @@ pub enum WorkflowAction {
     Reset,
     Run,
     Submit,
-    Watch,       // Watch workflow with recovery
-    WatchNoAuto, // Watch workflow without recovery
+    Watch,         // Watch workflow with recovery
+    WatchNoAuto,   // Watch workflow without recovery
+    Recover,       // One-shot recovery: adjust resources and resubmit failed jobs
+    RecoverDryRun, // Preview what recovery would do without applying changes
     Delete,
     Cancel,
 }
@@ -84,6 +86,19 @@ impl WorkflowAction {
                 "Watch workflow '{}'?\nThis will monitor without automatic recovery.",
                 workflow_name
             ),
+            Self::Recover => format!(
+                "Recover workflow '{}'?\n\
+                 Diagnoses failures, increases memory/runtime for OOM/timeout jobs, \
+                 resets failed jobs, and resubmits Slurm allocations.\n\
+                 Workflow must be complete with no active workers.",
+                workflow_name
+            ),
+            Self::RecoverDryRun => format!(
+                "Preview recovery for workflow '{}'?\n\
+                 Shows the proposed resource adjustments and Slurm scheduler plan \
+                 without making any changes.",
+                workflow_name
+            ),
             Self::Delete => format!(
                 "DELETE workflow '{}'?\nThis action cannot be undone!",
                 workflow_name
@@ -100,6 +115,7 @@ impl WorkflowAction {
                 | Self::Reinitialize
                 | Self::ReinitializeForce
                 | Self::InitializeForce
+                | Self::Recover
         )
     }
 
@@ -114,6 +130,8 @@ impl WorkflowAction {
             Self::Submit => "Submit Workflow",
             Self::Watch => "Watch Workflow (Auto-Recovery)",
             Self::WatchNoAuto => "Watch Workflow",
+            Self::Recover => "Recover Workflow",
+            Self::RecoverDryRun => "Recover Workflow (Dry Run)",
             Self::Delete => "Delete Workflow",
             Self::Cancel => "Cancel Workflow",
         }
@@ -148,6 +166,12 @@ pub enum PopupType {
     Confirmation {
         dialog: ConfirmationDialog,
         action: PendingAction,
+    },
+    RecoverPrompt {
+        dialog: RecoverPromptDialog,
+        workflow_id: i64,
+        workflow_name: String,
+        dry_run: bool,
     },
     Error(ErrorDialog),
 }
@@ -225,6 +249,7 @@ pub enum Focus {
     ServerUrlInput,
     WorkflowPathInput,
     OutputDirInput,
+    RecoverPrompt,
     Popup,
 }
 
@@ -606,6 +631,7 @@ impl App {
             Focus::ServerUrlInput => Focus::ServerUrlInput,
             Focus::WorkflowPathInput => Focus::WorkflowPathInput,
             Focus::OutputDirInput => Focus::OutputDirInput,
+            Focus::RecoverPrompt => Focus::RecoverPrompt,
             Focus::Popup => Focus::Popup,
         };
     }
@@ -651,6 +677,7 @@ impl App {
             | Focus::ServerUrlInput
             | Focus::WorkflowPathInput
             | Focus::OutputDirInput
+            | Focus::RecoverPrompt
             | Focus::Popup => {}
         }
     }
@@ -693,6 +720,7 @@ impl App {
             | Focus::ServerUrlInput
             | Focus::WorkflowPathInput
             | Focus::OutputDirInput
+            | Focus::RecoverPrompt
             | Focus::Popup => {}
         }
     }
@@ -740,6 +768,7 @@ impl App {
             | Focus::ServerUrlInput
             | Focus::WorkflowPathInput
             | Focus::OutputDirInput
+            | Focus::RecoverPrompt
             | Focus::Popup => {}
         }
     }
@@ -786,6 +815,7 @@ impl App {
             | Focus::ServerUrlInput
             | Focus::WorkflowPathInput
             | Focus::OutputDirInput
+            | Focus::RecoverPrompt
             | Focus::Popup => {}
         }
     }
@@ -822,6 +852,7 @@ impl App {
             | Focus::ServerUrlInput
             | Focus::WorkflowPathInput
             | Focus::OutputDirInput
+            | Focus::RecoverPrompt
             | Focus::Popup => {}
         }
     }
@@ -858,6 +889,7 @@ impl App {
             | Focus::ServerUrlInput
             | Focus::WorkflowPathInput
             | Focus::OutputDirInput
+            | Focus::RecoverPrompt
             | Focus::Popup => {}
         }
     }
@@ -1873,6 +1905,19 @@ impl App {
         if let Some(workflow) = self.get_selected_workflow() {
             if let Some(workflow_id) = workflow.id {
                 let workflow_name = workflow.name.clone();
+
+                // Recover actions skip the standard yes/no confirmation
+                // and use a dedicated prompt that collects multipliers.
+                // The prompt itself acts as the confirmation gate.
+                if matches!(
+                    action,
+                    WorkflowAction::Recover | WorkflowAction::RecoverDryRun
+                ) {
+                    let dry_run = action == WorkflowAction::RecoverDryRun;
+                    self.open_recover_prompt(workflow_id, &workflow_name, dry_run);
+                    return;
+                }
+
                 let dialog = ConfirmationDialog::new(
                     action.title(),
                     &action.confirmation_message(&workflow_name),
@@ -1966,6 +2011,8 @@ impl App {
             WorkflowAction::Run => unreachable!(),        // Handled above
             WorkflowAction::Watch => unreachable!(),      // Handled above
             WorkflowAction::WatchNoAuto => unreachable!(), // Handled above
+            WorkflowAction::Recover => unreachable!(),    // Handled above
+            WorkflowAction::RecoverDryRun => unreachable!(), // Handled above
             WorkflowAction::Submit => self.client.submit_workflow(workflow_id),
             WorkflowAction::Delete => self.client.delete_workflow(workflow_id),
             WorkflowAction::Cancel => self.client.cancel_workflow(workflow_id),
@@ -1982,6 +2029,8 @@ impl App {
                     WorkflowAction::Run => unreachable!(),
                     WorkflowAction::Watch => unreachable!(),
                     WorkflowAction::WatchNoAuto => unreachable!(),
+                    WorkflowAction::Recover => unreachable!(),
+                    WorkflowAction::RecoverDryRun => unreachable!(),
                     WorkflowAction::Submit => {
                         format!("Workflow '{}' submitted to scheduler", workflow_name)
                     }
@@ -2399,6 +2448,159 @@ impl App {
         }
 
         Ok(())
+    }
+
+    fn recover_workflow_with_viewer(
+        &mut self,
+        workflow_id: i64,
+        workflow_name: &str,
+        dry_run: bool,
+        memory_multiplier: f64,
+        runtime_multiplier: f64,
+    ) -> Result<()> {
+        let title = if dry_run {
+            format!("Recover (dry run): {}", workflow_name)
+        } else {
+            format!("Recovering: {}", workflow_name)
+        };
+        let mut viewer = ProcessViewer::new(title);
+
+        let exe_path = self.get_torc_exe_path();
+        let workflow_id_str = workflow_id.to_string();
+        let url = self.client.get_base_url();
+        let output_dir = self.output_dir.display().to_string();
+        let mem_str = format!("{}", memory_multiplier);
+        let rt_str = format!("{}", runtime_multiplier);
+
+        // --no-prompts is required because the interactive wizard would
+        // try to read from stdin, which the TUI owns.
+        let mut args = vec![
+            "--url",
+            &url,
+            "recover",
+            &workflow_id_str,
+            "--output-dir",
+            &output_dir,
+            "--memory-multiplier",
+            &mem_str,
+            "--runtime-multiplier",
+            &rt_str,
+            "--no-prompts",
+        ];
+        if dry_run {
+            args.push("--dry-run");
+        }
+
+        match viewer.start(&exe_path, &args) {
+            Ok(()) => {
+                self.previous_focus = self.focus;
+                self.focus = Focus::Popup;
+                self.popup = Some(PopupType::ProcessViewer(viewer));
+                let msg = if dry_run {
+                    format!("Previewing recovery for '{}'...", workflow_name)
+                } else {
+                    format!("Recovering workflow '{}'...", workflow_name)
+                };
+                self.set_status(StatusMessage::info(&msg));
+            }
+            Err(e) => {
+                self.set_status(StatusMessage::error(&format!(
+                    "Failed to start recovery: {}",
+                    e
+                )));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Open the multiplier-input modal that gates the actual `torc recover`
+    /// subprocess launch.
+    pub fn open_recover_prompt(&mut self, workflow_id: i64, workflow_name: &str, dry_run: bool) {
+        let title = if dry_run {
+            format!(" Recover '{}' (dry run) ", workflow_name)
+        } else {
+            format!(" Recover '{}' ", workflow_name)
+        };
+        let message = if dry_run {
+            "Preview proposed resource adjustments without applying them.".to_string()
+        } else {
+            "Bumps memory/runtime for OOM/timeout jobs, resets failed jobs, \
+             and resubmits Slurm allocations."
+                .to_string()
+        };
+
+        let dialog = RecoverPromptDialog::new(&title, &message, !dry_run);
+        self.previous_focus = self.focus;
+        self.focus = Focus::RecoverPrompt;
+        self.popup = Some(PopupType::RecoverPrompt {
+            dialog,
+            workflow_id,
+            workflow_name: workflow_name.to_string(),
+            dry_run,
+        });
+    }
+
+    pub fn recover_prompt_add_char(&mut self, c: char) {
+        if let Some(PopupType::RecoverPrompt { dialog, .. }) = self.popup.as_mut() {
+            dialog.add_char(c);
+        }
+    }
+
+    pub fn recover_prompt_backspace(&mut self) {
+        if let Some(PopupType::RecoverPrompt { dialog, .. }) = self.popup.as_mut() {
+            dialog.backspace();
+        }
+    }
+
+    pub fn recover_prompt_toggle_field(&mut self) {
+        if let Some(PopupType::RecoverPrompt { dialog, .. }) = self.popup.as_mut() {
+            dialog.toggle_field();
+        }
+    }
+
+    pub fn recover_prompt_cancel(&mut self) {
+        if matches!(self.popup, Some(PopupType::RecoverPrompt { .. })) {
+            self.popup = None;
+            self.focus = self.previous_focus;
+        }
+    }
+
+    pub fn recover_prompt_submit(&mut self) -> Result<()> {
+        // Parse first; if invalid, attach the error to the dialog and keep
+        // the modal open.
+        let parsed = if let Some(PopupType::RecoverPrompt { dialog, .. }) = self.popup.as_mut() {
+            match dialog.parse() {
+                Ok(values) => Some(values),
+                Err(err) => {
+                    dialog.set_error(err);
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        let Some((mem, rt)) = parsed else {
+            return Ok(());
+        };
+
+        // Take ownership of the popup so we can drop it before launching
+        // the subprocess (which installs its own popup).
+        let (workflow_id, workflow_name, dry_run) = if let Some(PopupType::RecoverPrompt {
+            workflow_id,
+            workflow_name,
+            dry_run,
+            ..
+        }) = self.popup.take()
+        {
+            (workflow_id, workflow_name, dry_run)
+        } else {
+            return Ok(());
+        };
+
+        self.focus = self.previous_focus;
+        self.recover_workflow_with_viewer(workflow_id, &workflow_name, dry_run, mem, rt)
     }
 
     // === Job Actions ===

--- a/src/tui/components.rs
+++ b/src/tui/components.rs
@@ -297,14 +297,20 @@ impl RecoverPromptDialog {
         } else {
             Style::default().fg(Color::Cyan)
         };
-        let cursor = if active { "_" } else { " " };
+        // The input buffer is capped at 8 chars; when active we render a cursor
+        // glyph in place of the trailing character so the field always occupies
+        // exactly 8 columns inside the brackets.
+        let display_value = if active {
+            let mut visible: String = value.chars().take(7).collect();
+            visible.push('_');
+            visible
+        } else {
+            value.to_string()
+        };
         Line::from(vec![
             Span::styled(label.to_string(), Style::default().fg(Color::White)),
             Span::raw("["),
-            Span::styled(
-                format!("{:<8}", format!("{}{}", value, cursor)),
-                value_style,
-            ),
+            Span::styled(format!("{:<8}", display_value), value_style),
             Span::raw("]"),
         ])
     }

--- a/src/tui/components.rs
+++ b/src/tui/components.rs
@@ -115,6 +115,201 @@ impl ConfirmationDialog {
     }
 }
 
+/// A small modal that asks the user for the two recovery multipliers
+/// (memory and runtime) before launching `torc recover`. The modal also
+/// serves as the confirmation gate: pressing Enter applies, Esc cancels.
+#[derive(Debug, Clone)]
+pub struct RecoverPromptDialog {
+    pub title: String,
+    pub message: String,
+    pub memory_input: String,
+    pub runtime_input: String,
+    /// 0 = memory field, 1 = runtime field
+    pub active_field: u8,
+    /// Validation error to show under the inputs (e.g. unparseable number)
+    pub error: Option<String>,
+    pub is_destructive: bool,
+}
+
+impl RecoverPromptDialog {
+    pub fn new(title: &str, message: &str, is_destructive: bool) -> Self {
+        Self {
+            title: title.to_string(),
+            message: message.to_string(),
+            memory_input: "1.5".to_string(),
+            runtime_input: "1.4".to_string(),
+            active_field: 0,
+            error: None,
+            is_destructive,
+        }
+    }
+
+    pub fn toggle_field(&mut self) {
+        self.active_field = 1 - self.active_field;
+    }
+
+    fn active_buf_mut(&mut self) -> &mut String {
+        if self.active_field == 0 {
+            &mut self.memory_input
+        } else {
+            &mut self.runtime_input
+        }
+    }
+
+    pub fn add_char(&mut self, c: char) {
+        // Allow only digits and a single decimal point.
+        if c.is_ascii_digit() || c == '.' {
+            let buf = self.active_buf_mut();
+            if c == '.' && buf.contains('.') {
+                return;
+            }
+            if buf.len() < 8 {
+                buf.push(c);
+            }
+            self.error = None;
+        }
+    }
+
+    pub fn backspace(&mut self) {
+        self.active_buf_mut().pop();
+        self.error = None;
+    }
+
+    /// Parse the two fields. Returns (memory_multiplier, runtime_multiplier)
+    /// or an error message suitable for inline display.
+    pub fn parse(&self) -> Result<(f64, f64), String> {
+        let mem = self
+            .memory_input
+            .parse::<f64>()
+            .map_err(|_| format!("Invalid memory multiplier: '{}'", self.memory_input))?;
+        let rt = self
+            .runtime_input
+            .parse::<f64>()
+            .map_err(|_| format!("Invalid runtime multiplier: '{}'", self.runtime_input))?;
+        if mem <= 0.0 || rt <= 0.0 {
+            return Err("Multipliers must be greater than 0".to_string());
+        }
+        Ok((mem, rt))
+    }
+
+    pub fn set_error(&mut self, message: String) {
+        self.error = Some(message);
+    }
+
+    pub fn render(&self, f: &mut Frame, area: Rect) {
+        let dialog_width = 60.min(area.width.saturating_sub(4));
+        let dialog_height = 12.min(area.height.saturating_sub(2));
+
+        let dialog_x = (area.width.saturating_sub(dialog_width)) / 2;
+        let dialog_y = (area.height.saturating_sub(dialog_height)) / 2;
+        let dialog_area = Rect::new(dialog_x, dialog_y, dialog_width, dialog_height);
+
+        f.render_widget(Clear, dialog_area);
+
+        let border_color = if self.is_destructive {
+            Color::Red
+        } else {
+            Color::Yellow
+        };
+
+        let block = Block::default()
+            .title(self.title.as_str())
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(border_color));
+        let inner = block.inner(dialog_area);
+        f.render_widget(block, dialog_area);
+
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Min(2),    // Message
+                Constraint::Length(1), // Memory field
+                Constraint::Length(1), // Runtime field
+                Constraint::Length(1), // Error / spacer
+                Constraint::Length(1), // Hints
+            ])
+            .split(inner);
+
+        let message = Paragraph::new(self.message.as_str())
+            .style(Style::default().fg(Color::White))
+            .alignment(Alignment::Center)
+            .wrap(Wrap { trim: true });
+        f.render_widget(message, chunks[0]);
+
+        let mem_line = Self::field_line(
+            "Memory multiplier  ",
+            &self.memory_input,
+            self.active_field == 0,
+        );
+        let rt_line = Self::field_line(
+            "Runtime multiplier ",
+            &self.runtime_input,
+            self.active_field == 1,
+        );
+        f.render_widget(
+            Paragraph::new(mem_line).alignment(Alignment::Center),
+            chunks[1],
+        );
+        f.render_widget(
+            Paragraph::new(rt_line).alignment(Alignment::Center),
+            chunks[2],
+        );
+
+        if let Some(ref err) = self.error {
+            let err_line = Paragraph::new(Line::from(Span::styled(
+                err.clone(),
+                Style::default().fg(Color::Red),
+            )))
+            .alignment(Alignment::Center);
+            f.render_widget(err_line, chunks[3]);
+        }
+
+        let confirm_color = if self.is_destructive {
+            Color::Red
+        } else {
+            Color::Green
+        };
+        let hints = Line::from(vec![
+            Span::styled("Tab", Style::default().fg(Color::Yellow)),
+            Span::raw(": switch field | "),
+            Span::styled(
+                "Enter",
+                Style::default()
+                    .fg(confirm_color)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(": apply | "),
+            Span::styled("Esc", Style::default().fg(Color::DarkGray)),
+            Span::raw(": cancel"),
+        ]);
+        f.render_widget(
+            Paragraph::new(hints).alignment(Alignment::Center),
+            chunks[4],
+        );
+    }
+
+    fn field_line(label: &str, value: &str, active: bool) -> Line<'static> {
+        let value_style = if active {
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::Cyan)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(Color::Cyan)
+        };
+        let cursor = if active { "_" } else { " " };
+        Line::from(vec![
+            Span::styled(label.to_string(), Style::default().fg(Color::White)),
+            Span::raw("["),
+            Span::styled(
+                format!("{:<8}", format!("{}{}", value, cursor)),
+                value_style,
+            ),
+            Span::raw("]"),
+        ])
+    }
+}
+
 /// Status message types for the status bar
 #[derive(Debug, Clone, PartialEq)]
 pub enum StatusLevel {
@@ -330,6 +525,8 @@ impl HelpPopup {
                 lines.push(Self::key_line("x", "Run workflow locally"));
                 lines.push(Self::key_line("s", "Submit workflow to scheduler"));
                 lines.push(Self::key_line("W", "Watch workflow (recovery)"));
+                lines.push(Self::key_line("V", "Recover workflow (one-shot)"));
+                lines.push(Self::key_line("v", "Preview recovery (dry run)"));
                 lines.push(Self::key_line("d", "Delete workflow"));
                 lines.push(Self::key_line(
                     "C",

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -146,6 +146,9 @@ pub fn draw(f: &mut Frame, app: &mut App) {
             PopupType::Confirmation { dialog, .. } => {
                 dialog.render(f, f.area());
             }
+            PopupType::RecoverPrompt { dialog, .. } => {
+                dialog.render(f, f.area());
+            }
             PopupType::JobDetails(details) => {
                 details.render(f, f.area());
             }


### PR DESCRIPTION
Press V to recover a workflow or v to preview (--dry-run). Both open a small centered modal pre-filled with the CLI defaults (1.5x memory, 1.4x runtime) where Tab switches fields, Enter applies, Esc cancels. The modal validates input inline and is the destructive-action gate (red border for V, yellow for v) — no second confirmation. After Enter the existing ProcessViewer streams the spawned `torc recover` output; --no-prompts is forced because the interactive wizard would compete with the TUI for stdin.