### PR TITLE
Remove dead workflows_with_failures branch in transport_update_workflow

### DIFF
--- a/src/server/http_server/workflows_transport.rs
+++ b/src/server/http_server/workflows_transport.rs
@@ -414,11 +414,6 @@ where
         context: &C,
     ) -> Result<UpdateWorkflowResponse, ApiError> {
         authorize_workflow!(self, id, context, UpdateWorkflowResponse);
-        if body.is_archived == Some(true)
-            && let Ok(mut set) = self.workflows_with_failures.write()
-        {
-            set.remove(&id);
-        }
         self.workflows_api.update_workflow(id, body, context).await
     }
 


### PR DESCRIPTION
After #300 made is_archived read-only on update_workflow, this branch can never fire — body.is_archived is documented and emitted as readOnly, so any client value is silently ignored, and update_workflow no longer mutates the column. The cleanup is now reachable via transport_archive_workflow, which is the only path that can set is_archived = true.