### PR TITLE
Consolidate Dependabot bumps: file-rotate, service-manager, sha2, reqwest, plotly, sysinfo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -112,19 +112,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
-dependencies = [
- "derive_arbitrary",
-]
-
-[[package]]
 name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
+name = "askama"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b8246bcbf8eb97abef10c2d92166449680d41d55c0fc6978a91dec2e3619608"
+dependencies = [
+ "askama_macros",
+ "itoa",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f9670bc84a28bb3da91821ef74226949ab63f1265aff7c751634f1dd0e6f97c"
+dependencies = [
+ "askama_parser",
+ "basic-toml",
+ "memchr",
+ "proc-macro2",
+ "quote",
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "askama_macros"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0756b45480437dded0565dfc568af62ccce146fb6cfe902e808ba86e445f44f"
+dependencies = [
+ "askama_derive",
+]
+
+[[package]]
+name = "askama_parser"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0af3691ba3af77949c0b5a3925444b85cb58a0184cc7fec16c68ba2e7be868"
+dependencies = [
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "unicode-ident",
+ "winnow 1.0.0",
+]
 
 [[package]]
 name = "async-stream"
@@ -336,6 +379,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "blowfish"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,21 +429,11 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bzip2"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
 dependencies = [
- "bzip2-sys",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.13+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
-dependencies = [
- "cc",
- "pkg-config",
+ "libbz2-rs-sys",
 ]
 
 [[package]]
@@ -453,7 +495,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -517,6 +559,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
+name = "codepage"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f68d061bc2828ae826206326e61251aca94c1e4a5305cf52d9138639c918b4"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -570,6 +621,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const-random"
@@ -641,10 +698,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc"
-version = "3.4.0"
+name = "cpufeatures"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
 dependencies = [
  "crc-catalog",
 ]
@@ -764,6 +830,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "csscolorparser"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -869,7 +944,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -882,17 +957,6 @@ checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
 dependencies = [
  "powerfmt",
  "serde_core",
-]
-
-[[package]]
-name = "derive_arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -954,10 +1018,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -1082,6 +1157,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "encoding-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87b881ab2524b96a5ce932056c7482ba6152e2226fed3936b3e592adeb95ca6d"
+dependencies = [
+ "codepage",
+ "encoding_rs",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1215,9 +1301,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "file-rotate"
-version = "0.7.6"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a3ed82142801f5b1363f7d463963d114db80f467e860b1cd82228eaebc627a0"
+checksum = "6e8e2fa049328a1f3295991407a88585805d126dfaadf74b9fe8c194c730aafc"
 dependencies = [
  "chrono",
  "flate2",
@@ -1277,6 +1363,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1694,7 +1781,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1769,12 +1856,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "humansize"
-version = "2.1.3"
+name = "hybrid-array"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
- "libm",
+ "typenum",
 ]
 
 [[package]]
@@ -2221,6 +2308,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "libbz2-rs-sys"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a6a8c165077efc8f3a971534c50ea6a1a18b329ef4a66e897a7e3a1494565f"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2322,24 +2415,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "lzma-rs"
-version = "0.3.0"
+name = "lzma-rust2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+checksum = "7fa48f5024824ecd3e8282cc948bd46fbd095aed5a98939de0594601a59b4e2b"
 dependencies = [
- "byteorder",
  "crc",
-]
-
-[[package]]
-name = "lzma-sys"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2374,7 +2456,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2566,7 +2648,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -2668,6 +2750,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b4d594420fcda43b1c2c4bd44d48974aa3c7a9ab2cbf10dc18e35265767bf0b"
 dependencies = [
  "libloading",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.10.0",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -2818,7 +2919,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "hmac",
 ]
 
@@ -2887,7 +2988,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2929,7 +3030,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -3008,30 +3109,34 @@ dependencies = [
 
 [[package]]
 name = "plotly"
-version = "0.10.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e1ffd11c8a6ef0b730b9d3e46ad2404f79905825cb20223fa0547434a2dff54"
+checksum = "7291750f368f10b87422a0407c0db27acf50cbcc5864564b8ac17c9711ee6afe"
 dependencies = [
+ "askama",
  "dyn-clone",
  "erased-serde",
  "once_cell",
  "plotly_derive",
  "plotly_kaleido",
- "rand",
- "rinja",
+ "rand 0.10.1",
  "serde",
+ "serde-wasm-bindgen",
  "serde_json",
  "serde_repr",
  "serde_with",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
 name = "plotly_derive"
-version = "0.10.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e940d8d8db30c6f4cc37dab9aab61f4c9cc1e6efb6d18902ab88fa09c03560"
+checksum = "eee829fde816615080d73fab040288d3844fecd2487d8936e2fd6d70c0b91db7"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3039,9 +3144,9 @@ dependencies = [
 
 [[package]]
 name = "plotly_kaleido"
-version = "0.10.0"
+version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aba29a8d739f39e09fecba28056860b87ff1f410873df2449cf33bbc1af9db0"
+checksum = "217959d69c1ea5089428b7614e96a8ab5e5aaf0b473ad65f56afb1cc79d0d152"
 dependencies = [
  "base64 0.22.1",
  "directories",
@@ -3080,6 +3185,12 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppmd-rust"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efca4c95a19a79d1c98f791f10aebd5c1363b473244630bb7dbde1dc98455a24"
 
 [[package]]
 name = "ppv-lite86"
@@ -3201,7 +3312,16 @@ checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3211,7 +3331,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3222,6 +3342,12 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "ratatui"
@@ -3434,9 +3560,9 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3471,49 +3597,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
-]
-
-[[package]]
-name = "rinja"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dc4940d00595430b3d7d5a01f6222b5e5b51395d1120bdb28d854bb8abb17a5"
-dependencies = [
- "humansize",
- "itoa",
- "percent-encoding",
- "rinja_derive",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "rinja_derive"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d9ed0146aef6e2825f1b1515f074510549efba38d71f4554eec32eb36ba18b"
-dependencies = [
- "basic-toml",
- "memchr",
- "mime",
- "mime_guess",
- "proc-macro2",
- "quote",
- "rinja_parser",
- "rustc-hash",
- "serde",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "rinja_parser"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f9a866e2e00a7a1fb27e46e9e324a6f7c0e7edc4543cae1d38f4e4a100c610"
-dependencies = [
- "memchr",
- "nom 7.1.3",
- "serde",
 ]
 
 [[package]]
@@ -3584,14 +3667,14 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
@@ -3681,7 +3764,7 @@ version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
 dependencies = [
- "sha2",
+ "sha2 0.10.9",
  "walkdir",
 ]
 
@@ -3886,6 +3969,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4067,12 +4161,15 @@ dependencies = [
 
 [[package]]
 name = "service-manager"
-version = "0.7.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59d7d62c9733631445d1b3fc7854c780088408d4b79a20dd928aaec41854ca3a"
+checksum = "b9ff6975a4ea07dda326cf122fcc1b5cf6266daad42d1442a666a99fe50f0de9"
 dependencies = [
  "cfg-if",
  "dirs 4.0.0",
+ "encoding-utils",
+ "encoding_rs",
+ "log",
  "plist",
  "which",
  "xml-rs",
@@ -4085,8 +4182,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4096,8 +4193,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4162,8 +4270,8 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
- "rand_core",
+ "digest 0.10.7",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4272,7 +4380,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.18",
  "tokio",
@@ -4309,7 +4417,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -4331,7 +4439,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "crc",
- "digest",
+ "digest 0.10.7",
  "dotenvy",
  "either",
  "futures-channel",
@@ -4348,11 +4456,11 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -4386,10 +4494,10 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand",
+ "rand 0.8.6",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -4528,17 +4636,16 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.29.11"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd727fc423c2060f6c92d9534cef765c65a6ed3f428a03d7def74a8c4348e666"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
 dependencies = [
- "cfg-if",
- "core-foundation-sys",
  "libc",
+ "memchr",
  "ntapi",
- "once_cell",
- "rayon",
- "winapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
 ]
 
 [[package]]
@@ -4645,7 +4752,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "phf",
- "sha2",
+ "sha2 0.10.9",
  "signal-hook 0.3.18",
  "siphasher",
  "terminfo",
@@ -4728,6 +4835,7 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
+ "js-sys",
  "libc",
  "num-conv",
  "num_threads",
@@ -4949,6 +5057,7 @@ dependencies = [
  "frunk_derives",
  "futures",
  "hdrhistogram",
+ "hex",
  "hostname",
  "http-body",
  "http-body-util",
@@ -4991,7 +5100,7 @@ dependencies = [
  "serde_yaml",
  "serial_test",
  "service-manager",
- "sha2",
+ "sha2 0.11.0",
  "shlex",
  "signal-hook 0.4.4",
  "sqlx",
@@ -5183,6 +5292,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5190,9 +5305,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ucd-trie"
@@ -5530,9 +5645,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -5581,7 +5696,7 @@ checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
 dependencies = [
  "getrandom 0.3.4",
  "mac_address",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "uuid",
 ]
@@ -6179,15 +6294,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
-name = "xz2"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
-dependencies = [
- "lzma-sys",
-]
-
-[[package]]
 name = "yaml-rust2"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6317,33 +6423,37 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.4.2"
+version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
 dependencies = [
  "aes",
- "arbitrary",
  "bzip2",
  "constant_time_eq",
  "crc32fast",
- "crossbeam-utils",
  "deflate64",
- "displaydoc",
  "flate2",
+ "generic-array",
  "getrandom 0.3.4",
  "hmac",
  "indexmap 2.13.0",
- "lzma-rs",
+ "lzma-rust2",
  "memchr",
  "pbkdf2",
+ "ppmd-rust",
  "sha1",
- "thiserror 2.0.18",
  "time",
- "xz2",
+ "typed-path",
  "zeroize",
  "zopfli",
  "zstd",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ tracing-timing = "0.7"
 hdrhistogram = "7.5"
 signal-hook = "0.4"
 libc = "0.2"
-file-rotate = "0.7"
+file-rotate = "0.8"
 clap = { version = "4.6", features = ["derive", "env", "color", "wrap_help"] }
 clap_complete = "4.6"
 tokio = { version = "1.52", features = ["rt-multi-thread", "macros", "net", "signal", "process", "io-util"] }
@@ -60,7 +60,7 @@ crossterm = "0.29"
 petgraph = "0.8"
 
 # Plot-resources-specific
-plotly = { version = "0.10", default-features = false, features = ["kaleido"] }
+plotly = { version = "0.14", default-features = false, features = ["kaleido"] }
 
 # Server-specific
 rust-embed = "8.5"
@@ -83,13 +83,14 @@ sqlx = { version = "0.8.6", features = ["runtime-tokio", "sqlite"] }
 dotenvy = "0.15.7"
 iso8601 = "0.6"
 jsonwebtoken = "10.3.0"
-sha2 = "0.10"
+sha2 = "0.11"
+hex = "0.4"
 base64 = "0.22"
 
 # Client-specific
 rayon = "1.12"
-reqwest = { version = "0.12", default-features = false, features = ["json", "blocking", "multipart", "native-tls", "stream"] }
-sysinfo = "0.29"
+reqwest = { version = "0.13", default-features = false, features = ["json", "blocking", "multipart", "native-tls", "query", "stream"] }
+sysinfo = "0.38"
 hostname = "0.4.1"
 json5 = "1.3"
 serde_yaml = "0.9"
@@ -102,7 +103,7 @@ flate2 = "1.0"
 tar = "0.4"
 
 # Service management
-service-manager = "0.7"
+service-manager = "0.11"
 
 # Platform-specific (macOS/Windows/iOS)
 native-tls = "0.2"
@@ -194,6 +195,7 @@ server = [
     "dep:dotenvy",
     "dep:jsonwebtoken",
     "dep:sha2",
+    "dep:hex",
     "dep:base64",
     "dep:tracing",
     "dep:bcrypt",
@@ -225,6 +227,7 @@ client = [
     "dep:nvml-wrapper",
     "dep:percent-encoding",
     "dep:sha2",
+    "dep:hex",
     "dep:shlex",
     "dep:flate2",
     "dep:tar",
@@ -333,6 +336,7 @@ dotenvy = { workspace = true, optional = true }
 iso8601 = { workspace = true }
 jsonwebtoken = { workspace = true, optional = true }
 sha2 = { workspace = true, optional = true }
+hex = { workspace = true, optional = true }
 base64 = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
 bcrypt = { workspace = true, optional = true }

--- a/src/client/commands/ro_crate.rs
+++ b/src/client/commands/ro_crate.rs
@@ -592,7 +592,7 @@ fn hash_file(path: &Path) -> std::io::Result<String> {
         hasher.update(&buffer[..n]);
     }
 
-    Ok(format!("{:x}", hasher.finalize()))
+    Ok(hex::encode(hasher.finalize()))
 }
 
 /// Compute statistics for a directory, including optional hash.
@@ -625,7 +625,7 @@ fn compute_dataset_stats(
             manifest_entries.sort();
             let manifest = manifest_entries.join("\n");
             let hash = Sha256::digest(manifest.as_bytes());
-            Some(format!("{:x}", hash))
+            Some(hex::encode(hash))
         }
         "content" => {
             // Hash all file contents in parallel
@@ -674,7 +674,7 @@ fn compute_content_hash_parallel(
         final_hasher.update(format!("{}:{}\n", path, hash).as_bytes());
     }
 
-    Ok(format!("{:x}", final_hasher.finalize()))
+    Ok(hex::encode(final_hasher.finalize()))
 }
 
 /// Merge user-supplied JSON-LD metadata into auto-generated dataset metadata.

--- a/src/client/hpc/slurm_interface.rs
+++ b/src/client/hpc/slurm_interface.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 use std::process::Command;
 use std::thread;
 use std::time::Duration;
-use sysinfo::{RefreshKind, System, SystemExt};
+use sysinfo::{MemoryRefreshKind, RefreshKind, System};
 
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
@@ -452,7 +452,9 @@ impl HpcInterface for SlurmInterface {
         // we can do when SLURM_MEM_PER_NODE is not set (the user did not set --mem).
         // Use new_with_specifics to only refresh memory, avoiding user enumeration
         // which can crash on HPC systems with large LDAP user databases
-        let sys = System::new_with_specifics(RefreshKind::new().with_memory());
+        let sys = System::new_with_specifics(
+            RefreshKind::nothing().with_memory(MemoryRefreshKind::everything()),
+        );
         // sysinfo::System::total_memory() returns bytes; convert to GiB
         sys.total_memory() as f64 / (1024.0 * 1024.0 * 1024.0)
     }

--- a/src/client/resource_monitor.rs
+++ b/src/client/resource_monitor.rs
@@ -7,7 +7,8 @@ use std::sync::mpsc::{Receiver, Sender, TryRecvError, channel};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 use sysinfo::{
-    CpuExt, CpuRefreshKind, Pid, ProcessExt, ProcessRefreshKind, RefreshKind, System, SystemExt,
+    CpuRefreshKind, MemoryRefreshKind, Pid, ProcessRefreshKind, ProcessesToUpdate, RefreshKind,
+    System,
 };
 
 const DB_FILENAME_PREFIX: &str = "resource_metrics";
@@ -583,10 +584,10 @@ fn run_monitoring_loop(
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Use new_with_specifics to only refresh processes, CPU, and memory, avoiding user enumeration
     // which can crash on HPC systems with large LDAP user databases
-    let refresh_kind = RefreshKind::new()
+    let refresh_kind = RefreshKind::nothing()
         .with_processes(ProcessRefreshKind::everything())
         .with_cpu(CpuRefreshKind::everything())
-        .with_memory();
+        .with_memory(MemoryRefreshKind::everything());
     let mut sys = System::new_with_specifics(refresh_kind);
     let mut monitored_jobs: HashMap<u32, MonitoredJob> = HashMap::new();
     let sample_interval = Duration::from_secs(config.sample_interval_seconds as u64);
@@ -714,11 +715,11 @@ fn run_monitoring_loop(
                 }
                 MonitorCommand::Shutdown { response_tx } => {
                     if let Some(compute_node_config) = &compute_node_config {
-                        sys.refresh_cpu();
+                        sys.refresh_cpu_all();
                         sys.refresh_memory();
                         let timestamp = chrono::Utc::now().timestamp();
                         let cpu_percent = if compute_node_config.cpu {
-                            sys.global_cpu_info().cpu_usage() as f64
+                            sys.global_cpu_usage() as f64
                         } else {
                             0.0
                         };
@@ -775,10 +776,10 @@ fn run_monitoring_loop(
                 .values()
                 .any(|j| matches!(j.source, MonitorJobSource::Local { .. }));
             if has_local_jobs || compute_node_config.is_some() {
-                sys.refresh_processes();
+                sys.refresh_processes(ProcessesToUpdate::All, true);
             }
             if compute_node_config.is_some() {
-                sys.refresh_cpu();
+                sys.refresh_cpu_all();
                 sys.refresh_memory();
             }
 
@@ -851,7 +852,7 @@ fn run_monitoring_loop(
             let mut sampled_jobs = Vec::new();
             if let Some(compute_node_config) = &compute_node_config {
                 let cpu_percent = if compute_node_config.cpu {
-                    sys.global_cpu_info().cpu_usage() as f64
+                    sys.global_cpu_usage() as f64
                 } else {
                     0.0
                 };

--- a/src/client/ro_crate_utils.rs
+++ b/src/client/ro_crate_utils.rs
@@ -57,7 +57,7 @@ pub fn compute_file_sha256(path: &str) -> Option<String> {
         }
     }
 
-    Some(format!("{:x}", hasher.finalize()))
+    Some(hex::encode(hasher.finalize()))
 }
 
 /// Build an RO-Crate File entity for a workflow file.

--- a/src/run_jobs_cmd.rs
+++ b/src/run_jobs_cmd.rs
@@ -16,7 +16,7 @@ use log::{LevelFilter, error, info};
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
-use sysinfo::{CpuRefreshKind, RefreshKind, System, SystemExt};
+use sysinfo::{CpuRefreshKind, MemoryRefreshKind, RefreshKind, System};
 
 pub enum LogStream {
     Stdout,
@@ -306,11 +306,11 @@ pub fn run_with_log_stream(args: &Args, log_stream: LogStream) -> WorkerResult {
 
     // Use new_with_specifics to only refresh CPU and memory, avoiding user enumeration
     // which can crash on HPC systems with large LDAP user databases
-    let refresh_kind = RefreshKind::new()
+    let refresh_kind = RefreshKind::nothing()
         .with_cpu(CpuRefreshKind::everything())
-        .with_memory();
+        .with_memory(MemoryRefreshKind::everything());
     let mut system = System::new_with_specifics(refresh_kind);
-    system.refresh_cpu();
+    system.refresh_cpu_all();
     system.refresh_memory();
     let system_cpus = system.cpus().len() as i64;
     let system_memory_gb = (system.total_memory() as f64) / (1024.0 * 1024.0 * 1024.0);

--- a/src/server/api/jobs.rs
+++ b/src/server/api/jobs.rs
@@ -805,7 +805,7 @@ impl JobsApiImpl {
         let mut hasher = Sha256::new();
         hasher.update(json_string.as_bytes());
         let hash_bytes = hasher.finalize();
-        let hash_hex = format!("{:x}", hash_bytes);
+        let hash_hex = hex::encode(hash_bytes);
 
         debug!("Computed input hash for job {}: {}", job_id, hash_hex);
         Ok(hash_hex)
@@ -1080,7 +1080,7 @@ impl JobsApiImpl {
 
             let mut hasher = Sha256::new();
             hasher.update(json_string.as_bytes());
-            let hash_hex = format!("{:x}", hasher.finalize());
+            let hash_hex = hex::encode(hasher.finalize());
 
             hash_pairs.push((job_id, hash_hex));
         }

--- a/src/server/credential_cache.rs
+++ b/src/server/credential_cache.rs
@@ -53,7 +53,7 @@ impl CredentialCache {
         hasher.update(username.as_bytes());
         hasher.update(b":");
         hasher.update(password.as_bytes());
-        format!("{:x}", hasher.finalize())
+        hex::encode(hasher.finalize())
     }
 
     /// Check if credentials are cached and still valid.

--- a/src/server/logging.rs
+++ b/src/server/logging.rs
@@ -29,7 +29,6 @@ impl RotatingWriter {
             AppendCount::new(5),                   // Keep 5 rotated files
             ContentLimit::Bytes(10 * 1024 * 1024), // 10 MiB
             Compression::None,
-            #[cfg(unix)]
             None,
         );
 

--- a/src/server/service.rs
+++ b/src/server/service.rs
@@ -297,6 +297,7 @@ pub fn install_service(config: &ServiceConfig, user_level: bool) -> Result<()> {
         working_directory: None,
         environment: None,
         autostart: true, // Start automatically on boot
+        restart_policy: RestartPolicy::default(),
     };
 
     // Install the service

--- a/tests/test_ro_crate_dataset.rs
+++ b/tests/test_ro_crate_dataset.rs
@@ -249,7 +249,7 @@ fn compute_manifest_hash_for_test(dir: &Path) -> String {
 
     manifest_entries.sort();
     let manifest = manifest_entries.join("\n");
-    format!("{:x}", Sha256::digest(manifest.as_bytes()))
+    hex::encode(Sha256::digest(manifest.as_bytes()))
 }
 
 fn compute_content_hash_for_test(dir: &Path, num_threads: usize) -> String {
@@ -289,7 +289,7 @@ fn compute_content_hash_for_test(dir: &Path, num_threads: usize) -> String {
                     hasher.update(&buffer[..n]);
                 }
 
-                (rel_path.clone(), format!("{:x}", hasher.finalize()))
+                (rel_path.clone(), hex::encode(hasher.finalize()))
             })
             .collect()
     });
@@ -303,5 +303,5 @@ fn compute_content_hash_for_test(dir: &Path, num_threads: usize) -> String {
         final_hasher.update(format!("{}:{}\n", path, hash).as_bytes());
     }
 
-    format!("{:x}", final_hasher.finalize())
+    hex::encode(final_hasher.finalize())
 }


### PR DESCRIPTION
## Summary

Bundles six pending Dependabot PRs into one branch and fixes the breakage each one introduced.

Supersedes:
- #136 — reqwest 0.12 → 0.13
- #158 — plotly 0.10 → 0.14
- #161 — file-rotate 0.7 → 0.8
- #180 — service-manager 0.7 → 0.11
- #253 — sysinfo 0.29 → 0.38
- #255 — sha2 0.10 → 0.11

## Per-bump notes

- **file-rotate 0.7 → 0.8**: drop-in.
- **service-manager 0.7 → 0.11**: new required `restart_policy` field on `ServiceInstallCtx`.
- **sha2 0.10 → 0.11**: `Digest::finalize()` now returns `hybrid_array::Array<u8, _>`, which no longer implements `LowerHex`. All `format!("{:x}", ...)` sites switched to `hex::encode(...)`; `hex` added as a workspace dep gated under the existing server/client features.
- **reqwest 0.12 → 0.13**: `RequestBuilder::query` is now behind the optional `query` feature; added it to the workspace dep.
- **plotly 0.10 → 0.14**: `plotly_kaleido` pulls in `lzma-rust2 0.15` which requires `crc <= 3.3`, but `sqlx-core` resolves `crc` to 3.4. Pinned transitive `crc` to 3.3.0 in `Cargo.lock`.
- **sysinfo 0.29 → 0.38**: large API overhaul — `RefreshKind::new` → `nothing`; `with_memory()` now takes `MemoryRefreshKind`; the `SystemExt`/`CpuExt`/`ProcessExt` traits are gone (methods are inherent); `refresh_cpu` → `refresh_cpu_all`; `global_cpu_info().cpu_usage()` → `global_cpu_usage()`; `refresh_processes()` now requires `ProcessesToUpdate::All` + a `remove_dead_processes: bool` flag.

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all --all-targets --all-features -- -D warnings`
- [x] `dprint check`
- [x] `cargo build --all-features`
- [x] `cargo build --release --bin torc`
- [x] `cargo build --release --features server-bin --bin torc-server`
- [x] `cargo build --release --features dash --bin torc-dash`
- [x] `cargo build --release --features mcp-server --bin torc-mcp-server`
- [x] `cargo build --release --features slurm-runner --bin torc-slurm-job-runner`
- [x] `cargo test --lib --all-features` — 400 passed
- [ ] CI green on Ubuntu + Windows
- [ ] Integration tests (require running server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)