### PR TITLE
Add --metadata to ro-crate add-dataset and export TORC_RUN_ID

### DIFF
--- a/docs/src/core/how-to/ro-crate-metadata.md
+++ b/docs/src/core/how-to/ro-crate-metadata.md
@@ -238,6 +238,38 @@ Computing dataset statistics for: output/results.parquet/ (using 8 threads)
 Created RO-Crate Dataset entity with ID: 42
 ```
 
+### Linking the Dataset to its Provenance Job
+
+Use `--metadata` to merge extra JSON-LD fields into the entity. The most common use is connecting
+the dataset to the job that produced it via `prov:wasGeneratedBy`, which references the
+`CreateAction` entity Torc emits for each job attempt (`#job-{job_id}-attempt-{attempt_id}`).
+
+When this command runs from inside a job, every job has the
+[`TORC_WORKFLOW_ID`, `TORC_RUN_ID`, `TORC_JOB_ID`, and `TORC_ATTEMPT_ID`](../reference/environment-variables.md)
+environment variables set, so the entity can be wired up automatically:
+
+```bash
+torc ro-crate add-dataset "${TORC_WORKFLOW_ID}" \
+  --name simulation_results \
+  --path output/results.parquet/ \
+  --metadata "{
+    \"prov:wasGeneratedBy\": {\"@id\": \"#job-${TORC_JOB_ID}-attempt-${TORC_ATTEMPT_ID}\"},
+    \"prov:wasAttributedTo\": {\"@id\": \"#torc-run-id-${TORC_RUN_ID}\"}
+  }"
+```
+
+The argument must be a JSON object. Its top-level fields are applied as a shallow merge over the
+auto-computed metadata: user-supplied keys replace the auto-generated ones (`@id`, `@type`, `name`,
+`contentSize`, ...) entirely on conflict, and nested objects are not deep-merged. Pass `-` to read
+the JSON from stdin for larger blobs:
+
+```bash
+torc ro-crate add-dataset "${TORC_WORKFLOW_ID}" \
+  --name simulation_results \
+  --path output/results.parquet/ \
+  --metadata - < dataset_provenance.json
+```
+
 ### When to Use add-dataset vs create
 
 | Scenario                       | Command       |

--- a/docs/src/core/reference/cli.md
+++ b/docs/src/core/reference/cli.md
@@ -204,7 +204,8 @@ resource requirements, and resubmits jobs.
   `1.5`
 - `--retry-unknown` — Also retry jobs with unknown failure causes (not just OOM or timeout)
 - `--recovery-hook <RECOVERY_HOOK>` — Custom recovery script for unknown failures. The workflow ID
-  is passed as an argument and via `TORC_WORKFLOW_ID` environment variable.
+  is passed as the final argument; the hook also receives `TORC_WORKFLOW_ID`, `TORC_RUN_ID`, and
+  `TORC_API_URL` in its environment.
 
 **Auto-scheduling:**
 

--- a/docs/src/core/reference/environment-variables.md
+++ b/docs/src/core/reference/environment-variables.md
@@ -21,6 +21,24 @@ mkdir -p "/data/results/workflow_${TORC_WORKFLOW_ID}"
 echo "Processing data..." > "/data/results/workflow_${TORC_WORKFLOW_ID}/output.txt"
 ```
 
+### TORC_RUN_ID
+
+The current run number for the workflow. Starts at 1 and increments each time the workflow is
+restarted (`torc workflows restart`).
+
+- **Type**: Integer (provided as string)
+- **Example**: `"1"` (first run), `"2"` (after first restart), etc.
+- **Use case**: Tag outputs or RO-Crate provenance entities by run, segregate per-run output
+  directories, or reference the run-scoped Torc entities (`#torc-run-id-{N}`)
+
+```bash
+# Example: Link a Dataset entity to the current run's provenance graph
+torc ro-crate add-dataset "${TORC_WORKFLOW_ID}" \
+  --name "${TORC_JOB_NAME}_output" \
+  --path "output/${TORC_JOB_NAME}/" \
+  --metadata "{\"prov:wasAttributedTo\": {\"@id\": \"#torc-run-id-${TORC_RUN_ID}\"}}"
+```
+
 ### TORC_JOB_ID
 
 The unique identifier of the currently executing job.
@@ -161,6 +179,7 @@ jobs:
 
       echo "=== Job Environment ==="
       echo "Workflow ID: ${TORC_WORKFLOW_ID}"
+      echo "Run ID: ${TORC_RUN_ID}"
       echo "Job ID: ${TORC_JOB_ID}"
       echo "Job Name: ${TORC_JOB_NAME}"
       echo "Attempt: ${TORC_ATTEMPT_ID}"
@@ -182,6 +201,7 @@ jobs:
 | Variable           | Type    | Available In           | Description                         |
 | ------------------ | ------- | ---------------------- | ----------------------------------- |
 | `TORC_WORKFLOW_ID` | Integer | Jobs, Recovery Scripts | Workflow identifier                 |
+| `TORC_RUN_ID`      | Integer | Jobs, Recovery Scripts | Workflow run number (1, 2, 3...)    |
 | `TORC_JOB_ID`      | Integer | Jobs, Recovery Scripts | Job identifier                      |
 | `TORC_JOB_NAME`    | String  | Jobs, Recovery Scripts | Job name from workflow spec         |
 | `TORC_API_URL`     | URL     | Jobs, Recovery Scripts | Torc server API endpoint            |

--- a/src/client/async_cli_command.rs
+++ b/src/client/async_cli_command.rs
@@ -244,6 +244,7 @@ impl AsyncCliCommand {
         let job_id_str = self.job_id.to_string();
         let workflow_id_str = workflow_id.to_string();
         let attempt_id_str = attempt_id.to_string();
+        let run_id_str = run_id.to_string();
 
         // Create output directory for stdio files (unless we're not capturing anything)
         if *stdio_mode != StdioMode::None {
@@ -361,6 +362,7 @@ impl AsyncCliCommand {
 
         let child = cmd
             .env("TORC_WORKFLOW_ID", workflow_id_str)
+            .env("TORC_RUN_ID", run_id_str)
             .env("TORC_JOB_ID", job_id_str)
             .env("TORC_JOB_NAME", &self.job.name)
             .env("TORC_OUTPUT_DIR", output_dir.to_string_lossy().to_string())

--- a/src/client/commands/recover.rs
+++ b/src/client/commands/recover.rs
@@ -360,7 +360,7 @@ pub fn recover_workflow(
             "{} job(s) with unknown failure cause - running recovery hook...",
             result.other_failures
         );
-        run_recovery_hook(args.workflow_id, hook_cmd)?;
+        run_recovery_hook(config, args.workflow_id, hook_cmd)?;
     }
 
     // Check if there are any jobs to retry
@@ -843,7 +843,11 @@ pub fn reinitialize_workflow(config: &Configuration, workflow_id: i64) -> Result
 }
 
 /// Run the user's custom recovery hook command
-pub fn run_recovery_hook(workflow_id: i64, hook_command: &str) -> Result<(), String> {
+pub fn run_recovery_hook(
+    config: &Configuration,
+    workflow_id: i64,
+    hook_command: &str,
+) -> Result<(), String> {
     info!("Running recovery hook: {}", hook_command);
 
     // Parse the command using shell-like quoting rules
@@ -871,8 +875,23 @@ pub fn run_recovery_hook(workflow_id: i64, hook_command: &str) -> Result<(), Str
     // Add workflow ID as final argument
     cmd.arg(workflow_id.to_string());
 
-    // Also set as environment variable for convenience
+    // Mirror the env surface JobRunner exposes to per-job recovery scripts so
+    // workflow-level hooks can also tag artifacts by run and call the API.
+    // Best-effort fetch of run_id: if the lookup fails we still run the hook
+    // with TORC_WORKFLOW_ID + TORC_API_URL set; we just skip TORC_RUN_ID.
     cmd.env("TORC_WORKFLOW_ID", workflow_id.to_string());
+    cmd.env("TORC_API_URL", &config.base_path);
+    match apis::workflows_api::get_workflow(config, workflow_id) {
+        Ok(workflow) => {
+            cmd.env("TORC_RUN_ID", workflow.run_id.unwrap_or(0).to_string());
+        }
+        Err(e) => {
+            warn!(
+                "Failed to fetch workflow_id={} for recovery hook env: {} - TORC_RUN_ID will not be set",
+                workflow_id, e
+            );
+        }
+    }
 
     let output = cmd
         .output()
@@ -1461,7 +1480,7 @@ fn recover_workflow_interactive(
         && let Some(ref hook_cmd) = args.recovery_hook
     {
         info!("Running recovery hook...");
-        run_recovery_hook(args.workflow_id, hook_cmd)?;
+        run_recovery_hook(config, args.workflow_id, hook_cmd)?;
     }
 
     // Reset failed jobs

--- a/src/client/commands/ro_crate.rs
+++ b/src/client/commands/ro_crate.rs
@@ -105,6 +105,11 @@ pub enum RoCrateCommands {
     /// Creates an RO-Crate Dataset entity representing a directory of files,
     /// such as a hive-partitioned Parquet dataset. Computes file count, total
     /// size, and optionally a manifest or content hash.
+    ///
+    /// Use `--metadata` to add JSON-LD fields to the entity, such as
+    /// `prov:wasGeneratedBy` to link the dataset to the job that created it.
+    /// The merge is shallow at the top level: user-supplied keys replace
+    /// auto-computed ones entirely (no deep object merge).
     #[command(name = "add-dataset")]
     AddDataset {
         /// Workflow ID (optional - will prompt if not provided)
@@ -128,6 +133,15 @@ pub enum RoCrateCommands {
         /// Number of threads for parallel processing (default: number of CPUs)
         #[arg(long, short = 't')]
         threads: Option<usize>,
+        /// Extra JSON-LD metadata applied as a top-level merge over the
+        /// entity (or "-" to read from stdin). Must be a JSON object. The
+        /// merge is shallow: each user-supplied top-level field replaces the
+        /// auto-computed one with the same key (`@id`, `@type`, `name`,
+        /// `contentSize`, ...) entirely; nested objects are not deep-merged.
+        ///
+        /// Example: `--metadata '{"prov:wasGeneratedBy": {"@id": "#job-42-attempt-1"}}'`
+        #[arg(long)]
+        metadata: Option<String>,
     },
 }
 
@@ -343,12 +357,14 @@ pub fn handle_ro_crate_commands(config: &Configuration, command: &RoCrateCommand
             description,
             encoding_format,
             threads,
+            metadata,
         } => {
             let user_name = get_env_user_name();
             let selected_workflow_id = match workflow_id {
                 Some(id) => *id,
                 None => select_workflow_interactively(config, &user_name).unwrap(),
             };
+            let extra_metadata = metadata.as_deref().map(read_metadata_input);
             handle_add_dataset(
                 config,
                 selected_workflow_id,
@@ -358,6 +374,7 @@ pub fn handle_ro_crate_commands(config: &Configuration, command: &RoCrateCommand
                 description.as_deref(),
                 encoding_format.as_deref(),
                 *threads,
+                extra_metadata.as_deref(),
                 format,
             );
         }
@@ -367,9 +384,10 @@ pub fn handle_ro_crate_commands(config: &Configuration, command: &RoCrateCommand
 fn read_metadata_input(metadata: &str) -> String {
     if metadata == "-" {
         let mut buf = String::new();
-        std::io::stdin()
-            .read_to_string(&mut buf)
-            .expect("Failed to read metadata from stdin");
+        if let Err(e) = std::io::stdin().read_to_string(&mut buf) {
+            eprintln!("Error reading metadata from stdin: {}", e);
+            std::process::exit(1);
+        }
         buf
     } else {
         metadata.to_string()
@@ -659,6 +677,31 @@ fn compute_content_hash_parallel(
     Ok(format!("{:x}", final_hasher.finalize()))
 }
 
+/// Merge user-supplied JSON-LD metadata into auto-generated dataset metadata.
+///
+/// The merge is **shallow**: each top-level key in `extra` replaces the
+/// matching key in `base` entirely (nested objects are not recursed into).
+/// Keys present only in one side are preserved. The base value must already
+/// be a JSON object; if `extra` does not parse as a JSON object an `Err` is
+/// returned with a user-facing message.
+fn merge_dataset_metadata(
+    mut base: serde_json::Value,
+    extra: &str,
+) -> Result<serde_json::Value, String> {
+    let parsed: serde_json::Value =
+        serde_json::from_str(extra).map_err(|e| format!("--metadata is not valid JSON: {}", e))?;
+    let extra_obj = parsed
+        .as_object()
+        .ok_or_else(|| "--metadata must be a JSON object".to_string())?;
+    let base_obj = base
+        .as_object_mut()
+        .expect("dataset metadata is constructed as a JSON object");
+    for (key, value) in extra_obj {
+        base_obj.insert(key.clone(), value.clone());
+    }
+    Ok(base)
+}
+
 #[allow(clippy::too_many_arguments)]
 fn handle_add_dataset(
     config: &Configuration,
@@ -669,6 +712,7 @@ fn handle_add_dataset(
     description: Option<&str>,
     encoding_format: Option<&str>,
     threads: Option<usize>,
+    extra_metadata: Option<&str>,
     format: &str,
 ) {
     // Validate hash mode
@@ -750,6 +794,19 @@ fn handle_add_dataset(
         metadata["encodingFormat"] = serde_json::json!(enc);
     }
 
+    // Apply user-supplied metadata last as a shallow top-level merge, so
+    // explicit fields like prov:wasGeneratedBy land in the final entity and
+    // any colliding top-level keys are replaced by the user-supplied value.
+    if let Some(extra) = extra_metadata {
+        metadata = match merge_dataset_metadata(metadata, extra) {
+            Ok(merged) => merged,
+            Err(e) => {
+                eprintln!("Error: {}", e);
+                std::process::exit(1);
+            }
+        };
+    }
+
     // Create the RO-Crate entity
     let entity = models::RoCrateEntityModel::new(
         workflow_id,
@@ -773,5 +830,62 @@ fn handle_add_dataset(
             print_error("creating RO-Crate Dataset entity", &e);
             std::process::exit(1);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn base_dataset_metadata() -> serde_json::Value {
+        json!({
+            "@id": "data/output.parquet/",
+            "@type": "Dataset",
+            "name": "training_output",
+            "contentSize": 1024,
+            "fileCount": 4,
+            "hashMode": "manifest",
+        })
+    }
+
+    #[test]
+    fn merge_dataset_metadata_adds_provenance_fields() {
+        let extra = r##"{"prov:wasGeneratedBy": {"@id": "#job-42-attempt-1"}}"##;
+        let merged = merge_dataset_metadata(base_dataset_metadata(), extra).unwrap();
+        assert_eq!(
+            merged["prov:wasGeneratedBy"],
+            json!({"@id": "#job-42-attempt-1"})
+        );
+        // Auto-computed fields are preserved when the user doesn't touch them.
+        assert_eq!(merged["fileCount"], json!(4));
+        assert_eq!(merged["@type"], json!("Dataset"));
+    }
+
+    #[test]
+    fn merge_dataset_metadata_user_fields_override_defaults() {
+        let extra = r#"{"name": "custom_name", "@type": ["Dataset", "prov:Entity"]}"#;
+        let merged = merge_dataset_metadata(base_dataset_metadata(), extra).unwrap();
+        assert_eq!(merged["name"], json!("custom_name"));
+        assert_eq!(merged["@type"], json!(["Dataset", "prov:Entity"]));
+    }
+
+    #[test]
+    fn merge_dataset_metadata_rejects_invalid_json() {
+        let err = merge_dataset_metadata(base_dataset_metadata(), "{not json").unwrap_err();
+        assert!(err.contains("not valid JSON"), "got: {}", err);
+    }
+
+    #[test]
+    fn merge_dataset_metadata_rejects_non_object() {
+        let err = merge_dataset_metadata(base_dataset_metadata(), "[1, 2, 3]").unwrap_err();
+        assert!(err.contains("must be a JSON object"), "got: {}", err);
+    }
+
+    #[test]
+    fn merge_dataset_metadata_empty_object_is_noop() {
+        let original = base_dataset_metadata();
+        let merged = merge_dataset_metadata(original.clone(), "{}").unwrap();
+        assert_eq!(merged, original);
     }
 }

--- a/src/client/commands/watch.rs
+++ b/src/client/commands/watch.rs
@@ -927,7 +927,7 @@ pub fn run_watch(config: &Configuration, args: &WatchArgs) {
                 "\n{} job(s) with unknown failure cause - running recovery hook...",
                 recovery_result.other_failures
             );
-            if let Err(e) = run_recovery_hook(args.workflow_id, hook_cmd) {
+            if let Err(e) = run_recovery_hook(config, args.workflow_id, hook_cmd) {
                 error!("Recovery hook failed: {}", e);
                 std::process::exit(1);
             }

--- a/src/client/job_runner.rs
+++ b/src/client/job_runner.rs
@@ -1984,6 +1984,7 @@ impl JobRunner {
         let output = crate::client::utils::shell_command()
             .arg(script)
             .env("TORC_WORKFLOW_ID", self.workflow_id.to_string())
+            .env("TORC_RUN_ID", self.run_id.to_string())
             .env("TORC_JOB_ID", job_id.to_string())
             .env("TORC_JOB_NAME", job_name)
             .env("TORC_API_URL", &self.config.base_path)


### PR DESCRIPTION
## Summary

Two related additions for RO-Crate provenance workflows:

1. **`torc ro-crate add-dataset --metadata <JSON|->`** — merges extra JSON-LD fields
   (commonly `prov:wasGeneratedBy`) into the auto-generated `Dataset` entity. Accepts
   inline JSON or `-` to read from stdin.
2. **`TORC_RUN_ID` exported to job environments** — jobs, per-job recovery scripts, and
   workflow-level recovery hooks (`torc recover --hook`) all now see the workflow's
   current run number, alongside the existing `TORC_WORKFLOW_ID` / `TORC_JOB_ID` /
   `TORC_ATTEMPT_ID`. The workflow-level hook also picks up `TORC_API_URL` to match the
   per-job recovery script env surface.

Together these let a job tag its outputs back to the run that produced them:

```bash
torc ro-crate add-dataset "${TORC_WORKFLOW_ID}" \
  --name simulation_results \
  --path output/results.parquet/ \
  --metadata "{
    \"prov:wasGeneratedBy\": {\"@id\": \"#job-${TORC_JOB_ID}-attempt-${TORC_ATTEMPT_ID}\"},
    \"prov:wasAttributedTo\": {\"@id\": \"#torc-run-id-${TORC_RUN_ID}\"}
  }"
```

## Behavior notes

- **Merge is shallow at the top level.** User-supplied keys replace the auto-computed
  ones (`@id`, `@type`, `name`, `contentSize`, ...) entirely; nested objects are not
  deep-merged. Documented in the clap docstrings, the helper doc-comment, the inline
  comment in `handle_add_dataset`, and the user-facing how-to.
- **Stdin read failure no longer panics.** `read_metadata_input` (shared with the
  existing `Create`/`Update` `--metadata` flags) now `eprintln!`s and exits 1, matching
  the rest of the file's error handling.
- **Recovery-hook run id is best-effort.** If the workflow lookup fails we `warn!` and
  run the hook with `TORC_WORKFLOW_ID` + `TORC_API_URL` set but no `TORC_RUN_ID`, rather
  than aborting the recovery.

## Tests

Five new unit tests on the merge helper cover provenance fields, override semantics,
invalid JSON, non-object input, and empty-object no-op. `cargo nextest run --features
client --lib` (299 tests) is green.

## Files

- `src/client/commands/ro_crate.rs` — new `--metadata` flag, `merge_dataset_metadata`
  helper, hardened `read_metadata_input`, tests.
- `src/client/async_cli_command.rs`, `src/client/job_runner.rs` — export `TORC_RUN_ID`
  to job processes and per-job recovery scripts.
- `src/client/commands/recover.rs`, `src/client/commands/watch.rs` —
  `run_recovery_hook` now takes `&Configuration` and exports `TORC_RUN_ID` /
  `TORC_API_URL` to the workflow-level recovery hook.
- `docs/src/core/reference/environment-variables.md`,
  `docs/src/core/how-to/ro-crate-metadata.md`,
  `docs/src/core/reference/cli.md` — env-var reference, provenance how-to,
  `--recovery-hook` env-surface clarification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)