### PR TITLE
ro-crate add-dataset: wire CreateAction provenance for producing jobs

### DIFF
--- a/src/client/commands/ro_crate.rs
+++ b/src/client/commands/ro_crate.rs
@@ -10,7 +10,7 @@ use crate::client::commands::{
     print_error, select_workflow_interactively, table_format::display_table_with_count,
 };
 use crate::models;
-use log::{error, info, warn};
+use log::{error, info};
 use rayon::prelude::*;
 use sha2::{Digest, Sha256};
 use std::collections::HashSet;
@@ -798,10 +798,17 @@ fn wire_dataset_job_provenance(
                 );
                 action_ids.push(action_id);
             }
-            None => warn!(
-                "Failed to record CreateAction provenance for job_id={}",
-                job_id
-            ),
+            None => {
+                // The user explicitly requested provenance for this job via
+                // `-j`; bail rather than silently emit a dataset whose
+                // `prov:wasGeneratedBy` is missing or partial. The inner
+                // call has already logged the failure cause.
+                error!(
+                    "Failed to record CreateAction provenance for job_id={}, aborting before dataset creation",
+                    job_id
+                );
+                std::process::exit(1);
+            }
         }
     }
     action_ids

--- a/src/client/commands/ro_crate.rs
+++ b/src/client/commands/ro_crate.rs
@@ -765,7 +765,11 @@ fn wire_dataset_job_provenance(
     crate::client::ro_crate_utils::create_software_entities(config, workflow_id, run_id);
 
     let mut action_ids = Vec::new();
+    let mut seen = std::collections::HashSet::new();
     for &job_id in job_ids {
+        if !seen.insert(job_id) {
+            continue;
+        }
         let job = match apis::jobs_api::get_job(config, job_id) {
             Ok(job) => job,
             Err(e) => {
@@ -776,6 +780,13 @@ fn wire_dataset_job_provenance(
                 std::process::exit(1);
             }
         };
+        if job.workflow_id != workflow_id {
+            eprintln!(
+                "Error: job {} belongs to workflow {}, not target workflow {}",
+                job_id, job.workflow_id, workflow_id
+            );
+            std::process::exit(1);
+        }
         let attempt_id = job.attempt_id.unwrap_or(1);
         let input_file_paths =
             resolve_file_paths(config, job.input_file_ids.as_deref().unwrap_or(&[]));

--- a/src/client/commands/ro_crate.rs
+++ b/src/client/commands/ro_crate.rs
@@ -106,10 +106,18 @@ pub enum RoCrateCommands {
     /// such as a hive-partitioned Parquet dataset. Computes file count, total
     /// size, and optionally a manifest or content hash.
     ///
-    /// Use `--metadata` to add JSON-LD fields to the entity, such as
-    /// `prov:wasGeneratedBy` to link the dataset to the job that created it.
-    /// The merge is shallow at the top level: user-supplied keys replace
-    /// auto-computed ones entirely (no deep object merge).
+    /// Use `--job-id` (repeatable, `-j`) to record provenance for the job(s)
+    /// that produced the dataset. For each job, a `CreateAction` entity is
+    /// created (or, if one already exists from a prior run, updated) with the
+    /// dataset added to its `result`, and the dataset's `prov:wasGeneratedBy`
+    /// is set to reference those CreateActions. This wires the full PROV graph
+    /// automatically without hand-writing internal
+    /// `#job-{id}-attempt-{attempt}` ids.
+    ///
+    /// Use `--metadata` to add or override JSON-LD fields on the Dataset
+    /// entity. The merge is shallow at the top level: user-supplied keys
+    /// replace auto-computed ones (including `prov:wasGeneratedBy`) entirely
+    /// (no deep object merge).
     #[command(name = "add-dataset")]
     AddDataset {
         /// Workflow ID (optional - will prompt if not provided)
@@ -133,6 +141,12 @@ pub enum RoCrateCommands {
         /// Number of threads for parallel processing (default: number of CPUs)
         #[arg(long, short = 't')]
         threads: Option<usize>,
+        /// Job ID that produced this dataset. Repeat the flag for multiple
+        /// jobs (e.g. `-j 42 -j 67`). For each job, a CreateAction provenance
+        /// entity is created or updated and the dataset's
+        /// `prov:wasGeneratedBy` is wired to reference it.
+        #[arg(long = "job-id", short = 'j', value_name = "JOB_ID")]
+        job_ids: Vec<i64>,
         /// Extra JSON-LD metadata applied as a top-level merge over the
         /// entity (or "-" to read from stdin). Must be a JSON object. The
         /// merge is shallow: each user-supplied top-level field replaces the
@@ -357,6 +371,7 @@ pub fn handle_ro_crate_commands(config: &Configuration, command: &RoCrateCommand
             description,
             encoding_format,
             threads,
+            job_ids,
             metadata,
         } => {
             let user_name = get_env_user_name();
@@ -374,6 +389,7 @@ pub fn handle_ro_crate_commands(config: &Configuration, command: &RoCrateCommand
                 description.as_deref(),
                 encoding_format.as_deref(),
                 *threads,
+                job_ids,
                 extra_metadata.as_deref(),
                 format,
             );
@@ -702,6 +718,96 @@ fn merge_dataset_metadata(
     Ok(base)
 }
 
+/// Resolve file ids to paths, logging (but not failing) on lookup errors.
+fn resolve_file_paths(config: &Configuration, file_ids: &[i64]) -> Vec<String> {
+    let mut paths = Vec::with_capacity(file_ids.len());
+    for &file_id in file_ids {
+        match apis::files_api::get_file(config, file_id) {
+            Ok(file) => paths.push(file.path),
+            Err(e) => eprintln!(
+                "Warning: could not resolve file id {} for provenance: {}",
+                file_id, e
+            ),
+        }
+    }
+    paths
+}
+
+/// Create or update CreateAction provenance entities for the jobs that produced
+/// a dataset, returning the CreateAction entity ids to wire into the dataset's
+/// `prov:wasGeneratedBy`.
+///
+/// Also ensures the workflow plan/run and software entities exist so the
+/// CreateActions resolve to a complete PROV graph even when `add-dataset` is
+/// run after the fact.
+fn wire_dataset_job_provenance(
+    config: &Configuration,
+    workflow_id: i64,
+    job_ids: &[i64],
+    dataset_entity_id: &str,
+) -> Vec<String> {
+    let (workflow_name, run_id) = match apis::workflows_api::get_workflow(config, workflow_id) {
+        Ok(workflow) => (workflow.name, workflow.run_id.unwrap_or(0)),
+        Err(e) => {
+            print_error("getting workflow for dataset provenance", &e);
+            std::process::exit(1);
+        }
+    };
+
+    // Idempotent: ensures plan/run/software entities referenced by the
+    // CreateActions exist (they normally are created during init/run).
+    crate::client::ro_crate_utils::create_workflow_provenance_entities(
+        config,
+        workflow_id,
+        run_id,
+        &workflow_name,
+    );
+    crate::client::ro_crate_utils::create_software_entities(config, workflow_id, run_id);
+
+    let mut action_ids = Vec::new();
+    for &job_id in job_ids {
+        let job = match apis::jobs_api::get_job(config, job_id) {
+            Ok(job) => job,
+            Err(e) => {
+                print_error(
+                    &format!("getting job {} for dataset provenance", job_id),
+                    &e,
+                );
+                std::process::exit(1);
+            }
+        };
+        let attempt_id = job.attempt_id.unwrap_or(1);
+        let input_file_paths =
+            resolve_file_paths(config, job.input_file_ids.as_deref().unwrap_or(&[]));
+        let output_file_paths =
+            resolve_file_paths(config, job.output_file_ids.as_deref().unwrap_or(&[]));
+
+        match crate::client::ro_crate_utils::link_dataset_to_job_create_action(
+            config,
+            workflow_id,
+            run_id,
+            &job,
+            attempt_id,
+            &input_file_paths,
+            &output_file_paths,
+            dataset_entity_id,
+        ) {
+            Some(action_id) => {
+                println!(
+                    "  Linked CreateAction '{}' (job '{}') to dataset",
+                    action_id, job.name
+                );
+                action_ids.push(action_id);
+            }
+            None => eprintln!(
+                "Warning: failed to record CreateAction provenance for job {}",
+                job_id
+            ),
+        }
+    }
+    action_ids
+}
+
 #[allow(clippy::too_many_arguments)]
 fn handle_add_dataset(
     config: &Configuration,
@@ -712,6 +818,7 @@ fn handle_add_dataset(
     description: Option<&str>,
     encoding_format: Option<&str>,
     threads: Option<usize>,
+    job_ids: &[i64],
     extra_metadata: Option<&str>,
     format: &str,
 ) {
@@ -792,6 +899,28 @@ fn handle_add_dataset(
 
     if let Some(enc) = encoding_format {
         metadata["encodingFormat"] = serde_json::json!(enc);
+    }
+
+    // Record provenance for the job(s) that produced this dataset. For each
+    // job we create or update its CreateAction entity (adding this dataset to
+    // its `result`) and collect the CreateAction ids to wire the dataset's
+    // `prov:wasGeneratedBy`. Done before the user `--metadata` merge so an
+    // explicit `prov:wasGeneratedBy` can still override it.
+    if !job_ids.is_empty() {
+        let action_ids = wire_dataset_job_provenance(config, workflow_id, job_ids, &entity_id);
+        match action_ids.as_slice() {
+            [] => {}
+            [single] => {
+                metadata["prov:wasGeneratedBy"] = serde_json::json!({ "@id": single });
+            }
+            many => {
+                metadata["prov:wasGeneratedBy"] = serde_json::Value::Array(
+                    many.iter()
+                        .map(|id| serde_json::json!({ "@id": id }))
+                        .collect(),
+                );
+            }
+        }
     }
 
     // Apply user-supplied metadata last as a shallow top-level merge, so

--- a/src/client/commands/ro_crate.rs
+++ b/src/client/commands/ro_crate.rs
@@ -10,6 +10,7 @@ use crate::client::commands::{
     print_error, select_workflow_interactively, table_format::display_table_with_count,
 };
 use crate::models;
+use log::{error, info, warn};
 use rayon::prelude::*;
 use sha2::{Digest, Sha256};
 use std::collections::HashSet;
@@ -718,21 +719,6 @@ fn merge_dataset_metadata(
     Ok(base)
 }
 
-/// Resolve file ids to paths, logging (but not failing) on lookup errors.
-fn resolve_file_paths(config: &Configuration, file_ids: &[i64]) -> Vec<String> {
-    let mut paths = Vec::with_capacity(file_ids.len());
-    for &file_id in file_ids {
-        match apis::files_api::get_file(config, file_id) {
-            Ok(file) => paths.push(file.path),
-            Err(e) => eprintln!(
-                "Warning: could not resolve file id {} for provenance: {}",
-                file_id, e
-            ),
-        }
-    }
-    paths
-}
-
 /// Create or update CreateAction provenance entities for the jobs that produced
 /// a dataset, returning the CreateAction entity ids to wire into the dataset's
 /// `prov:wasGeneratedBy`.
@@ -740,6 +726,14 @@ fn resolve_file_paths(config: &Configuration, file_ids: &[i64]) -> Vec<String> {
 /// Also ensures the workflow plan/run and software entities exist so the
 /// CreateActions resolve to a complete PROV graph even when `add-dataset` is
 /// run after the fact.
+///
+/// The built CreateAction intentionally records no `object`/`prov:used` or
+/// `result` other than the dataset itself: a job invoked via `add-dataset`
+/// produces a directory torc doesn't track, so the runtime never auto-creates
+/// a CreateAction (the runtime trigger requires non-empty tracked outputs).
+/// Populating tracked-file refs here would point at File entities that may not
+/// exist in the RO-Crate when `enable_ro_crate` is off. Users wanting richer
+/// `object`/`prov:used` can supply them via `--metadata`.
 fn wire_dataset_job_provenance(
     config: &Configuration,
     workflow_id: i64,
@@ -781,17 +775,13 @@ fn wire_dataset_job_provenance(
             }
         };
         if job.workflow_id != workflow_id {
-            eprintln!(
-                "Error: job {} belongs to workflow {}, not target workflow {}",
+            error!(
+                "job_id={} belongs to workflow_id={}, not target workflow_id={}",
                 job_id, job.workflow_id, workflow_id
             );
             std::process::exit(1);
         }
         let attempt_id = job.attempt_id.unwrap_or(1);
-        let input_file_paths =
-            resolve_file_paths(config, job.input_file_ids.as_deref().unwrap_or(&[]));
-        let output_file_paths =
-            resolve_file_paths(config, job.output_file_ids.as_deref().unwrap_or(&[]));
 
         match crate::client::ro_crate_utils::link_dataset_to_job_create_action(
             config,
@@ -799,19 +789,17 @@ fn wire_dataset_job_provenance(
             run_id,
             &job,
             attempt_id,
-            &input_file_paths,
-            &output_file_paths,
             dataset_entity_id,
         ) {
             Some(action_id) => {
-                println!(
-                    "  Linked CreateAction '{}' (job '{}') to dataset",
-                    action_id, job.name
+                info!(
+                    "Linked CreateAction entity_id={} job_id={} job_name={} to dataset entity_id={}",
+                    action_id, job_id, job.name, dataset_entity_id
                 );
                 action_ids.push(action_id);
             }
-            None => eprintln!(
-                "Warning: failed to record CreateAction provenance for job {}",
+            None => warn!(
+                "Failed to record CreateAction provenance for job_id={}",
                 job_id
             ),
         }

--- a/src/client/ro_crate_utils.rs
+++ b/src/client/ro_crate_utils.rs
@@ -692,10 +692,12 @@ pub fn create_create_action_entity(
 /// Append `{ "@id": id }` to the entity's `result` array if not already present.
 ///
 /// Normalizes a missing or non-array `result` value into an array so the dataset
-/// reference can be added without clobbering existing tracked results.
-fn append_result_ref(metadata: &mut serde_json::Value, id: &str) {
+/// reference can be added without clobbering existing tracked results. Returns
+/// `false` when `metadata` is not a JSON object, so the caller can treat the
+/// link as failed rather than reporting a spurious success.
+fn append_result_ref(metadata: &mut serde_json::Value, id: &str) -> bool {
     let Some(obj) = metadata.as_object_mut() else {
-        return;
+        return false;
     };
     let entry = obj
         .entry("result".to_string())
@@ -713,6 +715,7 @@ fn append_result_ref(metadata: &mut serde_json::Value, id: &str) {
     if !already {
         arr.push(id_ref(id));
     }
+    true
 }
 
 /// Create or update a job's CreateAction entity to record that it produced a
@@ -738,7 +741,17 @@ pub fn link_dataset_to_job_create_action(
     output_file_paths: &[String],
     dataset_entity_id: &str,
 ) -> Option<String> {
-    let action_id = format!("#job-{}-attempt-{}", job.id.unwrap_or(0), attempt_id);
+    let job_id = match job.id {
+        Some(id) => id,
+        None => {
+            warn!(
+                "Job '{}' has no id, cannot wire CreateAction provenance",
+                job.name
+            );
+            return None;
+        }
+    };
+    let action_id = format!("#job-{}-attempt-{}", job_id, attempt_id);
 
     if let Some(existing) = find_entity_by_entity_id(config, workflow_id, &action_id) {
         let entity_db_id = match existing.id {
@@ -758,7 +771,13 @@ pub fn link_dataset_to_job_create_action(
                 return None;
             }
         };
-        append_result_ref(&mut metadata, dataset_entity_id);
+        if !append_result_ref(&mut metadata, dataset_entity_id) {
+            warn!(
+                "CreateAction metadata for '{}' is not a JSON object; cannot record dataset result",
+                action_id
+            );
+            return None;
+        }
         let updated = RoCrateEntityModel {
             id: Some(entity_db_id),
             metadata: metadata.to_string(),
@@ -794,7 +813,13 @@ pub fn link_dataset_to_job_create_action(
             return None;
         }
     };
-    append_result_ref(&mut metadata, dataset_entity_id);
+    if !append_result_ref(&mut metadata, dataset_entity_id) {
+        warn!(
+            "Built CreateAction metadata for '{}' is not a JSON object; cannot record dataset result",
+            action_id
+        );
+        return None;
+    }
     entity.metadata = metadata.to_string();
 
     match apis::ro_crate_entities_api::create_ro_crate_entity(config, entity) {

--- a/src/client/ro_crate_utils.rs
+++ b/src/client/ro_crate_utils.rs
@@ -724,28 +724,29 @@ fn append_result_ref(metadata: &mut serde_json::Value, id: &str) -> bool {
 /// If a CreateAction already exists for the job/attempt (e.g. created during a
 /// prior run with tracked file I/O), the dataset is appended to its existing
 /// `result` array so runtime-tracked outputs are preserved. Otherwise a new
-/// CreateAction is built from the job's input/output files (with the full
-/// plan/software/run provenance links) and the dataset is added to its result.
+/// minimal CreateAction is built (plan/software/run refs only, no tracked
+/// `object`/`result`) and the dataset is added as its sole result. The
+/// minimal shape is intentional: the runtime only auto-creates a CreateAction
+/// for jobs with tracked outputs, so a dataset-producing job (which torc
+/// doesn't track) reaches this branch precisely when there are no tracked
+/// File entities to reference.
 ///
 /// Returns `Some("#job-{id}-attempt-{attempt}")` on success so the caller can
 /// wire the dataset's `prov:wasGeneratedBy`. This is a non-blocking operation:
 /// warnings are logged and `None` is returned on failure.
-#[allow(clippy::too_many_arguments)]
 pub fn link_dataset_to_job_create_action(
     config: &Configuration,
     workflow_id: i64,
     run_id: i64,
     job: &JobModel,
     attempt_id: i64,
-    input_file_paths: &[String],
-    output_file_paths: &[String],
     dataset_entity_id: &str,
 ) -> Option<String> {
     let job_id = match job.id {
         Some(id) => id,
         None => {
             warn!(
-                "Job '{}' has no id, cannot wire CreateAction provenance",
+                "job_name={} has no job_id, cannot wire CreateAction provenance",
                 job.name
             );
             return None;
@@ -757,37 +758,29 @@ pub fn link_dataset_to_job_create_action(
         let entity_db_id = match existing.id {
             Some(id) => id,
             None => {
-                warn!("Existing CreateAction entity has no ID, cannot update");
-                return None;
-            }
-        };
-        let mut metadata = match serde_json::from_str::<serde_json::Value>(&existing.metadata) {
-            Ok(value) => value,
-            Err(e) => {
                 warn!(
-                    "Failed to parse CreateAction metadata for '{}': {}",
-                    action_id, e
+                    "Existing CreateAction entity has no entity_db_id, cannot update action_id={}",
+                    action_id
                 );
                 return None;
             }
         };
-        if !append_result_ref(&mut metadata, dataset_entity_id) {
-            warn!(
-                "CreateAction metadata for '{}' is not a JSON object; cannot record dataset result",
-                action_id
-            );
-            return None;
-        }
+        let metadata_str = append_dataset_result(
+            &existing.metadata,
+            &action_id,
+            dataset_entity_id,
+            "existing",
+        )?;
         let updated = RoCrateEntityModel {
             id: Some(entity_db_id),
-            metadata: metadata.to_string(),
+            metadata: metadata_str,
             ..existing
         };
         if let Err(e) =
             apis::ro_crate_entities_api::update_ro_crate_entity(config, entity_db_id, updated)
         {
             warn!(
-                "Failed to update CreateAction entity '{}': {}",
+                "Failed to update CreateAction entity action_id={}: {}",
                 action_id, e
             );
             return None;
@@ -795,43 +788,52 @@ pub fn link_dataset_to_job_create_action(
         return Some(action_id);
     }
 
-    let mut entity = build_create_action_entity(
-        workflow_id,
-        run_id,
-        job,
-        attempt_id,
-        input_file_paths,
-        output_file_paths,
-    );
-    let mut metadata = match serde_json::from_str::<serde_json::Value>(&entity.metadata) {
+    let mut entity = build_create_action_entity(workflow_id, run_id, job, attempt_id, &[], &[]);
+    entity.metadata =
+        append_dataset_result(&entity.metadata, &action_id, dataset_entity_id, "built")?;
+
+    match apis::ro_crate_entities_api::create_ro_crate_entity(config, entity) {
+        Ok(_) => Some(action_id),
+        Err(e) => {
+            warn!(
+                "Failed to create CreateAction entity action_id={}: {}",
+                action_id, e
+            );
+            None
+        }
+    }
+}
+
+/// Parse a CreateAction's JSON metadata, append a dataset reference to its
+/// `result` array, and return the re-serialized metadata. Returns `None` on
+/// parse failure or non-object metadata so callers can short-circuit.
+///
+/// `source` distinguishes whether the metadata came from a stored entity
+/// ("existing") or a freshly built one ("built"), purely for diagnostics.
+fn append_dataset_result(
+    metadata_json: &str,
+    action_id: &str,
+    dataset_entity_id: &str,
+    source: &str,
+) -> Option<String> {
+    let mut metadata = match serde_json::from_str::<serde_json::Value>(metadata_json) {
         Ok(value) => value,
         Err(e) => {
             warn!(
-                "Failed to parse built CreateAction metadata for '{}': {}",
-                action_id, e
+                "Failed to parse {} CreateAction metadata for action_id={}: {}",
+                source, action_id, e
             );
             return None;
         }
     };
     if !append_result_ref(&mut metadata, dataset_entity_id) {
         warn!(
-            "Built CreateAction metadata for '{}' is not a JSON object; cannot record dataset result",
-            action_id
+            "{} CreateAction metadata for action_id={} is not a JSON object; cannot record dataset result",
+            source, action_id
         );
         return None;
     }
-    entity.metadata = metadata.to_string();
-
-    match apis::ro_crate_entities_api::create_ro_crate_entity(config, entity) {
-        Ok(_) => Some(action_id),
-        Err(e) => {
-            warn!(
-                "Failed to create CreateAction entity '{}': {}",
-                action_id, e
-            );
-            None
-        }
-    }
+    Some(metadata.to_string())
 }
 
 /// Create RO-Crate entities for input files of a workflow.

--- a/src/client/ro_crate_utils.rs
+++ b/src/client/ro_crate_utils.rs
@@ -689,6 +689,126 @@ pub fn create_create_action_entity(
     }
 }
 
+/// Append `{ "@id": id }` to the entity's `result` array if not already present.
+///
+/// Normalizes a missing or non-array `result` value into an array so the dataset
+/// reference can be added without clobbering existing tracked results.
+fn append_result_ref(metadata: &mut serde_json::Value, id: &str) {
+    let Some(obj) = metadata.as_object_mut() else {
+        return;
+    };
+    let entry = obj
+        .entry("result".to_string())
+        .or_insert_with(|| serde_json::json!([]));
+    if !entry.is_array() {
+        let prev = entry.clone();
+        *entry = serde_json::json!([prev]);
+    }
+    let arr = entry
+        .as_array_mut()
+        .expect("result was normalized to an array");
+    let already = arr
+        .iter()
+        .any(|v| v.get("@id").and_then(|x| x.as_str()) == Some(id));
+    if !already {
+        arr.push(id_ref(id));
+    }
+}
+
+/// Create or update a job's CreateAction entity to record that it produced a
+/// dataset, then return the CreateAction's entity id.
+///
+/// If a CreateAction already exists for the job/attempt (e.g. created during a
+/// prior run with tracked file I/O), the dataset is appended to its existing
+/// `result` array so runtime-tracked outputs are preserved. Otherwise a new
+/// CreateAction is built from the job's input/output files (with the full
+/// plan/software/run provenance links) and the dataset is added to its result.
+///
+/// Returns `Some("#job-{id}-attempt-{attempt}")` on success so the caller can
+/// wire the dataset's `prov:wasGeneratedBy`. This is a non-blocking operation:
+/// warnings are logged and `None` is returned on failure.
+#[allow(clippy::too_many_arguments)]
+pub fn link_dataset_to_job_create_action(
+    config: &Configuration,
+    workflow_id: i64,
+    run_id: i64,
+    job: &JobModel,
+    attempt_id: i64,
+    input_file_paths: &[String],
+    output_file_paths: &[String],
+    dataset_entity_id: &str,
+) -> Option<String> {
+    let action_id = format!("#job-{}-attempt-{}", job.id.unwrap_or(0), attempt_id);
+
+    if let Some(existing) = find_entity_by_entity_id(config, workflow_id, &action_id) {
+        let entity_db_id = match existing.id {
+            Some(id) => id,
+            None => {
+                warn!("Existing CreateAction entity has no ID, cannot update");
+                return None;
+            }
+        };
+        let mut metadata = match serde_json::from_str::<serde_json::Value>(&existing.metadata) {
+            Ok(value) => value,
+            Err(e) => {
+                warn!(
+                    "Failed to parse CreateAction metadata for '{}': {}",
+                    action_id, e
+                );
+                return None;
+            }
+        };
+        append_result_ref(&mut metadata, dataset_entity_id);
+        let updated = RoCrateEntityModel {
+            id: Some(entity_db_id),
+            metadata: metadata.to_string(),
+            ..existing
+        };
+        if let Err(e) =
+            apis::ro_crate_entities_api::update_ro_crate_entity(config, entity_db_id, updated)
+        {
+            warn!(
+                "Failed to update CreateAction entity '{}': {}",
+                action_id, e
+            );
+            return None;
+        }
+        return Some(action_id);
+    }
+
+    let mut entity = build_create_action_entity(
+        workflow_id,
+        run_id,
+        job,
+        attempt_id,
+        input_file_paths,
+        output_file_paths,
+    );
+    let mut metadata = match serde_json::from_str::<serde_json::Value>(&entity.metadata) {
+        Ok(value) => value,
+        Err(e) => {
+            warn!(
+                "Failed to parse built CreateAction metadata for '{}': {}",
+                action_id, e
+            );
+            return None;
+        }
+    };
+    append_result_ref(&mut metadata, dataset_entity_id);
+    entity.metadata = metadata.to_string();
+
+    match apis::ro_crate_entities_api::create_ro_crate_entity(config, entity) {
+        Ok(_) => Some(action_id),
+        Err(e) => {
+            warn!(
+                "Failed to create CreateAction entity '{}': {}",
+                action_id, e
+            );
+            None
+        }
+    }
+}
+
 /// Create RO-Crate entities for input files of a workflow.
 ///
 /// Called during workflow initialization when `enable_ro_crate` is true.
@@ -890,6 +1010,31 @@ mod tests {
         let metadata: serde_json::Value = serde_json::from_str(&entity.metadata).unwrap();
         assert_eq!(metadata["prov:wasGeneratedBy"]["@id"], "#job-42-attempt-1");
         assert_eq!(metadata["prov:wasAttributedTo"]["@id"], "#torc-run-id-1");
+    }
+
+    #[test]
+    fn test_append_result_ref() {
+        // Appends into an existing array, deduplicating.
+        let mut meta = serde_json::json!({ "result": [{ "@id": "out/a" }] });
+        append_result_ref(&mut meta, "data/ds/");
+        append_result_ref(&mut meta, "data/ds/"); // duplicate is a no-op
+        let arr = meta["result"].as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0]["@id"], "out/a");
+        assert_eq!(arr[1]["@id"], "data/ds/");
+
+        // Missing `result` is created as an array.
+        let mut meta = serde_json::json!({ "name": "x" });
+        append_result_ref(&mut meta, "data/ds/");
+        assert_eq!(meta["result"][0]["@id"], "data/ds/");
+
+        // A non-array `result` is normalized into an array first.
+        let mut meta = serde_json::json!({ "result": { "@id": "out/a" } });
+        append_result_ref(&mut meta, "data/ds/");
+        let arr = meta["result"].as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0]["@id"], "out/a");
+        assert_eq!(arr[1]["@id"], "data/ds/");
     }
 
     #[test]

--- a/tests/test_ro_crate_add_dataset_provenance.rs
+++ b/tests/test_ro_crate_add_dataset_provenance.rs
@@ -1,0 +1,285 @@
+//! Integration tests for `torc ro-crate add-dataset --job-id`.
+//!
+//! These verify the provenance wiring: that a CreateAction entity is created
+//! (or updated) for each producing job, that the dataset is added to the
+//! CreateAction's `result`, and that the dataset's `prov:wasGeneratedBy`
+//! references those CreateAction entities.
+
+mod common;
+
+use common::{ServerProcess, run_cli_command, start_server};
+use rstest::rstest;
+use std::fs;
+use std::path::Path;
+use torc::client::apis;
+use torc::models;
+
+/// Create a workflow with one job (no tracked files needed for these tests).
+/// Returns (workflow_id, job_id).
+fn create_workflow_with_job(config: &torc::client::Configuration, job_name: &str) -> (i64, i64) {
+    let workflow = models::WorkflowModel::new(
+        "test_add_dataset_provenance".to_string(),
+        "test_user".to_string(),
+    );
+    let created_workflow =
+        apis::workflows_api::create_workflow(config, workflow).expect("Failed to create workflow");
+    let workflow_id = created_workflow.id.unwrap();
+
+    let job = models::JobModel::new(workflow_id, job_name.to_string(), "echo hi".to_string());
+    let created_job = apis::jobs_api::create_job(config, job).expect("Failed to create job");
+    let job_id = created_job.id.unwrap();
+
+    (workflow_id, job_id)
+}
+
+/// Create a directory with a couple of files to register as a dataset.
+fn make_dataset_dir(base: &Path) -> String {
+    let dir = base.join("ds");
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join("part-0.parquet"), b"abc").unwrap();
+    fs::write(dir.join("part-1.parquet"), b"defg").unwrap();
+    dir.to_string_lossy().to_string()
+}
+
+fn list_entities(
+    config: &torc::client::Configuration,
+    workflow_id: i64,
+) -> Vec<models::RoCrateEntityModel> {
+    apis::ro_crate_api::list_ro_crate_entities(
+        config,
+        workflow_id,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .expect("Failed to list RO-Crate entities")
+    .items
+}
+
+#[rstest]
+fn test_add_dataset_creates_create_action_for_job(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+
+    let (workflow_id, job_id) = create_workflow_with_job(config, "produce_dataset");
+    let dataset_path = make_dataset_dir(temp_dir.path());
+
+    // The job never ran, so no CreateAction exists yet. add-dataset must create
+    // one and wire the bidirectional provenance link.
+    let workflow_id_str = workflow_id.to_string();
+    let job_id_str = job_id.to_string();
+    run_cli_command(
+        &[
+            "ro-crate",
+            "add-dataset",
+            &workflow_id_str,
+            "--name",
+            "training_output",
+            "--path",
+            &dataset_path,
+            "-j",
+            &job_id_str,
+        ],
+        start_server,
+        None,
+    )
+    .expect("add-dataset command failed");
+
+    let entities = list_entities(config, workflow_id);
+    let expected_action_id = format!("#job-{}-attempt-1", job_id);
+    let dataset_entity_id = format!("{}/", dataset_path);
+
+    // A CreateAction entity must exist for the producing job.
+    let action = entities
+        .iter()
+        .find(|e| e.entity_id == expected_action_id)
+        .unwrap_or_else(|| {
+            panic!(
+                "Expected a CreateAction entity '{}'. Found: {:?}",
+                expected_action_id,
+                entities.iter().map(|e| &e.entity_id).collect::<Vec<_>>()
+            )
+        });
+    assert_eq!(action.entity_type, "CreateAction");
+
+    let action_meta: serde_json::Value =
+        serde_json::from_str(&action.metadata).expect("CreateAction metadata is not valid JSON");
+    assert_eq!(action_meta["@type"][0], "CreateAction");
+    // The dataset must appear in the CreateAction's result array.
+    let result = action_meta["result"]
+        .as_array()
+        .expect("CreateAction should have a result array");
+    assert!(
+        result
+            .iter()
+            .any(|r| r["@id"] == serde_json::json!(dataset_entity_id)),
+        "CreateAction result should reference the dataset. result={:?}",
+        result
+    );
+
+    // The Dataset entity must point back at the CreateAction.
+    let dataset = entities
+        .iter()
+        .find(|e| e.entity_id == dataset_entity_id)
+        .expect("Dataset entity should exist");
+    assert_eq!(dataset.entity_type, "Dataset");
+    let dataset_meta: serde_json::Value =
+        serde_json::from_str(&dataset.metadata).expect("Dataset metadata is not valid JSON");
+    assert_eq!(
+        dataset_meta["prov:wasGeneratedBy"]["@id"],
+        serde_json::json!(expected_action_id),
+        "Dataset prov:wasGeneratedBy should reference the CreateAction"
+    );
+}
+
+#[rstest]
+fn test_add_dataset_multiple_jobs_creates_actions(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+
+    let (workflow_id, job1) = create_workflow_with_job(config, "writer_a");
+    // Add a second job to the same workflow.
+    let job2 = {
+        let j = models::JobModel::new(workflow_id, "writer_b".to_string(), "echo hi".to_string());
+        apis::jobs_api::create_job(config, j)
+            .expect("Failed to create job2")
+            .id
+            .unwrap()
+    };
+    let dataset_path = make_dataset_dir(temp_dir.path());
+
+    let workflow_id_str = workflow_id.to_string();
+    let job1_str = job1.to_string();
+    let job2_str = job2.to_string();
+    run_cli_command(
+        &[
+            "ro-crate",
+            "add-dataset",
+            &workflow_id_str,
+            "--name",
+            "shared_output",
+            "--path",
+            &dataset_path,
+            "-j",
+            &job1_str,
+            "-j",
+            &job2_str,
+        ],
+        start_server,
+        None,
+    )
+    .expect("add-dataset command failed");
+
+    let entities = list_entities(config, workflow_id);
+    let action1 = format!("#job-{}-attempt-1", job1);
+    let action2 = format!("#job-{}-attempt-1", job2);
+    let dataset_entity_id = format!("{}/", dataset_path);
+
+    for action_id in [&action1, &action2] {
+        assert!(
+            entities
+                .iter()
+                .any(|e| &e.entity_id == action_id && e.entity_type == "CreateAction"),
+            "Expected CreateAction entity '{}'",
+            action_id
+        );
+    }
+
+    let dataset = entities
+        .iter()
+        .find(|e| e.entity_id == dataset_entity_id)
+        .expect("Dataset entity should exist");
+    let dataset_meta: serde_json::Value =
+        serde_json::from_str(&dataset.metadata).expect("Dataset metadata is not valid JSON");
+    let generated_by = dataset_meta["prov:wasGeneratedBy"]
+        .as_array()
+        .expect("prov:wasGeneratedBy should be an array for multiple jobs");
+    let referenced: Vec<&str> = generated_by
+        .iter()
+        .filter_map(|v| v["@id"].as_str())
+        .collect();
+    assert!(referenced.contains(&action1.as_str()));
+    assert!(referenced.contains(&action2.as_str()));
+}
+
+#[rstest]
+fn test_add_dataset_updates_existing_create_action(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+
+    let (workflow_id, job_id) = create_workflow_with_job(config, "ran_already");
+    let dataset_path = make_dataset_dir(temp_dir.path());
+    let action_id = format!("#job-{}-attempt-1", job_id);
+
+    // Simulate a CreateAction that already exists from a prior run with a
+    // tracked output file in its result array.
+    let existing_meta = serde_json::json!({
+        "@id": action_id,
+        "@type": ["CreateAction", "prov:Activity"],
+        "name": "ran_already",
+        "result": [{ "@id": "output/existing.json" }]
+    });
+    let existing = models::RoCrateEntityModel::new(
+        workflow_id,
+        action_id.clone(),
+        "CreateAction".to_string(),
+        existing_meta.to_string(),
+    );
+    apis::ro_crate_entities_api::create_ro_crate_entity(config, existing)
+        .expect("Failed to pre-create CreateAction");
+
+    let workflow_id_str = workflow_id.to_string();
+    let job_id_str = job_id.to_string();
+    run_cli_command(
+        &[
+            "ro-crate",
+            "add-dataset",
+            &workflow_id_str,
+            "--name",
+            "training_output",
+            "--path",
+            &dataset_path,
+            "-j",
+            &job_id_str,
+        ],
+        start_server,
+        None,
+    )
+    .expect("add-dataset command failed");
+
+    let entities = list_entities(config, workflow_id);
+    let dataset_entity_id = format!("{}/", dataset_path);
+
+    // Still exactly one CreateAction for the job (updated, not duplicated).
+    let actions: Vec<_> = entities
+        .iter()
+        .filter(|e| e.entity_id == action_id)
+        .collect();
+    assert_eq!(
+        actions.len(),
+        1,
+        "CreateAction should be updated in place, not duplicated"
+    );
+
+    let action_meta: serde_json::Value =
+        serde_json::from_str(&actions[0].metadata).expect("CreateAction metadata invalid");
+    let result = action_meta["result"]
+        .as_array()
+        .expect("result should be an array");
+    let result_ids: Vec<&str> = result.iter().filter_map(|r| r["@id"].as_str()).collect();
+    // The pre-existing tracked output is preserved...
+    assert!(
+        result_ids.contains(&"output/existing.json"),
+        "Existing tracked output should be preserved. result={:?}",
+        result_ids
+    );
+    // ...and the dataset is appended.
+    assert!(
+        result_ids.contains(&dataset_entity_id.as_str()),
+        "Dataset should be appended to existing result. result={:?}",
+        result_ids
+    );
+}


### PR DESCRIPTION
## Problem

`torc ro-crate add-dataset` only ever created a `Dataset` entity. The only provenance hook was the shallow `--metadata` merge, so to link a dataset to its producing job a user had to hand-write `--metadata '{"prov:wasGeneratedBy": {"@id": "#job-42-attempt-1"}}'`. This was insufficient because:

1. **No `CreateAction` was ever created by this command.** `CreateAction` entities (`#job-{id}-attempt-{attempt}`) are only auto-generated during job execution for jobs with *tracked* file I/O. A directory dataset isn't a tracked workflow file, so the producing job could have **no `CreateAction` at all** — leaving the PROV graph broken (a dataset whose `prov:wasGeneratedBy` points at a non-existent activity).
2. Even when a `CreateAction` existed, its `result` array didn't reference the dataset.
3. Users were forced to know the internal `#job-{id}-attempt-{attempt}` id convention and the attempt number.
4. No ergonomic path for multiple contributing jobs (e.g. a hive-partitioned dataset written by many parameterized jobs).

## Changes

- **Repeatable `-j` / `--job-id` flag** on `add-dataset` (`Vec<i64>`). clap validates each value independently — no comma-string parsing.
- For each job: create-or-update its `CreateAction` entity (appending the dataset to its `result`, preserving any runtime-tracked outputs), idempotently ensure the workflow plan/run/software entities exist, and set the dataset's `prov:wasGeneratedBy` to reference those `CreateAction`s. The user `--metadata` merge still applies last, so an explicit override wins.
- `ro_crate_utils`: `link_dataset_to_job_create_action()` + `append_result_ref()`
- `ro_crate` command: `wire_dataset_job_provenance()` + `resolve_file_paths()`

## Tests

- New integration suite `tests/test_ro_crate_add_dataset_provenance.rs` (real server + CLI): create path, multiple-jobs path, and update-existing-CreateAction path.
- Unit test for `append_result_ref` (dedup, missing-key, non-array normalization).
- Full ro_crate suite (37) + new tests pass; `cargo fmt`, `clippy -D warnings` clean.

## Note

This command now uses a repeatable `-j` flag while `workflows correct-resources` / `slurm` still use `--flag a,b`. Consistent direction would be migrating those to repeatable flags too — left as a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)