### PR TITLE
Allow bzip2-1.0.6 license for plotly_kaleido build dep chain

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -21,6 +21,7 @@ allow = [
     "BSD-2-Clause",
     "BSD-3-Clause",
     "BSL-1.0",
+    "bzip2-1.0.6",
     "CC0-1.0",
     "ISC",
     "MIT",


### PR DESCRIPTION
## Summary

Fixes the Security workflow's `cargo-deny` license check that broke after #311 merged. The plotly 0.14 → plotly_kaleido 0.13 → zip 7 → bzip2 → `libbz2-rs-sys` chain pulled in a crate licensed `bzip2-1.0.6`, which wasn't on the allow-list.

## Why this is safe

- `bzip2-1.0.6` is a permissive SPDX-listed FOSS license (BSD-like with a non-endorsement clause), used by the original bzip2 C library and now by `libbz2-rs-sys` (a Rust port).
- The dep appears only via plotly_kaleido's `build.rs` — used at build time to extract the kaleido binary — so it doesn't land in the compiled `torc` binary.

Failing run for context: https://github.com/NatLabRockies/torc/actions/runs/25619601153

## Test plan

- [ ] `cargo deny check` (runs in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)