### PR TITLE
slurm: pass --wait=0 --kill-on-bad-exit=0 on the outer job-runner srun

### DIFF
--- a/src/client/hpc/slurm_interface.rs
+++ b/src/client/hpc/slurm_interface.rs
@@ -293,7 +293,15 @@ impl HpcInterface for SlurmInterface {
         script.push_str("unset SLURM_MEM_PER_CPU SLURM_MEM_PER_GPU\n");
         if start_one_worker_per_node {
             command.push_str(" --is-subtask");
-            script.push_str("srun --ntasks-per-node=1 ");
+            // --wait=0: do not terminate remaining tasks when the first one exits.
+            //   torc workers self-retire when idle ("No jobs claimed for N seconds"),
+            //   so staggered exits are normal. Without this, clusters that set
+            //   slurm.conf's WaitTime > 0 (e.g. WaitTime=30 on LLNL Dane) will
+            //   SIGKILL the still-working peers shortly after the first worker
+            //   exits cleanly.
+            // --kill-on-bad-exit=0: a single worker crash must not take down peers
+            //   that are still running user jobs; failure handling is the server's job.
+            script.push_str("srun --ntasks-per-node=1 --wait=0 --kill-on-bad-exit=0 ");
             if let Some(mpi_mode) = srun_mpi {
                 validate_srun_mpi_value(mpi_mode).map_err(anyhow::Error::msg)?;
                 script.push_str(&format!("--mpi={} ", mpi_mode.trim()));

--- a/tests/test_slurm_commands.rs
+++ b/tests/test_slurm_commands.rs
@@ -578,8 +578,9 @@ fn test_create_submission_script_with_srun() {
         fs::read_to_string(&script_path).expect("Failed to read submission script");
 
     assert!(
-        script_content.contains("srun --ntasks-per-node=1 "),
-        "Should have outer srun wrapper when start_one_worker_per_node is true"
+        script_content.contains("srun --ntasks-per-node=1 --wait=0 --kill-on-bad-exit=0 "),
+        "Should have outer srun wrapper with --wait=0 --kill-on-bad-exit=0 so torc's \
+         staggered worker exits don't cause SIGKILL of peers on clusters with WaitTime > 0"
     );
     assert!(
         script_content.contains("torc-slurm-job-runner"),
@@ -626,8 +627,9 @@ fn test_create_submission_script_with_srun_mpi() {
         fs::read_to_string(&script_path).expect("Failed to read submission script");
 
     assert!(
-        script_content.contains("srun --ntasks-per-node=1 --mpi=none "),
-        "Should include --mpi on the outer job-runner srun: {}",
+        script_content
+            .contains("srun --ntasks-per-node=1 --wait=0 --kill-on-bad-exit=0 --mpi=none "),
+        "Should include --mpi after the wait/kill flags on the outer job-runner srun: {}",
         script_content
     );
 


### PR DESCRIPTION
## Symptom

On clusters that set `WaitTime > 0` in `slurm.conf` (e.g. LLNL Dane sets `WaitTime=30`), torc workflows using `start_one_worker_per_node=true` get their workers SIGKILLed mid-run. Example from a user with a 5-node allocation:

```
srun: First task exited 30s ago
srun: StepId=5981146.0 tasks 0-3: running
srun: StepId=5981146.0 task 4: exited
srun: Terminating StepId=5981146.0
*** STEP 5981146.0 ON dane138 CANCELLED AT 2026-05-12T12:43:25 DUE to SIGNAL Killed ***
srun: error: dane900: task 3: Killed
srun: error: dane138: task 0: Killed
srun: error: dane894: task 2: Killed
srun: error: dane703: task 1: Killed
```

Task 4 had exited cleanly (return code 0) via torc's normal "No jobs claimed for 90 seconds. Exiting job runner." idle path.

## Root cause

The outer srun emitted by `create_submission_script()` was `srun --ntasks-per-node=1 [--mpi=<mode>]` with no `--wait` flag, so it inherited the cluster's `slurm.conf` `WaitTime`. That setting controls how long `srun` waits after the *first* task exits (any status) before terminating the remaining tasks.

- Slurm-shipped default: `WaitTime=0` → wait forever. Works on most permissive clusters (where this was developed/tested).
- Stricter sites: `WaitTime=30` → kill stragglers 30 s after first exit.

Staggered worker exits are intrinsic to torc's design — workers drain the work queue at slightly different rates and self-retire when idle — so the first worker to finish always starts the countdown on its peers. This made torc silently mis-fail on stricter clusters while working fine on permissive ones, which is the worst kind of portability bug.

## Fix

Pass `--wait=0 --kill-on-bad-exit=0` explicitly on the outer srun so torc behaves identically regardless of cluster policy:

- `--wait=0` — wait indefinitely for siblings; the cluster's `WaitTime` no longer applies.
- `--kill-on-bad-exit=0` — Slurm's default, but some sites override it; setting it explicitly ensures a single worker crash cannot take down peers that are still running user jobs (the workflow server handles failed jobs separately).

The inner per-job srun in `async_cli_command.rs` uses `--ntasks=1` and has no sibling tasks, so it's unaffected.

## Changes

- `src/client/hpc/slurm_interface.rs:296` — emit the two flags on the outer srun, with a comment explaining why.
- `tests/test_slurm_commands.rs` — update the two assertions that pin the outer srun string (`test_create_submission_script_with_srun` and `test_create_submission_script_with_srun_mpi`).

## Verification

```
$ cargo test --test test_slurm_commands -- test_create_submission_script
running 8 tests
test result: ok. 8 passed; 0 failed
```

Pre-commit hooks (cargo fmt, clippy -D warnings, dprint, shellcheck) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)