### PR TITLE
Fix resource plot filename collisions across workflow runs

### DIFF
--- a/src/client/job_runner.rs
+++ b/src/client/job_runner.rs
@@ -1064,11 +1064,23 @@ impl JobRunner {
         #[cfg(feature = "plot_resources")]
         {
             let output_dir = db_path.parent().unwrap_or(&self.output_dir).to_path_buf();
+            // Derive the plot filename prefix from the DB stem so aggregate plots
+            // (system_timeline, summary, cpu_all_jobs, etc.) from different
+            // workflow runs / compute-node allocations don't overwrite each other
+            // when they share an output directory. The DB is named
+            // `resource_metrics_<unique_label>.db`; the unique_label already
+            // disambiguates by workflow + host + run (or slurm job + pid).
+            let prefix = db_path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .and_then(|s| s.strip_prefix("resource_metrics_"))
+                .unwrap_or("")
+                .to_string();
             let args = crate::plot_resources_cmd::Args {
                 db_paths: vec![db_path.to_path_buf()],
                 output_dir,
                 job_ids: Vec::new(),
-                prefix: String::new(),
+                prefix,
                 format: "html".to_string(),
             };
             info!(


### PR DESCRIPTION
## Summary
- `generate_resource_plots` was passing an empty `prefix` to the plotter, so aggregate plots (`system_timeline`, `system_summary`, `summary`, `cpu_all_jobs`, `memory_all_jobs`) from different workflow runs silently overwrote each other when the output directory was shared.
- Derive the plot filename prefix from the DB file stem (`resource_metrics_<unique_label>.db`) so HTML filenames inherit the same `wf{id}_h{host}_r{run}` (local) or `wf{id}_sl{slurm_job}_n{node}_p{pid}` (slurm) disambiguation the DB already uses.
- Per-job plots get the same prefix, so they no longer collide either when two workflows happen to share a job-id range or when the same workflow is re-run.

## Test plan
- [x] `cargo clippy --all --all-targets --all-features -- -D warnings`
- [ ] Run two workflows back-to-back into the same `output_dir` with `resource_monitor.generate_plots: true` and verify both sets of `system_timeline`/`summary`/`cpu_all_jobs`/`memory_all_jobs` HTML files survive with distinct prefixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)