### PR TITLE
ro-crate: honor user-supplied stable identifiers on input files

### DIFF
--- a/docs/src/core/concepts/ro-crate.md
+++ b/docs/src/core/concepts/ro-crate.md
@@ -126,6 +126,26 @@ After running this workflow:
 - A CreateAction entity will describe the `process` job execution
 - `#torc-workflow` and `#torc-run-id-{run_id}` will describe the workflow plan and run activity
 
+### Stable identifiers for input files
+
+By default, an input file's `@id` is its filesystem path — a local, often transient string. When the
+file is a published dataset (DOI), a stable URN, or any other long-lived identifier, set
+`identifier` on the FileSpec and Torc uses it as the entity's `@id` instead:
+
+```yaml
+files:
+  - name: reference_genome
+    path: data/grch38.fa
+    identifier: https://doi.org/10.5524/100001
+```
+
+The local path is still recorded as `sameAs` so the bytes remain locatable. Identifiers must be
+unique within a workflow; parameterized files must include parameter placeholders in `identifier`
+the same way they do in `name` and `path`. Output files (produced by jobs) keep using the path as
+`@id`. See
+[FileSpec → RO-Crate identifiers](../reference/workflow-spec.md#ro-crate-identifiers-for-input-files)
+for the full reference.
+
 ## Dataset Entities for Directories
 
 Many workflows produce directory-based outputs rather than single files—for example,

--- a/docs/src/core/concepts/ro-crate.md
+++ b/docs/src/core/concepts/ro-crate.md
@@ -156,7 +156,8 @@ Spec-load validation rejects:
   `ro-crate-metadata.json`, `./`),
 - `identifier` on output files (including files used as both input and output, because the output
   completion path resets `entity_id` back to the file path),
-- `identifier` on files that are not referenced as a job input.
+- `identifier` on files that are not referenced as a job input AND have no explicit `st_mtime` (a
+  file with `st_mtime` set in the spec counts as a pre-existing input even without a job reference).
 
 For parameterized files, the identifier template must include the same placeholders as `name` and
 `path`. See

--- a/docs/src/core/concepts/ro-crate.md
+++ b/docs/src/core/concepts/ro-crate.md
@@ -130,19 +130,36 @@ After running this workflow:
 
 By default, an input file's `@id` is its filesystem path — a local, often transient string. When the
 file is a published dataset (DOI), a stable URN, or any other long-lived identifier, set
-`identifier` on the FileSpec and Torc uses it as the entity's `@id` instead:
+`identifier` on the FileSpec (and `enable_ro_crate: true` at the workflow level) and Torc uses it as
+the entity's `@id` instead:
 
 ```yaml
+name: my_workflow
+enable_ro_crate: true
+
 files:
   - name: reference_genome
     path: data/grch38.fa
     identifier: https://doi.org/10.5524/100001
 ```
 
-The local path is still recorded as `sameAs` so the bytes remain locatable. Identifiers must be
-unique within a workflow; parameterized files must include parameter placeholders in `identifier`
-the same way they do in `name` and `path`. Output files (produced by jobs) keep using the path as
-`@id`. See
+The local path is recorded as `sameAs` so the bytes remain locatable, and CreateAction provenance
+refs that would otherwise point at the path are rewritten to the identifier at export time so the
+exported `@graph` stays self-consistent.
+
+Spec-load validation rejects:
+
+- `identifier` on any file when `enable_ro_crate` is not `true`,
+- duplicate identifiers within the workflow,
+- identifiers equal to another file's path (would collide in the same uniqueness index),
+- identifiers matching Torc's reserved IDs (`#torc-…`, `#software-…`, `#job-…`,
+  `ro-crate-metadata.json`, `./`),
+- `identifier` on output files (including files used as both input and output, because the output
+  completion path resets `entity_id` back to the file path),
+- `identifier` on files that are not referenced as a job input.
+
+For parameterized files, the identifier template must include the same placeholders as `name` and
+`path`. See
 [FileSpec → RO-Crate identifiers](../reference/workflow-spec.md#ro-crate-identifiers-for-input-files)
 for the full reference.
 

--- a/docs/src/core/how-to/ro-crate-metadata.md
+++ b/docs/src/core/how-to/ro-crate-metadata.md
@@ -259,9 +259,12 @@ torc ro-crate add-dataset "${TORC_WORKFLOW_ID}" \
 ```
 
 The argument must be a JSON object. Its top-level fields are applied as a shallow merge over the
-auto-computed metadata: user-supplied keys replace the auto-generated ones (`@id`, `@type`, `name`,
+auto-computed metadata: user-supplied keys replace the auto-generated ones (`@type`, `name`,
 `contentSize`, ...) entirely on conflict, and nested objects are not deep-merged. Pass `-` to read
 the JSON from stdin for larger blobs:
+
+`@id` is not user-overridable via `--metadata`: it's derived from the dataset directory path and
+re-applied at export time, so any `@id` field inside the JSON is silently replaced.
 
 ```bash
 torc ro-crate add-dataset "${TORC_WORKFLOW_ID}" \
@@ -372,8 +375,9 @@ The exported document has this structure:
 }
 ```
 
-Torc preserves any explicit `@id` and `@type` already present in the stored metadata. If either
-field is missing, the exporter fills it in from the entity record.
+The exporter always sets each entity's `@id` from its stored `entity_id`, overwriting any `@id`
+field present in the stored metadata. `@type` is preserved when present and filled in from the
+entity record only when missing.
 
 ## Workflow Export/Import
 

--- a/docs/src/core/reference/workflow-spec.md
+++ b/docs/src/core/reference/workflow-spec.md
@@ -125,13 +125,55 @@ exports these variables before running the job's `invocation_script`, if any.
 
 Defines input/output file artifacts that establish implicit job dependencies.
 
-| Name             | Type                  | Default     | Description                                                   |
-| ---------------- | --------------------- | ----------- | ------------------------------------------------------------- |
-| `name`           | string                | _required_  | Name of the file (used for referencing in jobs)               |
-| `path`           | string                | _required_  | File system path                                              |
-| `parameters`     | map\<string, string\> | none        | Parameters for generating multiple files                      |
-| `parameter_mode` | string                | `"product"` | How to combine parameters: `"product"` (Cartesian) or `"zip"` |
-| `use_parameters` | [string]              | none        | Workflow parameter names to use for this file                 |
+| Name             | Type                  | Default     | Description                                                                                                                    |
+| ---------------- | --------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `name`           | string                | _required_  | Name of the file (used for referencing in jobs)                                                                                |
+| `path`           | string                | _required_  | File system path                                                                                                               |
+| `identifier`     | string                | none        | Stable RO-Crate `@id` for an input file (DOI, PURL, URN, …). See [RO-Crate identifiers](#ro-crate-identifiers-for-input-files) |
+| `parameters`     | map\<string, string\> | none        | Parameters for generating multiple files                                                                                       |
+| `parameter_mode` | string                | `"product"` | How to combine parameters: `"product"` (Cartesian) or `"zip"`                                                                  |
+| `use_parameters` | [string]              | none        | Workflow parameter names to use for this file                                                                                  |
+
+### RO-Crate identifiers for input files
+
+By default, the RO-Crate `@id` of an input file's File entity is its filesystem `path`. When that's
+the wrong identifier — e.g. the file is a published dataset with a DOI, or you want to reference a
+long-lived URN rather than a transient local path — set `identifier` on the FileSpec:
+
+```yaml
+files:
+  - name: reference_genome
+    path: data/grch38.fa
+    identifier: https://doi.org/10.5524/100001
+```
+
+The exported entity uses the supplied identifier as `@id`; the local path is preserved as `sameAs`
+so consumers can still locate the bytes on disk:
+
+```json
+{
+  "@id": "https://doi.org/10.5524/100001",
+  "@type": ["File", "prov:Entity"],
+  "name": "grch38.fa",
+  "sameAs": { "@id": "data/grch38.fa" }
+}
+```
+
+Identifiers must be unique within a workflow. For parameterized files, include the same placeholders
+in `identifier` that you use in `name` and `path`:
+
+```yaml
+files:
+  - name: input_{i}
+    path: data/input_{i}.csv
+    identifier: "urn:dataset:run-2026:{i}"
+    parameters:
+      i: "1:10"
+```
+
+`identifier` is honoured for files Torc classifies as **inputs** (files referenced as a job input,
+or with `st_mtime` set). Output files — those produced by jobs — still use the path as `@id`;
+setting `identifier` on an output file has no effect.
 
 ## UserDataSpec
 

--- a/docs/src/core/reference/workflow-spec.md
+++ b/docs/src/core/reference/workflow-spec.md
@@ -194,7 +194,9 @@ Spec-load validation rejects the following at parse time:
   (synthetic export roots).
 - `identifier` on output files, including files referenced as both input AND output (the output
   completion path always rewrites `entity_id` back to the file path).
-- `identifier` on files that are not referenced by any job as an input.
+- `identifier` on files that are not referenced by any job as an input AND have no explicit
+  `st_mtime` (a file with `st_mtime` set in the spec counts as a pre-existing input even without a
+  job reference).
 
 ## UserDataSpec
 

--- a/docs/src/core/reference/workflow-spec.md
+++ b/docs/src/core/reference/workflow-spec.md
@@ -138,9 +138,14 @@ Defines input/output file artifacts that establish implicit job dependencies.
 
 By default, the RO-Crate `@id` of an input file's File entity is its filesystem `path`. When that's
 the wrong identifier — e.g. the file is a published dataset with a DOI, or you want to reference a
-long-lived URN rather than a transient local path — set `identifier` on the FileSpec:
+long-lived URN rather than a transient local path — set `identifier` on the FileSpec. The workflow
+must also set `enable_ro_crate: true` at the top level; identifiers are rejected on workflows that
+opt out of automatic RO-Crate provenance.
 
 ```yaml
+name: my_workflow
+enable_ro_crate: true
+
 files:
   - name: reference_genome
     path: data/grch38.fa
@@ -159,10 +164,17 @@ so consumers can still locate the bytes on disk:
 }
 ```
 
-Identifiers must be unique within a workflow. For parameterized files, include the same placeholders
-in `identifier` that you use in `name` and `path`:
+CreateAction provenance references (`prov:used` / `object`) that would otherwise serialize as the
+file path are rewritten to the identifier at export time, so the exported `@graph` stays
+self-consistent.
+
+For parameterized files, include the same placeholders in `identifier` that you use in `name` and
+`path`:
 
 ```yaml
+name: parameterized_workflow
+enable_ro_crate: true
+
 files:
   - name: input_{i}
     path: data/input_{i}.csv
@@ -171,9 +183,18 @@ files:
       i: "1:10"
 ```
 
-`identifier` is honoured for files Torc classifies as **inputs** (files referenced as a job input,
-or with `st_mtime` set). Output files — those produced by jobs — still use the path as `@id`;
-setting `identifier` on an output file has no effect.
+Spec-load validation rejects the following at parse time:
+
+- `identifier` on any file when the workflow does not set `enable_ro_crate: true`.
+- Duplicate identifiers (after parameter expansion).
+- An identifier equal to another file's `path` (would collide in the same workflow-scoped uniqueness
+  index).
+- Identifiers matching Torc's reserved IDs / prefixes: `#torc-…` (workflow/run provenance),
+  `#software-…` (software agents), `#job-…` (CreateActions), `ro-crate-metadata.json`, and `./`
+  (synthetic export roots).
+- `identifier` on output files, including files referenced as both input AND output (the output
+  completion path always rewrites `entity_id` back to the file path).
+- `identifier` on files that are not referenced by any job as an input.
 
 ## UserDataSpec
 

--- a/docs/src/specialized/design/ro-crate.md
+++ b/docs/src/specialized/design/ro-crate.md
@@ -112,11 +112,15 @@ flowchart TD
 - The entity is keyed by workflow and `file_id`, with `entity_id = file.path` by default
 - When a `FileSpec` carries a user-supplied `identifier`, `create_files` pre-creates the entity row
   at workflow-creation time with `entity_id = identifier` and `metadata["@id"] = identifier`. The
-  server's init-time upsert preserves the `entity_id` column but rewrites `metadata["@id"]` to
-  `file.path`; the client-side `create_ro_crate_entity_for_file` then reads `entity_id` back and
-  uses it as an override when rebuilding metadata, restoring `@id`. This three-step round-trip is
-  what lets users carry a stable identifier (DOI, URN, …) into the exported crate without changing
-  the server
+  server's init-time upsert preserves the `entity_id` column even though it rewrites
+  `metadata["@id"]` back to `file.path`. Export then uses `entity_id` as the authoritative `@id`
+  (overwriting whatever ends up in `metadata["@id"]`), so the user identifier survives regardless of
+  whether the client-side `create_ro_crate_entity_for_file` ran afterward — important because the
+  async-init path returns before the client-side rebuild can re-write `metadata["@id"]`.
+- Export also builds a path → entity_id map from File entities' `sameAs` and rewrites nested
+  `{ "@id": "<path>" }` references throughout the graph, so CreateAction `prov:used` / `object` and
+  output `prov:wasDerivedFrom` link to the identifier rather than the path. The entity's own `@id`
+  and any `sameAs` field are deliberately not rewritten.
 - The local path is preserved as `sameAs` on entities whose `@id` was overridden, so consumers can
   still resolve to the bytes
 - Input file entities are expected to exist before jobs run, but the code does not rely on them

--- a/docs/src/specialized/design/ro-crate.md
+++ b/docs/src/specialized/design/ro-crate.md
@@ -109,7 +109,16 @@ flowchart TD
 
 - Input files are detected by `st_mtime IS NOT NULL`
 - During initialization, both the server and the client currently upsert the same input file entity
-- The entity is keyed by workflow and `file_id`, with `entity_id = file.path`
+- The entity is keyed by workflow and `file_id`, with `entity_id = file.path` by default
+- When a `FileSpec` carries a user-supplied `identifier`, `create_files` pre-creates the entity row
+  at workflow-creation time with `entity_id = identifier` and `metadata["@id"] = identifier`. The
+  server's init-time upsert preserves the `entity_id` column but rewrites `metadata["@id"]` to
+  `file.path`; the client-side `create_ro_crate_entity_for_file` then reads `entity_id` back and
+  uses it as an override when rebuilding metadata, restoring `@id`. This three-step round-trip is
+  what lets users carry a stable identifier (DOI, URN, …) into the exported crate without changing
+  the server
+- The local path is preserved as `sameAs` on entities whose `@id` was overridden, so consumers can
+  still resolve to the bytes
 - Input file entities are expected to exist before jobs run, but the code does not rely on them
   being create-only; it is intentionally upsert-based
 

--- a/src/client/commands/ro_crate.rs
+++ b/src/client/commands/ro_crate.rs
@@ -10,7 +10,7 @@ use crate::client::commands::{
     print_error, select_workflow_interactively, table_format::display_table_with_count,
 };
 use crate::models;
-use log::{error, info, warn};
+use log::{error, info};
 use rayon::prelude::*;
 use sha2::{Digest, Sha256};
 use std::collections::HashSet;
@@ -798,10 +798,17 @@ fn wire_dataset_job_provenance(
                 );
                 action_ids.push(action_id);
             }
-            None => warn!(
-                "Failed to record CreateAction provenance for job_id={}",
-                job_id
-            ),
+            None => {
+                // The user explicitly requested provenance for this job via
+                // `-j`; bail rather than silently emit a dataset whose
+                // `prov:wasGeneratedBy` is missing or partial. The inner
+                // call has already logged the failure cause.
+                error!(
+                    "Failed to record CreateAction provenance for job_id={}, aborting before dataset creation",
+                    job_id
+                );
+                std::process::exit(1);
+            }
         }
     }
     action_ids

--- a/src/client/commands/ro_crate.rs
+++ b/src/client/commands/ro_crate.rs
@@ -13,7 +13,7 @@ use crate::models;
 use log::{error, info};
 use rayon::prelude::*;
 use sha2::{Digest, Sha256};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use tabled::Tabled;
 
 #[derive(Tabled)]
@@ -412,6 +412,58 @@ fn read_metadata_input(metadata: &str) -> String {
     }
 }
 
+/// Rewrite every nested `{"@id": "<path>"}` reference inside `value` whose
+/// `<path>` is in `path_to_entity_id`, so provenance refs point at the
+/// file's stable identifier instead of a no-longer-keyed local path.
+///
+/// Skips:
+/// - the top-level `@id` of `value` (already set authoritatively from
+///   `entity_id` by the caller, and the file's own `@id` should not be
+///   rewritten away from its identifier).
+/// - the `sameAs` field, which is supposed to carry the original path.
+fn translate_path_refs(value: &mut serde_json::Value, path_to_entity_id: &HashMap<String, String>) {
+    if path_to_entity_id.is_empty() {
+        return;
+    }
+    fn walk(value: &mut serde_json::Value, map: &HashMap<String, String>) {
+        match value {
+            serde_json::Value::Object(obj) => {
+                for (key, child) in obj.iter_mut() {
+                    if key == "sameAs" {
+                        continue;
+                    }
+                    walk(child, map);
+                }
+                // After recursing, rewrite a child `@id` whose value is a
+                // path we know an identifier for. Doing this after the
+                // recursion is fine because `@id` values are strings, not
+                // objects, so there's nothing to recurse into.
+                if let Some(serde_json::Value::String(id)) = obj.get_mut("@id")
+                    && let Some(replacement) = map.get(id.as_str())
+                {
+                    *id = replacement.clone();
+                }
+            }
+            serde_json::Value::Array(arr) => {
+                for item in arr {
+                    walk(item, map);
+                }
+            }
+            _ => {}
+        }
+    }
+    // Top-level `@id` of `value` is the entity's own ID; preserve it by
+    // walking only the inner children.
+    if let serde_json::Value::Object(obj) = value {
+        for (key, child) in obj.iter_mut() {
+            if key == "@id" || key == "sameAs" {
+                continue;
+            }
+            walk(child, path_to_entity_id);
+        }
+    }
+}
+
 fn handle_export(config: &Configuration, workflow_id: i64, output_path: Option<&str>) {
     // Fetch the workflow name and current run for the root dataset.
     let (workflow_name, run_id) = match apis::workflows_api::get_workflow(config, workflow_id) {
@@ -460,16 +512,43 @@ fn handle_export(config: &Configuration, workflow_id: i64, output_path: Option<&
         synthetic_entities.push(run_entity);
     }
 
+    // Build a path → entity_id translation map from input File entities. When
+    // the user gave a file a stable identifier, `build_file_entity` records
+    // the local path under `sameAs` and uses the identifier as `entity_id`.
+    // CreateAction `prov:used` / `object` and output `prov:wasDerivedFrom`
+    // still serialize input references as paths, so translate them through
+    // this map at export time. This is also what restores user identifiers
+    // after the server's init-time upsert rewrites `metadata["@id"]` back to
+    // the path (which happens in the async-init path where no client-side
+    // rebuild runs afterward).
+    let path_to_entity_id: HashMap<String, String> = entities
+        .iter()
+        .filter(|e| e.file_id.is_some() && !e.entity_id.is_empty())
+        .filter_map(|e| {
+            let parsed: serde_json::Value = serde_json::from_str(&e.metadata).ok()?;
+            let path = parsed.get("sameAs")?.get("@id")?.as_str()?.to_string();
+            if path == e.entity_id {
+                return None;
+            }
+            Some((path, e.entity_id.clone()))
+        })
+        .collect();
+
     // Build user and synthetic entities first so hasPart can include the final set.
     let mut graph_entities: Vec<serde_json::Value> = synthetic_entities;
     for entity in &entities {
         if let Ok(mut parsed) = serde_json::from_str::<serde_json::Value>(&entity.metadata) {
             if let Some(obj) = parsed.as_object_mut() {
-                obj.entry("@id".to_string())
-                    .or_insert_with(|| serde_json::json!(entity.entity_id));
+                // `entity_id` is the source of truth for an entity's `@id`.
+                // Always emit it (overwriting any stale `metadata["@id"]` that
+                // the server's init-time upsert might have written back to the
+                // file path), so user-supplied identifiers persist regardless
+                // of which initialization code path ran.
+                obj.insert("@id".to_string(), serde_json::json!(entity.entity_id));
                 obj.entry("@type".to_string())
                     .or_insert_with(|| serde_json::json!(entity.entity_type));
             }
+            translate_path_refs(&mut parsed, &path_to_entity_id);
             graph_entities.push(parsed);
         } else {
             graph_entities.push(serde_json::json!({
@@ -1032,5 +1111,58 @@ mod tests {
     fn parse_extra_metadata_rejects_non_object() {
         let err = parse_extra_metadata("[1, 2, 3]").unwrap_err();
         assert!(err.contains("must be a JSON object"), "got: {}", err);
+    }
+
+    #[test]
+    fn translate_path_refs_rewrites_nested_id_refs() {
+        // CreateAction-style metadata that references inputs by their path.
+        // After translation, those refs must point at the input's identifier
+        // -- but the entity's own @id and the file-entity's sameAs must be
+        // left alone.
+        let mut map = HashMap::new();
+        map.insert(
+            "data/input.csv".to_string(),
+            "https://doi.org/10.1234/abc".to_string(),
+        );
+
+        let mut create_action = json!({
+            "@id": "#job-42-attempt-1",
+            "@type": ["CreateAction", "prov:Activity"],
+            "object": { "@id": "data/input.csv" },
+            "prov:used": [{ "@id": "data/input.csv" }],
+            "result": [{ "@id": "data/output.csv" }],
+        });
+        translate_path_refs(&mut create_action, &map);
+        assert_eq!(create_action["@id"], "#job-42-attempt-1");
+        assert_eq!(
+            create_action["object"]["@id"],
+            "https://doi.org/10.1234/abc"
+        );
+        assert_eq!(
+            create_action["prov:used"][0]["@id"],
+            "https://doi.org/10.1234/abc"
+        );
+        // Output paths without an identifier mapping pass through unchanged.
+        assert_eq!(create_action["result"][0]["@id"], "data/output.csv");
+
+        // The file entity itself: outer @id (its identifier) and inner
+        // sameAs (its local path) must both be preserved.
+        let mut file_entity = json!({
+            "@id": "https://doi.org/10.1234/abc",
+            "@type": ["File", "prov:Entity"],
+            "sameAs": { "@id": "data/input.csv" },
+        });
+        translate_path_refs(&mut file_entity, &map);
+        assert_eq!(file_entity["@id"], "https://doi.org/10.1234/abc");
+        assert_eq!(file_entity["sameAs"]["@id"], "data/input.csv");
+    }
+
+    #[test]
+    fn translate_path_refs_empty_map_is_noop() {
+        let map: HashMap<String, String> = HashMap::new();
+        let mut v = json!({ "object": { "@id": "data/x.csv" } });
+        let before = v.clone();
+        translate_path_refs(&mut v, &map);
+        assert_eq!(v, before);
     }
 }

--- a/src/client/commands/ro_crate.rs
+++ b/src/client/commands/ro_crate.rs
@@ -765,7 +765,11 @@ fn wire_dataset_job_provenance(
     crate::client::ro_crate_utils::create_software_entities(config, workflow_id, run_id);
 
     let mut action_ids = Vec::new();
+    let mut seen = std::collections::HashSet::new();
     for &job_id in job_ids {
+        if !seen.insert(job_id) {
+            continue;
+        }
         let job = match apis::jobs_api::get_job(config, job_id) {
             Ok(job) => job,
             Err(e) => {
@@ -776,6 +780,13 @@ fn wire_dataset_job_provenance(
                 std::process::exit(1);
             }
         };
+        if job.workflow_id != workflow_id {
+            eprintln!(
+                "Error: job {} belongs to workflow {}, not target workflow {}",
+                job_id, job.workflow_id, workflow_id
+            );
+            std::process::exit(1);
+        }
         let attempt_id = job.attempt_id.unwrap_or(1);
         let input_file_paths =
             resolve_file_paths(config, job.input_file_ids.as_deref().unwrap_or(&[]));

--- a/src/client/commands/ro_crate.rs
+++ b/src/client/commands/ro_crate.rs
@@ -36,13 +36,19 @@ pub enum RoCrateCommands {
         /// Workflow ID (optional - will prompt if not provided)
         #[arg()]
         workflow_id: Option<i64>,
-        /// JSON-LD @id for this entity (e.g., "data/output.parquet")
+        /// JSON-LD @id for this entity (e.g., "data/output.parquet"). This is
+        /// the authoritative `@id` -- the export step always sets the exported
+        /// entity's `@id` from this value, overwriting any `@id` field present
+        /// in `--metadata`.
         #[arg(long)]
         entity_id: String,
         /// Schema.org @type (e.g., "File", "Dataset", "SoftwareApplication")
         #[arg(long, name = "type")]
         entity_type: String,
-        /// JSON-LD metadata as a JSON string, or "-" to read from stdin
+        /// JSON-LD metadata as a JSON string, or "-" to read from stdin. Any
+        /// `@id` field inside the metadata is ignored at export time and
+        /// replaced with `--entity-id`; to change an entity's exported `@id`,
+        /// update `--entity-id`, not the metadata.
         #[arg(long)]
         metadata: String,
         /// Optional file ID to link this entity to
@@ -73,13 +79,18 @@ pub enum RoCrateCommands {
         /// ID of the RO-Crate entity to update
         #[arg()]
         id: i64,
-        /// New JSON-LD @id
+        /// New JSON-LD @id. This is the authoritative `@id` -- export always
+        /// sets the exported entity's `@id` from this value, overwriting any
+        /// `@id` field present in `--metadata`.
         #[arg(long)]
         entity_id: Option<String>,
         /// New Schema.org @type
         #[arg(long, name = "type")]
         entity_type: Option<String>,
-        /// New JSON-LD metadata as a JSON string, or "-" to read from stdin
+        /// New JSON-LD metadata as a JSON string, or "-" to read from stdin.
+        /// Any `@id` field inside the metadata is ignored at export time and
+        /// replaced with `--entity-id` (or the stored `entity_id` if you
+        /// don't pass `--entity-id`).
         #[arg(long)]
         metadata: Option<String>,
         /// New file ID to link (use 0 to unlink)
@@ -151,8 +162,12 @@ pub enum RoCrateCommands {
         /// Extra JSON-LD metadata applied as a top-level merge over the
         /// entity (or "-" to read from stdin). Must be a JSON object. The
         /// merge is shallow: each user-supplied top-level field replaces the
-        /// auto-computed one with the same key (`@id`, `@type`, `name`,
+        /// auto-computed one with the same key (`@type`, `name`,
         /// `contentSize`, ...) entirely; nested objects are not deep-merged.
+        ///
+        /// `@id` is NOT user-overridable here: it's set from the dataset
+        /// directory path and re-applied at export time, so any `@id` field
+        /// inside `--metadata` is silently replaced.
         ///
         /// To record which job(s) produced this dataset, use the `-j` flag
         /// rather than setting `prov:wasGeneratedBy` here directly.
@@ -417,21 +432,26 @@ fn read_metadata_input(metadata: &str) -> String {
 /// file's stable identifier instead of a no-longer-keyed local path.
 ///
 /// Skips:
-/// - the top-level `@id` of `value` (already set authoritatively from
-///   `entity_id` by the caller, and the file's own `@id` should not be
-///   rewritten away from its identifier).
-/// - the `sameAs` field, which is supposed to carry the original path.
-fn translate_path_refs(value: &mut serde_json::Value, path_to_entity_id: &HashMap<String, String>) {
+/// - the top-level `@id` of `value`: already set authoritatively from
+///   `entity_id` by the caller, and a File entity's own `@id` should not be
+///   rewritten away from its identifier.
+/// - the top-level `sameAs` of File entities only (`entity_type == "File"`):
+///   that field carries the deliberately-untranslated local path on file
+///   rows. Other entity types' `sameAs` (and any nested `sameAs`) is walked
+///   normally so refs stay consistent if a future Dataset/etc. uses one to
+///   alias a path.
+fn translate_path_refs(
+    value: &mut serde_json::Value,
+    path_to_entity_id: &HashMap<String, String>,
+    entity_type: &str,
+) {
     if path_to_entity_id.is_empty() {
         return;
     }
     fn walk(value: &mut serde_json::Value, map: &HashMap<String, String>) {
         match value {
             serde_json::Value::Object(obj) => {
-                for (key, child) in obj.iter_mut() {
-                    if key == "sameAs" {
-                        continue;
-                    }
+                for (_key, child) in obj.iter_mut() {
                     walk(child, map);
                 }
                 // After recursing, rewrite a child `@id` whose value is a
@@ -452,11 +472,10 @@ fn translate_path_refs(value: &mut serde_json::Value, path_to_entity_id: &HashMa
             _ => {}
         }
     }
-    // Top-level `@id` of `value` is the entity's own ID; preserve it by
-    // walking only the inner children.
+    let skip_top_level_same_as = entity_type == "File";
     if let serde_json::Value::Object(obj) = value {
         for (key, child) in obj.iter_mut() {
-            if key == "@id" || key == "sameAs" {
+            if key == "@id" || (skip_top_level_same_as && key == "sameAs") {
                 continue;
             }
             walk(child, path_to_entity_id);
@@ -548,7 +567,7 @@ fn handle_export(config: &Configuration, workflow_id: i64, output_path: Option<&
                 obj.entry("@type".to_string())
                     .or_insert_with(|| serde_json::json!(entity.entity_type));
             }
-            translate_path_refs(&mut parsed, &path_to_entity_id);
+            translate_path_refs(&mut parsed, &path_to_entity_id, &entity.entity_type);
             graph_entities.push(parsed);
         } else {
             graph_entities.push(serde_json::json!({
@@ -1132,7 +1151,7 @@ mod tests {
             "prov:used": [{ "@id": "data/input.csv" }],
             "result": [{ "@id": "data/output.csv" }],
         });
-        translate_path_refs(&mut create_action, &map);
+        translate_path_refs(&mut create_action, &map, "CreateAction");
         assert_eq!(create_action["@id"], "#job-42-attempt-1");
         assert_eq!(
             create_action["object"]["@id"],
@@ -1145,16 +1164,36 @@ mod tests {
         // Output paths without an identifier mapping pass through unchanged.
         assert_eq!(create_action["result"][0]["@id"], "data/output.csv");
 
-        // The file entity itself: outer @id (its identifier) and inner
+        // The file entity itself: outer @id (its identifier) and outer
         // sameAs (its local path) must both be preserved.
         let mut file_entity = json!({
             "@id": "https://doi.org/10.1234/abc",
             "@type": ["File", "prov:Entity"],
             "sameAs": { "@id": "data/input.csv" },
         });
-        translate_path_refs(&mut file_entity, &map);
+        translate_path_refs(&mut file_entity, &map, "File");
         assert_eq!(file_entity["@id"], "https://doi.org/10.1234/abc");
         assert_eq!(file_entity["sameAs"]["@id"], "data/input.csv");
+    }
+
+    #[test]
+    fn translate_path_refs_non_file_top_level_same_as_is_translated() {
+        // The top-level `sameAs` preservation is scoped to File entities. For
+        // any other entity type, `sameAs` is treated like any other ref and
+        // gets translated when its `@id` matches a known path.
+        let mut map = HashMap::new();
+        map.insert(
+            "data/input.csv".to_string(),
+            "https://doi.org/10.1234/abc".to_string(),
+        );
+
+        let mut dataset = json!({
+            "@id": "#some-dataset",
+            "@type": "Dataset",
+            "sameAs": { "@id": "data/input.csv" },
+        });
+        translate_path_refs(&mut dataset, &map, "Dataset");
+        assert_eq!(dataset["sameAs"]["@id"], "https://doi.org/10.1234/abc");
     }
 
     #[test]
@@ -1162,7 +1201,7 @@ mod tests {
         let map: HashMap<String, String> = HashMap::new();
         let mut v = json!({ "object": { "@id": "data/x.csv" } });
         let before = v.clone();
-        translate_path_refs(&mut v, &map);
+        translate_path_refs(&mut v, &map, "CreateAction");
         assert_eq!(v, before);
     }
 }

--- a/src/client/commands/ro_crate.rs
+++ b/src/client/commands/ro_crate.rs
@@ -106,10 +106,18 @@ pub enum RoCrateCommands {
     /// such as a hive-partitioned Parquet dataset. Computes file count, total
     /// size, and optionally a manifest or content hash.
     ///
-    /// Use `--metadata` to add JSON-LD fields to the entity, such as
-    /// `prov:wasGeneratedBy` to link the dataset to the job that created it.
-    /// The merge is shallow at the top level: user-supplied keys replace
-    /// auto-computed ones entirely (no deep object merge).
+    /// Use `--job-id` (repeatable, `-j`) to record provenance for the job(s)
+    /// that produced the dataset. For each job, a `CreateAction` entity is
+    /// created (or, if one already exists from a prior run, updated) with the
+    /// dataset added to its `result`, and the dataset's `prov:wasGeneratedBy`
+    /// is set to reference those CreateActions. This wires the full PROV graph
+    /// automatically without hand-writing internal
+    /// `#job-{id}-attempt-{attempt}` ids.
+    ///
+    /// Use `--metadata` to add or override JSON-LD fields on the Dataset
+    /// entity. The merge is shallow at the top level: user-supplied keys
+    /// replace auto-computed ones (including `prov:wasGeneratedBy`) entirely
+    /// (no deep object merge).
     #[command(name = "add-dataset")]
     AddDataset {
         /// Workflow ID (optional - will prompt if not provided)
@@ -133,6 +141,12 @@ pub enum RoCrateCommands {
         /// Number of threads for parallel processing (default: number of CPUs)
         #[arg(long, short = 't')]
         threads: Option<usize>,
+        /// Job ID that produced this dataset. Repeat the flag for multiple
+        /// jobs (e.g. `-j 42 -j 67`). For each job, a CreateAction provenance
+        /// entity is created or updated and the dataset's
+        /// `prov:wasGeneratedBy` is wired to reference it.
+        #[arg(long = "job-id", short = 'j', value_name = "JOB_ID")]
+        job_ids: Vec<i64>,
         /// Extra JSON-LD metadata applied as a top-level merge over the
         /// entity (or "-" to read from stdin). Must be a JSON object. The
         /// merge is shallow: each user-supplied top-level field replaces the
@@ -357,6 +371,7 @@ pub fn handle_ro_crate_commands(config: &Configuration, command: &RoCrateCommand
             description,
             encoding_format,
             threads,
+            job_ids,
             metadata,
         } => {
             let user_name = get_env_user_name();
@@ -374,6 +389,7 @@ pub fn handle_ro_crate_commands(config: &Configuration, command: &RoCrateCommand
                 description.as_deref(),
                 encoding_format.as_deref(),
                 *threads,
+                job_ids,
                 extra_metadata.as_deref(),
                 format,
             );
@@ -702,6 +718,96 @@ fn merge_dataset_metadata(
     Ok(base)
 }
 
+/// Resolve file ids to paths, logging (but not failing) on lookup errors.
+fn resolve_file_paths(config: &Configuration, file_ids: &[i64]) -> Vec<String> {
+    let mut paths = Vec::with_capacity(file_ids.len());
+    for &file_id in file_ids {
+        match apis::files_api::get_file(config, file_id) {
+            Ok(file) => paths.push(file.path),
+            Err(e) => eprintln!(
+                "Warning: could not resolve file id {} for provenance: {}",
+                file_id, e
+            ),
+        }
+    }
+    paths
+}
+
+/// Create or update CreateAction provenance entities for the jobs that produced
+/// a dataset, returning the CreateAction entity ids to wire into the dataset's
+/// `prov:wasGeneratedBy`.
+///
+/// Also ensures the workflow plan/run and software entities exist so the
+/// CreateActions resolve to a complete PROV graph even when `add-dataset` is
+/// run after the fact.
+fn wire_dataset_job_provenance(
+    config: &Configuration,
+    workflow_id: i64,
+    job_ids: &[i64],
+    dataset_entity_id: &str,
+) -> Vec<String> {
+    let (workflow_name, run_id) = match apis::workflows_api::get_workflow(config, workflow_id) {
+        Ok(workflow) => (workflow.name, workflow.run_id.unwrap_or(0)),
+        Err(e) => {
+            print_error("getting workflow for dataset provenance", &e);
+            std::process::exit(1);
+        }
+    };
+
+    // Idempotent: ensures plan/run/software entities referenced by the
+    // CreateActions exist (they normally are created during init/run).
+    crate::client::ro_crate_utils::create_workflow_provenance_entities(
+        config,
+        workflow_id,
+        run_id,
+        &workflow_name,
+    );
+    crate::client::ro_crate_utils::create_software_entities(config, workflow_id, run_id);
+
+    let mut action_ids = Vec::new();
+    for &job_id in job_ids {
+        let job = match apis::jobs_api::get_job(config, job_id) {
+            Ok(job) => job,
+            Err(e) => {
+                print_error(
+                    &format!("getting job {} for dataset provenance", job_id),
+                    &e,
+                );
+                std::process::exit(1);
+            }
+        };
+        let attempt_id = job.attempt_id.unwrap_or(1);
+        let input_file_paths =
+            resolve_file_paths(config, job.input_file_ids.as_deref().unwrap_or(&[]));
+        let output_file_paths =
+            resolve_file_paths(config, job.output_file_ids.as_deref().unwrap_or(&[]));
+
+        match crate::client::ro_crate_utils::link_dataset_to_job_create_action(
+            config,
+            workflow_id,
+            run_id,
+            &job,
+            attempt_id,
+            &input_file_paths,
+            &output_file_paths,
+            dataset_entity_id,
+        ) {
+            Some(action_id) => {
+                println!(
+                    "  Linked CreateAction '{}' (job '{}') to dataset",
+                    action_id, job.name
+                );
+                action_ids.push(action_id);
+            }
+            None => eprintln!(
+                "Warning: failed to record CreateAction provenance for job {}",
+                job_id
+            ),
+        }
+    }
+    action_ids
+}
+
 #[allow(clippy::too_many_arguments)]
 fn handle_add_dataset(
     config: &Configuration,
@@ -712,6 +818,7 @@ fn handle_add_dataset(
     description: Option<&str>,
     encoding_format: Option<&str>,
     threads: Option<usize>,
+    job_ids: &[i64],
     extra_metadata: Option<&str>,
     format: &str,
 ) {
@@ -792,6 +899,28 @@ fn handle_add_dataset(
 
     if let Some(enc) = encoding_format {
         metadata["encodingFormat"] = serde_json::json!(enc);
+    }
+
+    // Record provenance for the job(s) that produced this dataset. For each
+    // job we create or update its CreateAction entity (adding this dataset to
+    // its `result`) and collect the CreateAction ids to wire the dataset's
+    // `prov:wasGeneratedBy`. Done before the user `--metadata` merge so an
+    // explicit `prov:wasGeneratedBy` can still override it.
+    if !job_ids.is_empty() {
+        let action_ids = wire_dataset_job_provenance(config, workflow_id, job_ids, &entity_id);
+        match action_ids.as_slice() {
+            [] => {}
+            [single] => {
+                metadata["prov:wasGeneratedBy"] = serde_json::json!({ "@id": single });
+            }
+            many => {
+                metadata["prov:wasGeneratedBy"] = serde_json::Value::Array(
+                    many.iter()
+                        .map(|id| serde_json::json!({ "@id": id }))
+                        .collect(),
+                );
+            }
+        }
     }
 
     // Apply user-supplied metadata last as a shallow top-level merge, so

--- a/src/client/commands/ro_crate.rs
+++ b/src/client/commands/ro_crate.rs
@@ -10,6 +10,7 @@ use crate::client::commands::{
     print_error, select_workflow_interactively, table_format::display_table_with_count,
 };
 use crate::models;
+use log::{error, info, warn};
 use rayon::prelude::*;
 use sha2::{Digest, Sha256};
 use std::collections::HashSet;
@@ -718,21 +719,6 @@ fn merge_dataset_metadata(
     Ok(base)
 }
 
-/// Resolve file ids to paths, logging (but not failing) on lookup errors.
-fn resolve_file_paths(config: &Configuration, file_ids: &[i64]) -> Vec<String> {
-    let mut paths = Vec::with_capacity(file_ids.len());
-    for &file_id in file_ids {
-        match apis::files_api::get_file(config, file_id) {
-            Ok(file) => paths.push(file.path),
-            Err(e) => eprintln!(
-                "Warning: could not resolve file id {} for provenance: {}",
-                file_id, e
-            ),
-        }
-    }
-    paths
-}
-
 /// Create or update CreateAction provenance entities for the jobs that produced
 /// a dataset, returning the CreateAction entity ids to wire into the dataset's
 /// `prov:wasGeneratedBy`.
@@ -740,6 +726,14 @@ fn resolve_file_paths(config: &Configuration, file_ids: &[i64]) -> Vec<String> {
 /// Also ensures the workflow plan/run and software entities exist so the
 /// CreateActions resolve to a complete PROV graph even when `add-dataset` is
 /// run after the fact.
+///
+/// The built CreateAction intentionally records no `object`/`prov:used` or
+/// `result` other than the dataset itself: a job invoked via `add-dataset`
+/// produces a directory torc doesn't track, so the runtime never auto-creates
+/// a CreateAction (the runtime trigger requires non-empty tracked outputs).
+/// Populating tracked-file refs here would point at File entities that may not
+/// exist in the RO-Crate when `enable_ro_crate` is off. Users wanting richer
+/// `object`/`prov:used` can supply them via `--metadata`.
 fn wire_dataset_job_provenance(
     config: &Configuration,
     workflow_id: i64,
@@ -781,17 +775,13 @@ fn wire_dataset_job_provenance(
             }
         };
         if job.workflow_id != workflow_id {
-            eprintln!(
-                "Error: job {} belongs to workflow {}, not target workflow {}",
+            error!(
+                "job_id={} belongs to workflow_id={}, not target workflow_id={}",
                 job_id, job.workflow_id, workflow_id
             );
             std::process::exit(1);
         }
         let attempt_id = job.attempt_id.unwrap_or(1);
-        let input_file_paths =
-            resolve_file_paths(config, job.input_file_ids.as_deref().unwrap_or(&[]));
-        let output_file_paths =
-            resolve_file_paths(config, job.output_file_ids.as_deref().unwrap_or(&[]));
 
         match crate::client::ro_crate_utils::link_dataset_to_job_create_action(
             config,
@@ -799,19 +789,17 @@ fn wire_dataset_job_provenance(
             run_id,
             &job,
             attempt_id,
-            &input_file_paths,
-            &output_file_paths,
             dataset_entity_id,
         ) {
             Some(action_id) => {
-                println!(
-                    "  Linked CreateAction '{}' (job '{}') to dataset",
-                    action_id, job.name
+                info!(
+                    "Linked CreateAction entity_id={} job_id={} job_name={} to dataset entity_id={}",
+                    action_id, job_id, job.name, dataset_entity_id
                 );
                 action_ids.push(action_id);
             }
-            None => eprintln!(
-                "Warning: failed to record CreateAction provenance for job {}",
+            None => warn!(
+                "Failed to record CreateAction provenance for job_id={}",
                 job_id
             ),
         }

--- a/src/client/commands/ro_crate.rs
+++ b/src/client/commands/ro_crate.rs
@@ -116,9 +116,9 @@ pub enum RoCrateCommands {
     /// `#job-{id}-attempt-{attempt}` ids.
     ///
     /// Use `--metadata` to add or override JSON-LD fields on the Dataset
-    /// entity. The merge is shallow at the top level: user-supplied keys
-    /// replace auto-computed ones (including `prov:wasGeneratedBy`) entirely
-    /// (no deep object merge).
+    /// entity (e.g. `license`, `creator`, `description`). The merge is
+    /// shallow at the top level: user-supplied keys replace auto-computed
+    /// ones entirely (no deep object merge).
     #[command(name = "add-dataset")]
     AddDataset {
         /// Workflow ID (optional - will prompt if not provided)
@@ -154,7 +154,8 @@ pub enum RoCrateCommands {
         /// auto-computed one with the same key (`@id`, `@type`, `name`,
         /// `contentSize`, ...) entirely; nested objects are not deep-merged.
         ///
-        /// Example: `--metadata '{"prov:wasGeneratedBy": {"@id": "#job-42-attempt-1"}}'`
+        /// To record which job(s) produced this dataset, use the `-j` flag
+        /// rather than setting `prov:wasGeneratedBy` here directly.
         #[arg(long)]
         metadata: Option<String>,
     },
@@ -694,29 +695,37 @@ fn compute_content_hash_parallel(
     Ok(hex::encode(final_hasher.finalize()))
 }
 
-/// Merge user-supplied JSON-LD metadata into auto-generated dataset metadata.
+/// Parse and validate user-supplied `--metadata` as a JSON object.
 ///
-/// The merge is **shallow**: each top-level key in `extra` replaces the
-/// matching key in `base` entirely (nested objects are not recursed into).
-/// Keys present only in one side are preserved. The base value must already
-/// be a JSON object; if `extra` does not parse as a JSON object an `Err` is
-/// returned with a user-facing message.
-fn merge_dataset_metadata(
-    mut base: serde_json::Value,
-    extra: &str,
-) -> Result<serde_json::Value, String> {
+/// Returns a user-facing error string if the input is not valid JSON or is
+/// not a JSON object. Separated from the merge so the parse can happen up
+/// front in `handle_add_dataset`, before any provenance side effects.
+fn parse_extra_metadata(extra: &str) -> Result<serde_json::Map<String, serde_json::Value>, String> {
     let parsed: serde_json::Value =
         serde_json::from_str(extra).map_err(|e| format!("--metadata is not valid JSON: {}", e))?;
-    let extra_obj = parsed
-        .as_object()
-        .ok_or_else(|| "--metadata must be a JSON object".to_string())?;
+    match parsed {
+        serde_json::Value::Object(map) => Ok(map),
+        _ => Err("--metadata must be a JSON object".to_string()),
+    }
+}
+
+/// Shallow top-level merge of an already-parsed user metadata object into
+/// auto-generated dataset metadata.
+///
+/// Each key in `extra` replaces the matching key in `base` entirely (nested
+/// objects are not recursed into). Keys present only in one side are
+/// preserved. Infallible: callers validate `extra` via `parse_extra_metadata`.
+fn merge_dataset_metadata(
+    mut base: serde_json::Value,
+    extra: &serde_json::Map<String, serde_json::Value>,
+) -> serde_json::Value {
     let base_obj = base
         .as_object_mut()
         .expect("dataset metadata is constructed as a JSON object");
-    for (key, value) in extra_obj {
+    for (key, value) in extra {
         base_obj.insert(key.clone(), value.clone());
     }
-    Ok(base)
+    base
 }
 
 /// Create or update CreateAction provenance entities for the jobs that produced
@@ -850,6 +859,21 @@ fn handle_add_dataset(
         std::process::exit(1);
     }
 
+    // Parse --metadata up front so a malformed value fails before any
+    // provenance side effects (CreateAction creates/updates). Without this,
+    // a bad --metadata would leave CreateActions whose `result` references a
+    // Dataset entity that never got created.
+    let parsed_extra_metadata = match extra_metadata {
+        Some(extra) => match parse_extra_metadata(extra) {
+            Ok(map) => Some(map),
+            Err(e) => {
+                eprintln!("Error: {}", e);
+                std::process::exit(1);
+            }
+        },
+        None => None,
+    };
+
     // Determine number of threads (default to number of CPUs)
     let num_threads = threads.unwrap_or_else(|| {
         std::thread::available_parallelism()
@@ -932,14 +956,8 @@ fn handle_add_dataset(
     // Apply user-supplied metadata last as a shallow top-level merge, so
     // explicit fields like prov:wasGeneratedBy land in the final entity and
     // any colliding top-level keys are replaced by the user-supplied value.
-    if let Some(extra) = extra_metadata {
-        metadata = match merge_dataset_metadata(metadata, extra) {
-            Ok(merged) => merged,
-            Err(e) => {
-                eprintln!("Error: {}", e);
-                std::process::exit(1);
-            }
-        };
+    if let Some(extra) = parsed_extra_metadata.as_ref() {
+        metadata = merge_dataset_metadata(metadata, extra);
     }
 
     // Create the RO-Crate entity
@@ -985,42 +1003,34 @@ mod tests {
     }
 
     #[test]
-    fn merge_dataset_metadata_adds_provenance_fields() {
-        let extra = r##"{"prov:wasGeneratedBy": {"@id": "#job-42-attempt-1"}}"##;
-        let merged = merge_dataset_metadata(base_dataset_metadata(), extra).unwrap();
-        assert_eq!(
-            merged["prov:wasGeneratedBy"],
-            json!({"@id": "#job-42-attempt-1"})
-        );
-        // Auto-computed fields are preserved when the user doesn't touch them.
-        assert_eq!(merged["fileCount"], json!(4));
-        assert_eq!(merged["@type"], json!("Dataset"));
-    }
-
-    #[test]
     fn merge_dataset_metadata_user_fields_override_defaults() {
-        let extra = r#"{"name": "custom_name", "@type": ["Dataset", "prov:Entity"]}"#;
-        let merged = merge_dataset_metadata(base_dataset_metadata(), extra).unwrap();
+        let extra =
+            parse_extra_metadata(r#"{"name": "custom_name", "@type": ["Dataset", "prov:Entity"]}"#)
+                .unwrap();
+        let merged = merge_dataset_metadata(base_dataset_metadata(), &extra);
         assert_eq!(merged["name"], json!("custom_name"));
         assert_eq!(merged["@type"], json!(["Dataset", "prov:Entity"]));
-    }
-
-    #[test]
-    fn merge_dataset_metadata_rejects_invalid_json() {
-        let err = merge_dataset_metadata(base_dataset_metadata(), "{not json").unwrap_err();
-        assert!(err.contains("not valid JSON"), "got: {}", err);
-    }
-
-    #[test]
-    fn merge_dataset_metadata_rejects_non_object() {
-        let err = merge_dataset_metadata(base_dataset_metadata(), "[1, 2, 3]").unwrap_err();
-        assert!(err.contains("must be a JSON object"), "got: {}", err);
+        // Auto-computed fields are preserved when the user doesn't touch them.
+        assert_eq!(merged["fileCount"], json!(4));
     }
 
     #[test]
     fn merge_dataset_metadata_empty_object_is_noop() {
+        let extra = parse_extra_metadata("{}").unwrap();
         let original = base_dataset_metadata();
-        let merged = merge_dataset_metadata(original.clone(), "{}").unwrap();
+        let merged = merge_dataset_metadata(original.clone(), &extra);
         assert_eq!(merged, original);
+    }
+
+    #[test]
+    fn parse_extra_metadata_rejects_invalid_json() {
+        let err = parse_extra_metadata("{not json").unwrap_err();
+        assert!(err.contains("not valid JSON"), "got: {}", err);
+    }
+
+    #[test]
+    fn parse_extra_metadata_rejects_non_object() {
+        let err = parse_extra_metadata("[1, 2, 3]").unwrap_err();
+        assert!(err.contains("must be a JSON object"), "got: {}", err);
     }
 }

--- a/src/client/ro_crate_utils.rs
+++ b/src/client/ro_crate_utils.rs
@@ -15,6 +15,25 @@ use std::fs::File;
 use std::io::{BufReader, Read as IoRead};
 use std::path::Path;
 
+/// `@id` prefixes Torc itself synthesizes for provenance entities. User-supplied
+/// `FileSpec::identifier` values starting with one of these would collide in the
+/// `(workflow_id, entity_id)` uniqueness index or shadow synthetic entities
+/// emitted at export time. Validator and exporter share this list so adding a
+/// new synthetic prefix in one place doesn't drift from the other.
+pub const RESERVED_ENTITY_ID_PREFIXES: &[&str] = &["#torc-", "#software-", "#job-"];
+
+/// Exact `@id` values reserved for Torc's synthetic export-root entities. Same
+/// rationale as [`RESERVED_ENTITY_ID_PREFIXES`].
+pub const RESERVED_ENTITY_IDS: &[&str] = &["ro-crate-metadata.json", "./"];
+
+/// True when `id` matches a reserved exact value or starts with a reserved prefix.
+pub fn is_reserved_entity_id(id: &str) -> bool {
+    RESERVED_ENTITY_IDS.contains(&id)
+        || RESERVED_ENTITY_ID_PREFIXES
+            .iter()
+            .any(|p| id.starts_with(p))
+}
+
 fn id_ref(id: impl AsRef<str>) -> serde_json::Value {
     serde_json::json!({ "@id": id.as_ref() })
 }
@@ -1070,6 +1089,53 @@ pub fn create_software_entities(config: &Configuration, workflow_id: i64, run_id
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Drift guard: every synthetic `@id` Torc actually emits must be
+    /// classified as reserved by [`is_reserved_entity_id`]. If a builder gains
+    /// a new prefix and the constants aren't updated, this test fails and
+    /// keeps the validator from silently letting users collide with it.
+    #[test]
+    fn reserved_id_constants_cover_synthetic_builders() {
+        let plan = build_workflow_plan_entity(1, "wf");
+        assert!(
+            is_reserved_entity_id(&plan.entity_id),
+            "workflow plan id {} not reserved",
+            plan.entity_id
+        );
+
+        let run = build_workflow_run_entity_base(1, 7, "wf");
+        assert!(
+            is_reserved_entity_id(&run.entity_id),
+            "workflow run id {} not reserved",
+            run.entity_id
+        );
+
+        let job = JobModel::new(1, "j".to_string(), "echo".to_string());
+        let mut job_with_id = job;
+        job_with_id.id = Some(42);
+        let action = build_create_action_entity(1, 7, &job_with_id, 1, &[], &[]);
+        assert!(
+            is_reserved_entity_id(&action.entity_id),
+            "create action id {} not reserved",
+            action.entity_id
+        );
+
+        let software = build_software_entity(1, 7, "torc", "/usr/bin/torc");
+        assert!(
+            is_reserved_entity_id(&software.entity_id),
+            "software id {} not reserved",
+            software.entity_id
+        );
+
+        // Synthetic export-root ids that the exporter writes directly.
+        assert!(is_reserved_entity_id("ro-crate-metadata.json"));
+        assert!(is_reserved_entity_id("./"));
+
+        // Negative cases: typical user identifiers must NOT be classified as reserved.
+        assert!(!is_reserved_entity_id("data/input.csv"));
+        assert!(!is_reserved_entity_id("https://doi.org/10.1234/abc"));
+        assert!(!is_reserved_entity_id("urn:dataset:abc"));
+    }
 
     #[test]
     fn test_build_file_entity_basic() {

--- a/src/client/ro_crate_utils.rs
+++ b/src/client/ro_crate_utils.rs
@@ -692,10 +692,12 @@ pub fn create_create_action_entity(
 /// Append `{ "@id": id }` to the entity's `result` array if not already present.
 ///
 /// Normalizes a missing or non-array `result` value into an array so the dataset
-/// reference can be added without clobbering existing tracked results.
-fn append_result_ref(metadata: &mut serde_json::Value, id: &str) {
+/// reference can be added without clobbering existing tracked results. Returns
+/// `false` when `metadata` is not a JSON object, so the caller can treat the
+/// link as failed rather than reporting a spurious success.
+fn append_result_ref(metadata: &mut serde_json::Value, id: &str) -> bool {
     let Some(obj) = metadata.as_object_mut() else {
-        return;
+        return false;
     };
     let entry = obj
         .entry("result".to_string())
@@ -713,6 +715,7 @@ fn append_result_ref(metadata: &mut serde_json::Value, id: &str) {
     if !already {
         arr.push(id_ref(id));
     }
+    true
 }
 
 /// Create or update a job's CreateAction entity to record that it produced a
@@ -738,7 +741,17 @@ pub fn link_dataset_to_job_create_action(
     output_file_paths: &[String],
     dataset_entity_id: &str,
 ) -> Option<String> {
-    let action_id = format!("#job-{}-attempt-{}", job.id.unwrap_or(0), attempt_id);
+    let job_id = match job.id {
+        Some(id) => id,
+        None => {
+            warn!(
+                "Job '{}' has no id, cannot wire CreateAction provenance",
+                job.name
+            );
+            return None;
+        }
+    };
+    let action_id = format!("#job-{}-attempt-{}", job_id, attempt_id);
 
     if let Some(existing) = find_entity_by_entity_id(config, workflow_id, &action_id) {
         let entity_db_id = match existing.id {
@@ -758,7 +771,13 @@ pub fn link_dataset_to_job_create_action(
                 return None;
             }
         };
-        append_result_ref(&mut metadata, dataset_entity_id);
+        if !append_result_ref(&mut metadata, dataset_entity_id) {
+            warn!(
+                "CreateAction metadata for '{}' is not a JSON object; cannot record dataset result",
+                action_id
+            );
+            return None;
+        }
         let updated = RoCrateEntityModel {
             id: Some(entity_db_id),
             metadata: metadata.to_string(),
@@ -794,7 +813,13 @@ pub fn link_dataset_to_job_create_action(
             return None;
         }
     };
-    append_result_ref(&mut metadata, dataset_entity_id);
+    if !append_result_ref(&mut metadata, dataset_entity_id) {
+        warn!(
+            "Built CreateAction metadata for '{}' is not a JSON object; cannot record dataset result",
+            action_id
+        );
+        return None;
+    }
     entity.metadata = metadata.to_string();
 
     match apis::ro_crate_entities_api::create_ro_crate_entity(config, entity) {

--- a/src/client/ro_crate_utils.rs
+++ b/src/client/ro_crate_utils.rs
@@ -724,28 +724,29 @@ fn append_result_ref(metadata: &mut serde_json::Value, id: &str) -> bool {
 /// If a CreateAction already exists for the job/attempt (e.g. created during a
 /// prior run with tracked file I/O), the dataset is appended to its existing
 /// `result` array so runtime-tracked outputs are preserved. Otherwise a new
-/// CreateAction is built from the job's input/output files (with the full
-/// plan/software/run provenance links) and the dataset is added to its result.
+/// minimal CreateAction is built (plan/software/run refs only, no tracked
+/// `object`/`result`) and the dataset is added as its sole result. The
+/// minimal shape is intentional: the runtime only auto-creates a CreateAction
+/// for jobs with tracked outputs, so a dataset-producing job (which torc
+/// doesn't track) reaches this branch precisely when there are no tracked
+/// File entities to reference.
 ///
 /// Returns `Some("#job-{id}-attempt-{attempt}")` on success so the caller can
 /// wire the dataset's `prov:wasGeneratedBy`. This is a non-blocking operation:
 /// warnings are logged and `None` is returned on failure.
-#[allow(clippy::too_many_arguments)]
 pub fn link_dataset_to_job_create_action(
     config: &Configuration,
     workflow_id: i64,
     run_id: i64,
     job: &JobModel,
     attempt_id: i64,
-    input_file_paths: &[String],
-    output_file_paths: &[String],
     dataset_entity_id: &str,
 ) -> Option<String> {
     let job_id = match job.id {
         Some(id) => id,
         None => {
             warn!(
-                "Job '{}' has no id, cannot wire CreateAction provenance",
+                "job_name={} has no job_id, cannot wire CreateAction provenance",
                 job.name
             );
             return None;
@@ -757,37 +758,29 @@ pub fn link_dataset_to_job_create_action(
         let entity_db_id = match existing.id {
             Some(id) => id,
             None => {
-                warn!("Existing CreateAction entity has no ID, cannot update");
-                return None;
-            }
-        };
-        let mut metadata = match serde_json::from_str::<serde_json::Value>(&existing.metadata) {
-            Ok(value) => value,
-            Err(e) => {
                 warn!(
-                    "Failed to parse CreateAction metadata for '{}': {}",
-                    action_id, e
+                    "Existing CreateAction entity has no entity_db_id, cannot update action_id={}",
+                    action_id
                 );
                 return None;
             }
         };
-        if !append_result_ref(&mut metadata, dataset_entity_id) {
-            warn!(
-                "CreateAction metadata for '{}' is not a JSON object; cannot record dataset result",
-                action_id
-            );
-            return None;
-        }
+        let metadata_str = append_dataset_result(
+            &existing.metadata,
+            &action_id,
+            dataset_entity_id,
+            "existing",
+        )?;
         let updated = RoCrateEntityModel {
             id: Some(entity_db_id),
-            metadata: metadata.to_string(),
+            metadata: metadata_str,
             ..existing
         };
         if let Err(e) =
             apis::ro_crate_entities_api::update_ro_crate_entity(config, entity_db_id, updated)
         {
             warn!(
-                "Failed to update CreateAction entity '{}': {}",
+                "Failed to update CreateAction entity action_id={}: {}",
                 action_id, e
             );
             return None;
@@ -795,43 +788,52 @@ pub fn link_dataset_to_job_create_action(
         return Some(action_id);
     }
 
-    let mut entity = build_create_action_entity(
-        workflow_id,
-        run_id,
-        job,
-        attempt_id,
-        input_file_paths,
-        output_file_paths,
-    );
-    let mut metadata = match serde_json::from_str::<serde_json::Value>(&entity.metadata) {
+    let mut entity = build_create_action_entity(workflow_id, run_id, job, attempt_id, &[], &[]);
+    entity.metadata =
+        append_dataset_result(&entity.metadata, &action_id, dataset_entity_id, "built")?;
+
+    match apis::ro_crate_entities_api::create_ro_crate_entity(config, entity) {
+        Ok(_) => Some(action_id),
+        Err(e) => {
+            warn!(
+                "Failed to create CreateAction entity action_id={}: {}",
+                action_id, e
+            );
+            None
+        }
+    }
+}
+
+/// Parse a CreateAction's JSON metadata, append a dataset reference to its
+/// `result` array, and return the re-serialized metadata. Returns `None` on
+/// parse failure or non-object metadata so callers can short-circuit.
+///
+/// `source` distinguishes whether the metadata came from a stored entity
+/// ("existing") or a freshly built one ("built"), purely for diagnostics.
+fn append_dataset_result(
+    metadata_json: &str,
+    action_id: &str,
+    dataset_entity_id: &str,
+    source: &str,
+) -> Option<String> {
+    let mut metadata = match serde_json::from_str::<serde_json::Value>(metadata_json) {
         Ok(value) => value,
         Err(e) => {
             warn!(
-                "Failed to parse built CreateAction metadata for '{}': {}",
-                action_id, e
+                "Failed to parse {} CreateAction metadata for action_id={}: {}",
+                source, action_id, e
             );
             return None;
         }
     };
     if !append_result_ref(&mut metadata, dataset_entity_id) {
         warn!(
-            "Built CreateAction metadata for '{}' is not a JSON object; cannot record dataset result",
-            action_id
+            "{} CreateAction metadata for action_id={} is not a JSON object; cannot record dataset result",
+            source, action_id
         );
         return None;
     }
-    entity.metadata = metadata.to_string();
-
-    match apis::ro_crate_entities_api::create_ro_crate_entity(config, entity) {
-        Ok(_) => Some(action_id),
-        Err(e) => {
-            warn!(
-                "Failed to create CreateAction entity '{}': {}",
-                action_id, e
-            );
-            None
-        }
-    }
+    Some(metadata.to_string())
 }
 
 /// Create RO-Crate entities for input files of a workflow.

--- a/src/client/ro_crate_utils.rs
+++ b/src/client/ro_crate_utils.rs
@@ -63,19 +63,25 @@ pub fn compute_file_sha256(path: &str) -> Option<String> {
 /// Build an RO-Crate File entity for a workflow file.
 ///
 /// Creates a JSON-LD entity with:
-/// - `@id`: file path
+/// - `@id`: `identifier_override` when set, otherwise the file path
 /// - `@type`: "File"
 /// - `name`: basename from path
 /// - `encodingFormat`: MIME type via `mime_guess`
 /// - `contentSize`: file size (when available)
 /// - `sha256`: SHA256 hash (when available)
 /// - `dateModified`: ISO8601 from st_mtime
+/// - `sameAs`: the file path, when `identifier_override` differs from it
 /// - `@type` is emitted as `["File", "prov:Entity"]`
+///
+/// `identifier_override` carries a user-supplied stable identifier (DOI, PURL, URN,
+/// ...) for input files; see [`FileSpec::identifier`]. When None, the @id falls back
+/// to the file path to preserve the original behaviour.
 pub fn build_file_entity(
     workflow_id: i64,
     file: &FileModel,
     content_size: Option<u64>,
     sha256: Option<String>,
+    identifier_override: Option<&str>,
 ) -> RoCrateEntityModel {
     let file_path = &file.path;
     let basename = Path::new(file_path)
@@ -89,13 +95,23 @@ pub fn build_file_entity(
         .map(|m| m.to_string())
         .unwrap_or_else(|| "application/octet-stream".to_string());
 
+    let entity_id = identifier_override
+        .unwrap_or(file_path.as_str())
+        .to_string();
+
     // Build metadata JSON object
     let mut metadata = serde_json::json!({
-        "@id": file_path,
+        "@id": entity_id,
         "@type": typed_entity("File", "prov:Entity"),
         "name": basename,
         "encodingFormat": mime_type
     });
+
+    // Preserve the local path under sameAs whenever a stable identifier was supplied,
+    // so consumers can still locate the bytes on disk.
+    if identifier_override.is_some_and(|id| id != file_path.as_str()) {
+        metadata["sameAs"] = serde_json::json!({ "@id": file_path });
+    }
 
     // Add content size if available
     if let Some(size) = content_size {
@@ -117,7 +133,7 @@ pub fn build_file_entity(
         id: None,
         workflow_id,
         file_id: file.id,
-        entity_id: file_path.clone(),
+        entity_id,
         entity_type: "File".to_string(),
         metadata: metadata.to_string(),
     }
@@ -503,11 +519,24 @@ pub fn create_ro_crate_entity_for_file(
     // Compute SHA256 hash
     let sha256 = compute_file_sha256(&file.path);
 
+    // An entity may already exist for this file: the workflow-creation step
+    // pre-populates one whenever the user supplied a stable `identifier` in
+    // FileSpec, and the server's `create_entities_for_input_files` upserts a
+    // path-keyed row at init time. When a pre-existing entity_id differs from
+    // the file path, treat it as the user's stable identifier and preserve it
+    // here -- otherwise the rebuilt metadata would silently revert @id back to
+    // the path.
+    let existing = find_entity_for_file(config, workflow_id, file_id);
+    let identifier_override = existing
+        .as_ref()
+        .map(|e| e.entity_id.as_str())
+        .filter(|id| *id != file.path.as_str());
+
     // Build the entity
-    let entity = build_file_entity(workflow_id, file, content_size, sha256);
+    let entity = build_file_entity(workflow_id, file, content_size, sha256, identifier_override);
 
     // Check if entity already exists - if so, update it
-    if let Some(existing) = find_entity_for_file(config, workflow_id, file_id) {
+    if let Some(existing) = existing {
         let entity_id = match existing.id {
             Some(id) => id,
             None => {
@@ -836,6 +865,53 @@ fn append_dataset_result(
     Some(metadata.to_string())
 }
 
+/// Pre-create an RO-Crate File entity that carries a user-supplied stable identifier.
+///
+/// Called from `create_files` at workflow-creation time for every input file that
+/// has a `FileSpec::identifier` set. The entity is created with `entity_id` (and
+/// `metadata["@id"]`) equal to the user-supplied identifier; the file path is
+/// preserved as `sameAs`.
+///
+/// Persistence matters: the server's `create_entities_for_input_files` (run at
+/// init time) upserts metadata for the same `file_id` and forcefully resets
+/// `metadata["@id"]` to the file path. It does NOT touch the `entity_id` column,
+/// so the user identifier survives in `entity_id`. The client-side
+/// `create_ro_crate_entity_for_file` then reads `entity_id` back and uses it as
+/// the override when rebuilding metadata, restoring `@id`. Pre-creating here is
+/// what makes that round-trip possible without a server change.
+///
+/// Returns an error if the entity cannot be created -- callers should roll back
+/// the workflow on failure, the same way they do for other creation steps.
+pub fn create_input_file_entity_with_identifier(
+    config: &Configuration,
+    workflow_id: i64,
+    file: &FileModel,
+    identifier: &str,
+) -> Result<(), String> {
+    let file_id = file
+        .id
+        .ok_or_else(|| "Cannot pre-create RO-Crate entity: file has no ID".to_string())?;
+
+    // Content size is best-effort; SHA256 is intentionally skipped here because
+    // hashing happens again at init time and we don't want to pay the cost twice.
+    let content_size = std::fs::metadata(&file.path).ok().map(|m| m.len());
+    let entity = build_file_entity(workflow_id, file, content_size, None, Some(identifier));
+
+    apis::ro_crate_entities_api::create_ro_crate_entity(config, entity).map_err(|e| {
+        format!(
+            "Failed to create RO-Crate entity with identifier '{}' for file '{}' \
+             (file_id={}): {}",
+            identifier, file.path, file_id, e
+        )
+    })?;
+
+    debug!(
+        "Pre-created RO-Crate entity for input file '{}' (file_id={}) with identifier '{}'",
+        file.path, file_id, identifier
+    );
+    Ok(())
+}
+
 /// Create RO-Crate entities for input files of a workflow.
 ///
 /// Called during workflow initialization when `enable_ro_crate` is true.
@@ -1005,7 +1081,7 @@ mod tests {
             st_mtime: Some(1704067200.0), // 2024-01-01T00:00:00Z
         };
 
-        let entity = build_file_entity(100, &file, Some(1024), None);
+        let entity = build_file_entity(100, &file, Some(1024), None, None);
 
         assert_eq!(entity.workflow_id, 100);
         assert_eq!(entity.file_id, Some(1));
@@ -1112,7 +1188,7 @@ mod tests {
                 st_mtime: None,
             };
 
-            let entity = build_file_entity(1, &file, None, None);
+            let entity = build_file_entity(1, &file, None, None, None);
             let metadata: serde_json::Value = serde_json::from_str(&entity.metadata).unwrap();
             let mime = metadata["encodingFormat"].as_str().unwrap();
 
@@ -1136,7 +1212,7 @@ mod tests {
                 st_mtime: None,
             };
 
-            let entity = build_file_entity(1, &file, None, None);
+            let entity = build_file_entity(1, &file, None, None, None);
             let metadata: serde_json::Value = serde_json::from_str(&entity.metadata).unwrap();
             let mime = metadata["encodingFormat"].as_str().unwrap();
 
@@ -1213,6 +1289,56 @@ mod tests {
     }
 
     #[test]
+    fn test_build_file_entity_with_identifier_override() {
+        // When the user supplies a stable identifier (DOI/PURL/URN), both the @id
+        // and the entity_id column must use it. The local path is preserved under
+        // sameAs so consumers can still locate the bytes.
+        let file = FileModel {
+            id: Some(7),
+            workflow_id: 100,
+            name: "reference.csv".to_string(),
+            path: "data/reference.csv".to_string(),
+            st_mtime: Some(1704067200.0),
+        };
+
+        let entity = build_file_entity(
+            100,
+            &file,
+            Some(2048),
+            None,
+            Some("https://doi.org/10.1234/abc"),
+        );
+
+        assert_eq!(entity.entity_id, "https://doi.org/10.1234/abc");
+        let metadata: serde_json::Value = serde_json::from_str(&entity.metadata).unwrap();
+        assert_eq!(metadata["@id"], "https://doi.org/10.1234/abc");
+        assert_eq!(metadata["sameAs"]["@id"], "data/reference.csv");
+        // Basename and other derived fields stay tied to the local path.
+        assert_eq!(metadata["name"], "reference.csv");
+        assert_eq!(metadata["encodingFormat"], "text/csv");
+        assert_eq!(metadata["contentSize"], 2048);
+    }
+
+    #[test]
+    fn test_build_file_entity_override_equal_to_path_omits_same_as() {
+        // If the caller's "override" happens to equal the file path (e.g. legacy
+        // entities), there's no extra information in sameAs -- it would be a
+        // self-reference. Keep it out to avoid confusing consumers.
+        let file = FileModel {
+            id: Some(8),
+            workflow_id: 100,
+            name: "noop.txt".to_string(),
+            path: "data/noop.txt".to_string(),
+            st_mtime: None,
+        };
+
+        let entity = build_file_entity(100, &file, None, None, Some("data/noop.txt"));
+        let metadata: serde_json::Value = serde_json::from_str(&entity.metadata).unwrap();
+        assert_eq!(metadata["@id"], "data/noop.txt");
+        assert!(metadata.get("sameAs").is_none());
+    }
+
+    #[test]
     fn test_build_file_entity_with_sha256() {
         let file = FileModel {
             id: Some(1),
@@ -1223,7 +1349,7 @@ mod tests {
         };
 
         let sha256 = Some("abc123def456".to_string());
-        let entity = build_file_entity(100, &file, Some(1024), sha256);
+        let entity = build_file_entity(100, &file, Some(1024), sha256, None);
 
         let metadata: serde_json::Value = serde_json::from_str(&entity.metadata).unwrap();
         assert_eq!(metadata["sha256"], "abc123def456");

--- a/src/client/ro_crate_utils.rs
+++ b/src/client/ro_crate_utils.rs
@@ -689,6 +689,126 @@ pub fn create_create_action_entity(
     }
 }
 
+/// Append `{ "@id": id }` to the entity's `result` array if not already present.
+///
+/// Normalizes a missing or non-array `result` value into an array so the dataset
+/// reference can be added without clobbering existing tracked results.
+fn append_result_ref(metadata: &mut serde_json::Value, id: &str) {
+    let Some(obj) = metadata.as_object_mut() else {
+        return;
+    };
+    let entry = obj
+        .entry("result".to_string())
+        .or_insert_with(|| serde_json::json!([]));
+    if !entry.is_array() {
+        let prev = entry.clone();
+        *entry = serde_json::json!([prev]);
+    }
+    let arr = entry
+        .as_array_mut()
+        .expect("result was normalized to an array");
+    let already = arr
+        .iter()
+        .any(|v| v.get("@id").and_then(|x| x.as_str()) == Some(id));
+    if !already {
+        arr.push(id_ref(id));
+    }
+}
+
+/// Create or update a job's CreateAction entity to record that it produced a
+/// dataset, then return the CreateAction's entity id.
+///
+/// If a CreateAction already exists for the job/attempt (e.g. created during a
+/// prior run with tracked file I/O), the dataset is appended to its existing
+/// `result` array so runtime-tracked outputs are preserved. Otherwise a new
+/// CreateAction is built from the job's input/output files (with the full
+/// plan/software/run provenance links) and the dataset is added to its result.
+///
+/// Returns `Some("#job-{id}-attempt-{attempt}")` on success so the caller can
+/// wire the dataset's `prov:wasGeneratedBy`. This is a non-blocking operation:
+/// warnings are logged and `None` is returned on failure.
+#[allow(clippy::too_many_arguments)]
+pub fn link_dataset_to_job_create_action(
+    config: &Configuration,
+    workflow_id: i64,
+    run_id: i64,
+    job: &JobModel,
+    attempt_id: i64,
+    input_file_paths: &[String],
+    output_file_paths: &[String],
+    dataset_entity_id: &str,
+) -> Option<String> {
+    let action_id = format!("#job-{}-attempt-{}", job.id.unwrap_or(0), attempt_id);
+
+    if let Some(existing) = find_entity_by_entity_id(config, workflow_id, &action_id) {
+        let entity_db_id = match existing.id {
+            Some(id) => id,
+            None => {
+                warn!("Existing CreateAction entity has no ID, cannot update");
+                return None;
+            }
+        };
+        let mut metadata = match serde_json::from_str::<serde_json::Value>(&existing.metadata) {
+            Ok(value) => value,
+            Err(e) => {
+                warn!(
+                    "Failed to parse CreateAction metadata for '{}': {}",
+                    action_id, e
+                );
+                return None;
+            }
+        };
+        append_result_ref(&mut metadata, dataset_entity_id);
+        let updated = RoCrateEntityModel {
+            id: Some(entity_db_id),
+            metadata: metadata.to_string(),
+            ..existing
+        };
+        if let Err(e) =
+            apis::ro_crate_entities_api::update_ro_crate_entity(config, entity_db_id, updated)
+        {
+            warn!(
+                "Failed to update CreateAction entity '{}': {}",
+                action_id, e
+            );
+            return None;
+        }
+        return Some(action_id);
+    }
+
+    let mut entity = build_create_action_entity(
+        workflow_id,
+        run_id,
+        job,
+        attempt_id,
+        input_file_paths,
+        output_file_paths,
+    );
+    let mut metadata = match serde_json::from_str::<serde_json::Value>(&entity.metadata) {
+        Ok(value) => value,
+        Err(e) => {
+            warn!(
+                "Failed to parse built CreateAction metadata for '{}': {}",
+                action_id, e
+            );
+            return None;
+        }
+    };
+    append_result_ref(&mut metadata, dataset_entity_id);
+    entity.metadata = metadata.to_string();
+
+    match apis::ro_crate_entities_api::create_ro_crate_entity(config, entity) {
+        Ok(_) => Some(action_id),
+        Err(e) => {
+            warn!(
+                "Failed to create CreateAction entity '{}': {}",
+                action_id, e
+            );
+            None
+        }
+    }
+}
+
 /// Create RO-Crate entities for input files of a workflow.
 ///
 /// Called during workflow initialization when `enable_ro_crate` is true.
@@ -890,6 +1010,31 @@ mod tests {
         let metadata: serde_json::Value = serde_json::from_str(&entity.metadata).unwrap();
         assert_eq!(metadata["prov:wasGeneratedBy"]["@id"], "#job-42-attempt-1");
         assert_eq!(metadata["prov:wasAttributedTo"]["@id"], "#torc-run-id-1");
+    }
+
+    #[test]
+    fn test_append_result_ref() {
+        // Appends into an existing array, deduplicating.
+        let mut meta = serde_json::json!({ "result": [{ "@id": "out/a" }] });
+        append_result_ref(&mut meta, "data/ds/");
+        append_result_ref(&mut meta, "data/ds/"); // duplicate is a no-op
+        let arr = meta["result"].as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0]["@id"], "out/a");
+        assert_eq!(arr[1]["@id"], "data/ds/");
+
+        // Missing `result` is created as an array.
+        let mut meta = serde_json::json!({ "name": "x" });
+        append_result_ref(&mut meta, "data/ds/");
+        assert_eq!(meta["result"][0]["@id"], "data/ds/");
+
+        // A non-array `result` is normalized into an array first.
+        let mut meta = serde_json::json!({ "result": { "@id": "out/a" } });
+        append_result_ref(&mut meta, "data/ds/");
+        let arr = meta["result"].as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0]["@id"], "out/a");
+        assert_eq!(arr[1]["@id"], "data/ds/");
     }
 
     #[test]

--- a/src/client/workflow_spec.rs
+++ b/src/client/workflow_spec.rs
@@ -106,6 +106,14 @@ pub struct FileSpec {
     pub name: String,
     /// Path to the file
     pub path: String,
+    /// Optional stable RO-Crate identifier for this file (e.g. a DOI, PURL, or URN).
+    /// When provided, this string is used as the `@id` of the file's RO-Crate entity
+    /// instead of the file path. The path is still recorded as `sameAs` so the
+    /// local location is preserved. Identifiers must be unique within the workflow
+    /// after parameter expansion. Parameter tokens (`{name}` / `{name:fmt}`) are
+    /// substituted into the identifier just like `name` and `path`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub identifier: Option<String>,
     /// File modification time as Unix timestamp (seconds since epoch).
     /// If not specified, torc automatically checks if the file exists on disk
     /// during workflow creation and uses its actual modification time.
@@ -134,6 +142,7 @@ impl FileSpec {
         FileSpec {
             name,
             path,
+            identifier: None,
             st_mtime: None,
             parameters: None,
             parameter_mode: None,
@@ -170,9 +179,13 @@ impl FileSpec {
             new_spec.parameters = None; // Remove parameters from expanded specs
             new_spec.parameter_mode = None; // Remove parameter_mode from expanded specs
 
-            // Substitute parameters in name and path
+            // Substitute parameters in name, path, and (when set) identifier.
             new_spec.name = substitute_parameters(&self.name, &combo);
             new_spec.path = substitute_parameters(&self.path, &combo);
+            new_spec.identifier = self
+                .identifier
+                .as_deref()
+                .map(|template| substitute_parameters(template, &combo));
 
             expanded.push(new_spec);
         }
@@ -1779,6 +1792,7 @@ impl WorkflowSpec {
 
         if let Some(files) = &self.files {
             let mut seen_files: HashSet<&str> = HashSet::with_capacity(files.len());
+            let mut seen_identifiers: HashMap<&str, &str> = HashMap::with_capacity(files.len());
             for file in files {
                 if !seen_files.insert(file.name.as_str()) {
                     return Err(format!(
@@ -1786,6 +1800,20 @@ impl WorkflowSpec {
                          parameterized file's name template must include a placeholder \
                          for every parameter in `parameters` / `use_parameters`.",
                         file.name
+                    )
+                    .into());
+                }
+                if let Some(identifier) = file.identifier.as_deref()
+                    && let Some(prior_name) =
+                        seen_identifiers.insert(identifier, file.name.as_str())
+                {
+                    return Err(format!(
+                        "Duplicate file identifier '{}' after parameter expansion \
+                         (used by files '{}' and '{}'). Identifiers must be unique \
+                         within a workflow; for parameterized files, the identifier \
+                         template must include a placeholder for every parameter in \
+                         `parameters` / `use_parameters`.",
+                        identifier, prior_name, file.name
                     )
                     .into());
                 }
@@ -3283,6 +3311,34 @@ impl WorkflowSpec {
             .into());
         }
 
+        // Pre-create RO-Crate entities for input files that carry a user-supplied
+        // identifier. We only do this for files we resolved as inputs above
+        // (st_mtime is Some); outputs are produced by jobs and follow a separate
+        // entity-creation path. Persisting the identifier into the `entity_id`
+        // column here is what makes it survive the server's init-time upsert -- see
+        // `create_input_file_entity_with_identifier` for the round-trip details.
+        for (file_spec, file_model) in files.iter().zip(file_models.iter()) {
+            let Some(identifier) = file_spec.identifier.as_deref() else {
+                continue;
+            };
+            if file_model.st_mtime.is_none() {
+                continue;
+            }
+            let file_id = *file_name_to_id
+                .get(&file_spec.name)
+                .ok_or_else(|| format!("missing file id for '{}'", file_spec.name))?;
+            let file_with_id = models::FileModel {
+                id: Some(file_id),
+                ..file_model.clone()
+            };
+            crate::client::ro_crate_utils::create_input_file_entity_with_identifier(
+                config,
+                workflow_id,
+                &file_with_id,
+                identifier,
+            )?;
+        }
+
         Ok(file_name_to_id)
     }
 
@@ -4303,6 +4359,14 @@ impl WorkflowSpec {
             );
         }
 
+        // identifier can also be specified as a property on the same line.
+        if let Some(identifier) = node.get("identifier").and_then(|e| e.as_string()) {
+            obj.insert(
+                "identifier".to_string(),
+                serde_json::Value::String(identifier.to_string()),
+            );
+        }
+
         // Check for child nodes
         if let Some(children) = node.children() {
             for child in children.nodes() {
@@ -4312,6 +4376,15 @@ impl WorkflowSpec {
                         {
                             obj.insert(
                                 "path".to_string(),
+                                serde_json::Value::String(v.to_string()),
+                            );
+                        }
+                    }
+                    "identifier" => {
+                        if let Some(v) = child.entries().first().and_then(|e| e.value().as_string())
+                        {
+                            obj.insert(
+                                "identifier".to_string(),
                                 serde_json::Value::String(v.to_string()),
                             );
                         }
@@ -5544,7 +5617,9 @@ impl WorkflowSpec {
         let has_mode = file.parameter_mode.is_some();
         let has_use_params = file.use_parameters.is_some();
 
-        if !has_params && !has_mode && !has_use_params {
+        let has_identifier = file.identifier.is_some();
+
+        if !has_params && !has_mode && !has_use_params && !has_identifier {
             // Simple form: file "name" path="value"
             lines.push(format!(
                 "file {} path={}",
@@ -5554,6 +5629,9 @@ impl WorkflowSpec {
         } else {
             lines.push(format!("file {} {{", escape(&file.name)));
             lines.push(format!("    path {}", escape(&file.path)));
+            if let Some(ref identifier) = file.identifier {
+                lines.push(format!("    identifier {}", escape(identifier)));
+            }
             if let Some(ref params) = file.parameters
                 && !params.is_empty()
             {
@@ -6465,6 +6543,54 @@ job "train_lr{lr:.4f}_bs{batch_size}" {
         assert_eq!(expanded[0].path, "/data/output_1.txt");
         assert_eq!(expanded[2].name, "output_3");
         assert_eq!(expanded[2].path, "/data/output_3.txt");
+    }
+
+    #[test]
+    fn test_file_identifier_parameter_substitution() {
+        // Parameterized identifiers must expand the same way `name` and `path` do.
+        // Otherwise an unparameterized identifier template silently collapses every
+        // expanded file onto the same `@id` and the duplicate-identifier validation
+        // below would always fire -- which is misleading when the real bug is a
+        // missing placeholder.
+        let mut file = FileSpec::new("input_{i}".to_string(), "/data/input_{i}.csv".to_string());
+        file.identifier = Some("urn:dataset:{i}".to_string());
+
+        let mut params = HashMap::new();
+        params.insert("i".to_string(), "1:3".to_string());
+        file.parameters = Some(params);
+
+        let expanded = file.expand().expect("Failed to expand file");
+
+        assert_eq!(expanded.len(), 3);
+        assert_eq!(expanded[0].identifier.as_deref(), Some("urn:dataset:1"));
+        assert_eq!(expanded[2].identifier.as_deref(), Some("urn:dataset:3"));
+    }
+
+    #[test]
+    fn test_validate_unique_names_rejects_duplicate_file_identifiers() {
+        // Two distinct files trying to claim the same RO-Crate `@id` must be
+        // rejected up-front; otherwise the pre-create step in `create_files`
+        // would fail mid-creation with a server-side uniqueness error and roll
+        // back the entire workflow, which is much harder to debug than a clear
+        // spec-load error.
+        let mut a = FileSpec::new("a".to_string(), "/data/a.csv".to_string());
+        a.identifier = Some("urn:dataset:shared".to_string());
+        let mut b = FileSpec::new("b".to_string(), "/data/b.csv".to_string());
+        b.identifier = Some("urn:dataset:shared".to_string());
+
+        let mut spec = WorkflowSpec::new("wf".to_string(), "tester".to_string(), None, vec![]);
+        spec.files = Some(vec![a, b]);
+
+        let err = spec
+            .validate_unique_names_after_expansion()
+            .expect_err("expected duplicate-identifier rejection");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Duplicate file identifier 'urn:dataset:shared'"),
+            "unexpected error message: {}",
+            msg
+        );
+        assert!(msg.contains("'a'") && msg.contains("'b'"), "{}", msg);
     }
 
     #[test]

--- a/src/client/workflow_spec.rs
+++ b/src/client/workflow_spec.rs
@@ -1842,6 +1842,95 @@ impl WorkflowSpec {
         Ok(())
     }
 
+    /// Validate user-supplied RO-Crate identifiers on files.
+    ///
+    /// Three checks, all run together because they share the file/job traversal:
+    ///
+    /// 1. `identifier` only has effect when `enable_ro_crate: true`. Setting it
+    ///    on a workflow that opted out of RO-Crate would silently create a single
+    ///    partial entity row with no other provenance — confusing rather than
+    ///    helpful, so reject.
+    /// 2. `identifier` only applies to **input** files. Outputs are produced by
+    ///    jobs and follow a separate entity-creation path that does not consult
+    ///    the identifier. Rather than silently dropping the value, reject any
+    ///    file that's referenced only as a job output.
+    /// 3. Identifiers must not collide with Torc's reserved prefixes
+    ///    (`#torc-` and `#software-`); those entity IDs are used by workflow,
+    ///    run, and software provenance entities that share the same uniqueness
+    ///    constraint, so a user identifier with those prefixes would be silently
+    ///    overwritten at init time.
+    fn validate_file_identifiers(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let Some(files) = &self.files else {
+            return Ok(());
+        };
+        if !files.iter().any(|f| f.identifier.is_some()) {
+            return Ok(());
+        }
+
+        if self.enable_ro_crate != Some(true) {
+            // Pick the first offender so the error names a concrete file.
+            let offender = files
+                .iter()
+                .find(|f| f.identifier.is_some())
+                .expect("at least one file has identifier");
+            return Err(format!(
+                "File '{}' sets `identifier` but the workflow does not have \
+                 `enable_ro_crate: true`. Stable RO-Crate identifiers only have \
+                 effect when automatic RO-Crate provenance is enabled; set \
+                 `enable_ro_crate: true` at the workflow level or remove the \
+                 identifier.",
+                offender.name
+            )
+            .into());
+        }
+
+        // Classify each file as input/output by how jobs reference it. A file
+        // appearing in some `output_files` and never in `input_files` (and with
+        // no user-supplied `st_mtime` marking it as pre-existing) is treated as
+        // output-only.
+        let mut input_names: HashSet<&str> = HashSet::new();
+        let mut output_names: HashSet<&str> = HashSet::new();
+        for job in &self.jobs {
+            if let Some(inputs) = &job.input_files {
+                input_names.extend(inputs.iter().map(String::as_str));
+            }
+            if let Some(outputs) = &job.output_files {
+                output_names.extend(outputs.iter().map(String::as_str));
+            }
+        }
+
+        for file in files {
+            let Some(identifier) = file.identifier.as_deref() else {
+                continue;
+            };
+            let name = file.name.as_str();
+            let is_input = file.st_mtime.is_some() || input_names.contains(name);
+            if !is_input && output_names.contains(name) {
+                return Err(format!(
+                    "File '{}' sets `identifier` but is referenced only as an output \
+                     of some job. RO-Crate identifiers are only honored for input \
+                     files; output files keep using their path as `@id`. Remove the \
+                     identifier or reference the file as an input.",
+                    file.name
+                )
+                .into());
+            }
+
+            if identifier.starts_with("#torc-") || identifier.starts_with("#software-") {
+                return Err(format!(
+                    "File '{}' uses identifier '{}', which begins with a reserved \
+                     prefix (`#torc-` or `#software-`). Those prefixes are used by \
+                     Torc's own workflow, run, and software provenance entities and \
+                     would collide with them at export time.",
+                    file.name, identifier
+                )
+                .into());
+            }
+        }
+
+        Ok(())
+    }
+
     /// Validate workflow actions
     pub fn validate_actions(&self) -> Result<(), Box<dyn std::error::Error>> {
         if let Some(ref actions) = self.actions {
@@ -2263,6 +2352,7 @@ impl WorkflowSpec {
         spec.expand_parameters()?;
         spec.validate_unique_names_after_expansion()?;
         spec.validate_env_maps()?;
+        spec.validate_file_identifiers()?;
 
         spec.validate_scheduler_node_requirements()?;
 
@@ -2299,6 +2389,10 @@ impl WorkflowSpec {
             std::process::exit(1);
         }
         if let Err(e) = spec.validate_env_maps() {
+            eprintln!("Validation error: {}", e);
+            std::process::exit(1);
+        }
+        if let Err(e) = spec.validate_file_identifiers() {
             eprintln!("Validation error: {}", e);
             std::process::exit(1);
         }
@@ -2421,6 +2515,10 @@ impl WorkflowSpec {
 
         if let Err(e) = spec.validate_env_maps() {
             errors.push(format!("Environment validation failed: {}", e));
+        }
+
+        if let Err(e) = spec.validate_file_identifiers() {
+            errors.push(format!("File identifier validation failed: {}", e));
         }
 
         // Step 4: Validate scheduler node requirements
@@ -2854,6 +2952,7 @@ impl WorkflowSpec {
             });
         }
         spec.validate_env_maps()?;
+        spec.validate_file_identifiers()?;
         spec.validate_actions()?;
         spec.substitute_variables()?;
         Self::create_from_prepared_spec(config, spec)
@@ -2883,6 +2982,7 @@ impl WorkflowSpec {
         spec.expand_parameters()?;
         spec.validate_unique_names_after_expansion()?;
         spec.validate_env_maps()?;
+        spec.validate_file_identifiers()?;
         spec.validate_actions()?;
         spec.substitute_variables()?;
         Ok(())
@@ -3312,16 +3412,25 @@ impl WorkflowSpec {
         }
 
         // Pre-create RO-Crate entities for input files that carry a user-supplied
-        // identifier. We only do this for files we resolved as inputs above
-        // (st_mtime is Some); outputs are produced by jobs and follow a separate
-        // entity-creation path. Persisting the identifier into the `entity_id`
-        // column here is what makes it survive the server's init-time upsert -- see
+        // identifier. Persisting the identifier into the `entity_id` column here
+        // is what makes it survive the server's init-time upsert -- see
         // `create_input_file_entity_with_identifier` for the round-trip details.
+        //
+        // Gate on "declared as a job input OR has st_mtime" rather than just
+        // `st_mtime.is_some()`. An input file that doesn't yet exist on disk has
+        // st_mtime=None here; if we skipped it, the identifier would be silently
+        // dropped because `initialize_files` later refreshes st_mtime but the
+        // FileSpec (and its identifier) is no longer in scope at that point. The
+        // server-side filter on st_mtime still applies for *whether* init touches
+        // the entity at all -- but the pre-created row carries the identifier
+        // regardless of disk state.
         for (file_spec, file_model) in files.iter().zip(file_models.iter()) {
             let Some(identifier) = file_spec.identifier.as_deref() else {
                 continue;
             };
-            if file_model.st_mtime.is_none() {
+            let is_input =
+                file_model.st_mtime.is_some() || input_file_names.contains(file_spec.name.as_str());
+            if !is_input {
                 continue;
             }
             let file_id = *file_name_to_id
@@ -6591,6 +6700,104 @@ job "train_lr{lr:.4f}_bs{batch_size}" {
             msg
         );
         assert!(msg.contains("'a'") && msg.contains("'b'"), "{}", msg);
+    }
+
+    #[test]
+    fn test_validate_file_identifiers_requires_enable_ro_crate() {
+        // Setting `identifier` without enabling RO-Crate would silently create one
+        // dangling entity row with no other provenance -- friendlier to reject than
+        // to half-honor.
+        let mut f = FileSpec::new("a".to_string(), "/data/a.csv".to_string());
+        f.identifier = Some("urn:dataset:abc".to_string());
+        let mut spec = WorkflowSpec::new("wf".to_string(), "tester".to_string(), None, vec![]);
+        spec.files = Some(vec![f]);
+        // enable_ro_crate is None by default
+
+        let err = spec
+            .validate_file_identifiers()
+            .expect_err("expected enable_ro_crate requirement");
+        let msg = err.to_string();
+        assert!(msg.contains("enable_ro_crate"), "{}", msg);
+        assert!(msg.contains("'a'"), "{}", msg);
+
+        // Enabling it makes the same spec validate cleanly.
+        spec.enable_ro_crate = Some(true);
+        spec.validate_file_identifiers()
+            .expect("identifier+enable_ro_crate should be allowed");
+    }
+
+    #[test]
+    fn test_validate_file_identifiers_rejects_output_only_file() {
+        // A file referenced only as a job output cannot carry an identifier
+        // because the output-file entity-creation path doesn't consult it.
+        // Silently dropping the value would be confusing, so reject.
+        let mut producer = JobSpec::new("producer".to_string(), "echo".to_string());
+        producer.output_files = Some(vec!["out".to_string()]);
+
+        let mut out = FileSpec::new("out".to_string(), "/data/out.csv".to_string());
+        out.identifier = Some("urn:dataset:out".to_string());
+
+        let mut spec =
+            WorkflowSpec::new("wf".to_string(), "tester".to_string(), None, vec![producer]);
+        spec.enable_ro_crate = Some(true);
+        spec.files = Some(vec![out]);
+
+        let err = spec
+            .validate_file_identifiers()
+            .expect_err("expected output-only rejection");
+        let msg = err.to_string();
+        assert!(msg.contains("output"), "{}", msg);
+        assert!(msg.contains("'out'"), "{}", msg);
+    }
+
+    #[test]
+    fn test_validate_file_identifiers_allows_file_used_as_both_input_and_output() {
+        // A file referenced as both input and output (e.g. an in-place transform)
+        // is still an input from RO-Crate's perspective; identifier should be allowed.
+        let mut producer = JobSpec::new("producer".to_string(), "make".to_string());
+        producer.output_files = Some(vec!["shared".to_string()]);
+        let mut consumer = JobSpec::new("consumer".to_string(), "transform".to_string());
+        consumer.input_files = Some(vec!["shared".to_string()]);
+
+        let mut shared = FileSpec::new("shared".to_string(), "/data/shared.csv".to_string());
+        shared.identifier = Some("urn:dataset:shared".to_string());
+
+        let mut spec = WorkflowSpec::new(
+            "wf".to_string(),
+            "tester".to_string(),
+            None,
+            vec![producer, consumer],
+        );
+        spec.enable_ro_crate = Some(true);
+        spec.files = Some(vec![shared]);
+
+        spec.validate_file_identifiers()
+            .expect("identifier on a file used as both input and output should be allowed");
+    }
+
+    #[test]
+    fn test_validate_file_identifiers_rejects_reserved_prefixes() {
+        // Identifiers starting with reserved prefixes would collide with Torc's own
+        // provenance entities, which share the (workflow_id, entity_id) uniqueness
+        // index. Reject at spec load to surface a clear error.
+        for reserved in [
+            "#torc-workflow",
+            "#torc-run-id-1",
+            "#software-torc-run-id-1",
+        ] {
+            let mut f = FileSpec::new("a".to_string(), "/data/a.csv".to_string());
+            f.identifier = Some(reserved.to_string());
+            let mut spec = WorkflowSpec::new("wf".to_string(), "tester".to_string(), None, vec![]);
+            spec.enable_ro_crate = Some(true);
+            spec.files = Some(vec![f]);
+
+            let err = spec
+                .validate_file_identifiers()
+                .expect_err(&format!("expected rejection of reserved id '{}'", reserved));
+            let msg = err.to_string();
+            assert!(msg.contains("reserved"), "for '{}': {}", reserved, msg);
+            assert!(msg.contains(reserved), "for '{}': {}", reserved, msg);
+        }
     }
 
     #[test]

--- a/src/client/workflow_spec.rs
+++ b/src/client/workflow_spec.rs
@@ -1943,13 +1943,25 @@ impl WorkflowSpec {
             };
             let name = file.name.as_str();
 
-            // Check 3: reserved IDs.
-            if identifier.starts_with("#torc-")
-                || identifier.starts_with("#software-")
-                || identifier.starts_with("#job-")
-                || identifier == "ro-crate-metadata.json"
-                || identifier == "./"
-            {
+            // Check 0: identifier must be a non-empty, non-whitespace string.
+            // An empty or blank identifier would round-trip as `entity_id = ""`
+            // and `@id = ""` in the exported graph, which is meaningless and
+            // bypasses every other check below.
+            if identifier.trim().is_empty() {
+                return Err(format!(
+                    "File '{}' has an empty or whitespace-only `identifier`. \
+                     Identifiers must be non-blank strings; remove the field \
+                     or set it to a stable @id value (DOI, PURL, URN, …).",
+                    file.name
+                )
+                .into());
+            }
+
+            // Check 3: reserved IDs. The validator and the exporter share one
+            // list (see `ro_crate_utils::RESERVED_ENTITY_ID_PREFIXES` /
+            // `RESERVED_ENTITY_IDS`) so a new synthetic prefix added to the
+            // exporter doesn't drift past this check.
+            if crate::client::ro_crate_utils::is_reserved_entity_id(identifier) {
                 return Err(format!(
                     "File '{}' uses identifier '{}', which matches a reserved \
                      value or prefix (`#torc-`, `#software-`, `#job-`, \
@@ -2009,6 +2021,23 @@ impl WorkflowSpec {
         }
 
         Ok(())
+    }
+
+    /// Run [`Self::validate_file_identifiers`] against a substituted copy of
+    /// `self` so the caller's spec stays in its unsubstituted form.
+    ///
+    /// Identifier classification needs `input_files` / `output_files` populated
+    /// from `${files.*.NAME}` tokens (which only happens after
+    /// `substitute_variables`), but the *return* value of some validators is
+    /// the unsubstituted spec — callers will substitute again later. Cloning
+    /// here keeps that contract.
+    ///
+    /// Call sites where the spec has already been substituted in place should
+    /// call [`Self::validate_file_identifiers`] directly instead.
+    fn validate_file_identifiers_on_clone(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let mut clone = self.clone();
+        clone.substitute_variables()?;
+        clone.validate_file_identifiers()
     }
 
     /// Validate workflow actions
@@ -2416,15 +2445,17 @@ impl WorkflowSpec {
 
     /// Validate a spec file for creation by non-interactive callers (MCP server, TUI).
     ///
-    /// Runs parameter expansion, scheduler node requirement checks, and scheduler
-    /// resource checks (memory, runtime, GPUs). Returns the parsed spec on success
-    /// so callers can pass it to [`create_from_validated_spec`] without re-reading
-    /// the file.
+    /// Runs parameter expansion, duplicate-name/identifier checks, env-map checks,
+    /// file-identifier checks (which internally substitute variables on a clone),
+    /// scheduler node requirement checks, and scheduler resource checks. Returns
+    /// the parsed spec **unsubstituted** on success so callers can pass it to
+    /// [`create_from_validated_spec`] without re-reading the file.
     ///
-    /// **Note:** This is a partial validation step. Action validation and variable
-    /// substitution are performed later by [`create_from_validated_spec`]. A spec
-    /// that passes this function can still fail during creation if it has invalid
-    /// actions or unresolvable variable references.
+    /// **Note:** Action validation is still performed later by
+    /// [`create_from_validated_spec`], so a spec that passes here can still fail
+    /// during creation if it has invalid actions. Variable substitution errors,
+    /// in contrast, surface here because the file-identifier check substitutes on
+    /// a clone — the returned spec stays in its unsubstituted form.
     pub fn validate_for_creation<P: AsRef<Path>>(
         path: P,
     ) -> Result<WorkflowSpec, Box<dyn std::error::Error>> {
@@ -2432,14 +2463,10 @@ impl WorkflowSpec {
         spec.expand_parameters()?;
         spec.validate_unique_names_after_expansion()?;
         spec.validate_env_maps()?;
-        // Substitute variables on a clone so the returned spec stays in its
-        // unsubstituted form (the caller's `create_from_validated_spec` will
-        // substitute again); but identifier validation needs the substituted
-        // `input_files` / `output_files` populated from `${files.*.NAME}`
-        // tokens to correctly classify input vs output files.
-        let mut for_identifier_check = spec.clone();
-        for_identifier_check.substitute_variables()?;
-        for_identifier_check.validate_file_identifiers()?;
+        // The returned spec must stay unsubstituted -- `create_from_validated_spec`
+        // substitutes again -- so this helper does the substitute-then-validate
+        // dance on a clone.
+        spec.validate_file_identifiers_on_clone()?;
 
         spec.validate_scheduler_node_requirements()?;
 
@@ -2480,14 +2507,9 @@ impl WorkflowSpec {
             std::process::exit(1);
         }
         // Identifier classification needs input/output_files populated from
-        // ${files.*.NAME} tokens; substitute on a clone so this remains
-        // pre-validation only.
-        let mut for_identifier_check = spec.clone();
-        if let Err(e) = for_identifier_check.substitute_variables() {
-            eprintln!("Variable substitution failed: {}", e);
-            std::process::exit(1);
-        }
-        if let Err(e) = for_identifier_check.validate_file_identifiers() {
+        // ${files.*.NAME} tokens; this helper substitutes on a clone so this
+        // remains pre-validation only.
+        if let Err(e) = spec.validate_file_identifiers_on_clone() {
             eprintln!("Validation error: {}", e);
             std::process::exit(1);
         }
@@ -7034,6 +7056,27 @@ job "train_lr{lr:.4f}_bs{batch_size}" {
         let msg = err.to_string();
         assert!(msg.contains("'orphan'"), "{}", msg);
         assert!(msg.contains("input"), "{}", msg);
+    }
+
+    #[test]
+    fn test_validate_file_identifiers_rejects_blank_identifier() {
+        // Empty/whitespace identifiers would round-trip as `entity_id = ""`
+        // and `@id = ""` in the exported graph -- nonsense values that
+        // bypass every other identifier check. Reject early.
+        for blank in ["", "   ", "\t\n"] {
+            let mut f = FileSpec::new("a".to_string(), "/data/a.csv".to_string());
+            f.identifier = Some(blank.to_string());
+            let mut spec = WorkflowSpec::new("wf".to_string(), "tester".to_string(), None, vec![]);
+            spec.enable_ro_crate = Some(true);
+            spec.files = Some(vec![f]);
+
+            let err = spec
+                .validate_file_identifiers()
+                .expect_err(&format!("expected rejection of blank id {:?}", blank));
+            let msg = err.to_string();
+            assert!(msg.contains("empty"), "for {:?}: {}", blank, msg);
+            assert!(msg.contains("'a'"), "for {:?}: {}", blank, msg);
+        }
     }
 
     #[test]

--- a/src/client/workflow_spec.rs
+++ b/src/client/workflow_spec.rs
@@ -1844,21 +1844,32 @@ impl WorkflowSpec {
 
     /// Validate user-supplied RO-Crate identifiers on files.
     ///
-    /// Three checks, all run together because they share the file/job traversal:
+    /// Five checks, all run together because they share the file/job traversal:
     ///
     /// 1. `identifier` only has effect when `enable_ro_crate: true`. Setting it
     ///    on a workflow that opted out of RO-Crate would silently create a single
     ///    partial entity row with no other provenance — confusing rather than
     ///    helpful, so reject.
     /// 2. `identifier` only applies to **input** files. Outputs are produced by
-    ///    jobs and follow a separate entity-creation path that does not consult
-    ///    the identifier. Rather than silently dropping the value, reject any
-    ///    file that's referenced only as a job output.
-    /// 3. Identifiers must not collide with Torc's reserved prefixes
-    ///    (`#torc-` and `#software-`); those entity IDs are used by workflow,
-    ///    run, and software provenance entities that share the same uniqueness
-    ///    constraint, so a user identifier with those prefixes would be silently
-    ///    overwritten at init time.
+    ///    jobs and follow a separate entity-creation path that always rewrites
+    ///    `entity_id` to the file path (`build_file_entity_with_provenance`).
+    ///    Reject any file referenced as a job output (including files used as
+    ///    both input and output — the output completion clobbers the identifier).
+    /// 3. Identifiers must not match reserved values or prefixes used by Torc's
+    ///    own provenance and synthetic export entities: `#torc-`, `#software-`,
+    ///    `#job-` (CreateActions), `ro-crate-metadata.json`, and `./` (synthetic
+    ///    root). All of these share the `(workflow_id, entity_id)` uniqueness
+    ///    index or would produce duplicate `@id` entries in the exported graph.
+    /// 4. No file's `identifier` may collide with another file's path. The
+    ///    `(workflow_id, entity_id)` unique index means a user identifier equal
+    ///    to another file's path would silently lose one of the two file
+    ///    entities at init time. Reject up-front.
+    /// 5. Run AFTER [`Self::substitute_variables`] so that `input_files` /
+    ///    `output_files` populated from `${files.input.NAME}` /
+    ///    `${files.output.NAME}` tokens are visible. Otherwise an output-only
+    ///    file declared via a token escapes check (2). The check also accounts
+    ///    for `input_file_regexes` / `output_file_regexes` so regex-matched
+    ///    files aren't misclassified.
     fn validate_file_identifiers(&self) -> Result<(), Box<dyn std::error::Error>> {
         let Some(files) = &self.files else {
             return Ok(());
@@ -1884,12 +1895,14 @@ impl WorkflowSpec {
             .into());
         }
 
-        // Classify each file as input/output by how jobs reference it. A file
-        // appearing in some `output_files` and never in `input_files` (and with
-        // no user-supplied `st_mtime` marking it as pre-existing) is treated as
-        // output-only.
+        // Classify each file as input/output by how jobs reference it. Both
+        // exact-name lists (`input_files` / `output_files`) and regex lists
+        // (`input_file_regexes` / `output_file_regexes`) contribute, because
+        // `resolve_names_and_regexes` later merges them at creation time.
         let mut input_names: HashSet<&str> = HashSet::new();
         let mut output_names: HashSet<&str> = HashSet::new();
+        let mut input_regexes: Vec<Regex> = Vec::new();
+        let mut output_regexes: Vec<Regex> = Vec::new();
         for job in &self.jobs {
             if let Some(inputs) = &job.input_files {
                 input_names.extend(inputs.iter().map(String::as_str));
@@ -1897,6 +1910,31 @@ impl WorkflowSpec {
             if let Some(outputs) = &job.output_files {
                 output_names.extend(outputs.iter().map(String::as_str));
             }
+            if let Some(patterns) = &job.input_file_regexes {
+                for p in patterns {
+                    // Skip malformed regexes silently here; `validate_spec` /
+                    // `create_jobs` surface those errors via their own checks.
+                    if let Ok(re) = Regex::new(p) {
+                        input_regexes.push(re);
+                    }
+                }
+            }
+            if let Some(patterns) = &job.output_file_regexes {
+                for p in patterns {
+                    if let Ok(re) = Regex::new(p) {
+                        output_regexes.push(re);
+                    }
+                }
+            }
+        }
+        let is_referenced_as = |name: &str, names: &HashSet<&str>, regexes: &[Regex]| {
+            names.contains(name) || regexes.iter().any(|re| re.is_match(name))
+        };
+
+        // Build path → file-name map for the path-collision check.
+        let mut path_to_name: HashMap<&str, &str> = HashMap::with_capacity(files.len());
+        for file in files {
+            path_to_name.insert(file.path.as_str(), file.name.as_str());
         }
 
         for file in files {
@@ -1904,25 +1942,67 @@ impl WorkflowSpec {
                 continue;
             };
             let name = file.name.as_str();
-            let is_input = file.st_mtime.is_some() || input_names.contains(name);
-            if !is_input && output_names.contains(name) {
+
+            // Check 3: reserved IDs.
+            if identifier.starts_with("#torc-")
+                || identifier.starts_with("#software-")
+                || identifier.starts_with("#job-")
+                || identifier == "ro-crate-metadata.json"
+                || identifier == "./"
+            {
                 return Err(format!(
-                    "File '{}' sets `identifier` but is referenced only as an output \
-                     of some job. RO-Crate identifiers are only honored for input \
-                     files; output files keep using their path as `@id`. Remove the \
-                     identifier or reference the file as an input.",
+                    "File '{}' uses identifier '{}', which matches a reserved \
+                     value or prefix (`#torc-`, `#software-`, `#job-`, \
+                     `ro-crate-metadata.json`, or `./`). Those are used by \
+                     Torc's own provenance entities or the synthetic export \
+                     root and would collide at export time.",
+                    file.name, identifier
+                )
+                .into());
+            }
+
+            // Check 4: identifier must not equal another file's path.
+            if let Some(&other_name) = path_to_name.get(identifier)
+                && other_name != name
+            {
+                return Err(format!(
+                    "File '{}' uses identifier '{}', which is also the path of \
+                     file '{}'. Both would map to the same `entity_id`; \
+                     workflow-wide RO-Crate entity IDs must be unique. Pick a \
+                     distinct identifier.",
+                    file.name, identifier, other_name
+                )
+                .into());
+            }
+
+            // Checks 2 + 5: dual-use rejection.
+            let is_output = is_referenced_as(name, &output_names, &output_regexes);
+            if is_output {
+                return Err(format!(
+                    "File '{}' sets `identifier` but is referenced as an output \
+                     of some job. RO-Crate identifiers are only honored for \
+                     input files; the output completion path always resets \
+                     `entity_id` to the file path and would silently overwrite \
+                     the identifier. Remove the identifier, or restructure so \
+                     this file is only an input.",
                     file.name
                 )
                 .into());
             }
 
-            if identifier.starts_with("#torc-") || identifier.starts_with("#software-") {
+            let is_input =
+                file.st_mtime.is_some() || is_referenced_as(name, &input_names, &input_regexes);
+            if !is_input {
+                // Not referenced anywhere — there's no input File entity for the
+                // identifier to attach to. Reject so the user catches typos
+                // rather than silently exporting an orphan.
                 return Err(format!(
-                    "File '{}' uses identifier '{}', which begins with a reserved \
-                     prefix (`#torc-` or `#software-`). Those prefixes are used by \
-                     Torc's own workflow, run, and software provenance entities and \
-                     would collide with them at export time.",
-                    file.name, identifier
+                    "File '{}' sets `identifier` but is not referenced by any \
+                     job's `input_files` / `input_file_regexes` and has no \
+                     pre-existing `st_mtime`. Identifiers attach to input \
+                     entities, so this would create a dangling RO-Crate row. \
+                     Either reference it as a job input or remove the identifier.",
+                    file.name
                 )
                 .into());
             }
@@ -2352,7 +2432,14 @@ impl WorkflowSpec {
         spec.expand_parameters()?;
         spec.validate_unique_names_after_expansion()?;
         spec.validate_env_maps()?;
-        spec.validate_file_identifiers()?;
+        // Substitute variables on a clone so the returned spec stays in its
+        // unsubstituted form (the caller's `create_from_validated_spec` will
+        // substitute again); but identifier validation needs the substituted
+        // `input_files` / `output_files` populated from `${files.*.NAME}`
+        // tokens to correctly classify input vs output files.
+        let mut for_identifier_check = spec.clone();
+        for_identifier_check.substitute_variables()?;
+        for_identifier_check.validate_file_identifiers()?;
 
         spec.validate_scheduler_node_requirements()?;
 
@@ -2392,7 +2479,15 @@ impl WorkflowSpec {
             eprintln!("Validation error: {}", e);
             std::process::exit(1);
         }
-        if let Err(e) = spec.validate_file_identifiers() {
+        // Identifier classification needs input/output_files populated from
+        // ${files.*.NAME} tokens; substitute on a clone so this remains
+        // pre-validation only.
+        let mut for_identifier_check = spec.clone();
+        if let Err(e) = for_identifier_check.substitute_variables() {
+            eprintln!("Variable substitution failed: {}", e);
+            std::process::exit(1);
+        }
+        if let Err(e) = for_identifier_check.validate_file_identifiers() {
             eprintln!("Validation error: {}", e);
             std::process::exit(1);
         }
@@ -2517,8 +2612,12 @@ impl WorkflowSpec {
             errors.push(format!("Environment validation failed: {}", e));
         }
 
-        if let Err(e) = spec.validate_file_identifiers() {
-            errors.push(format!("File identifier validation failed: {}", e));
+        // Check duplicates of names and identifiers after expansion. This was
+        // missing from the dry-run path -- without it, a spec with two files
+        // sharing an expanded identifier would pass `validate` and only fail
+        // later in `create_files`.
+        if let Err(e) = spec.validate_unique_names_after_expansion() {
+            errors.push(format!("Validation error: {}", e));
         }
 
         // Step 4: Validate scheduler node requirements
@@ -2533,6 +2632,14 @@ impl WorkflowSpec {
         // Step 5: Validate variable substitution
         if let Err(e) = spec.substitute_variables() {
             errors.push(format!("Variable substitution failed: {}", e));
+        }
+
+        // Identifier validation MUST run after substitute_variables: jobs that
+        // declare files via `${files.output.NAME}` only have `output_files`
+        // populated post-substitution, and we'd otherwise miss output-only
+        // files that should reject `identifier`.
+        if let Err(e) = spec.validate_file_identifiers() {
+            errors.push(format!("File identifier validation failed: {}", e));
         }
 
         // Step 6: Check for duplicate names
@@ -2952,9 +3059,12 @@ impl WorkflowSpec {
             });
         }
         spec.validate_env_maps()?;
-        spec.validate_file_identifiers()?;
         spec.validate_actions()?;
         spec.substitute_variables()?;
+        // Identifier validation runs AFTER substitution so jobs that declare
+        // files via ${files.*.NAME} have their input_files/output_files filled
+        // in -- otherwise the input/output classification is wrong.
+        spec.validate_file_identifiers()?;
         Self::create_from_prepared_spec(config, spec)
     }
 
@@ -2982,9 +3092,11 @@ impl WorkflowSpec {
         spec.expand_parameters()?;
         spec.validate_unique_names_after_expansion()?;
         spec.validate_env_maps()?;
-        spec.validate_file_identifiers()?;
         spec.validate_actions()?;
         spec.substitute_variables()?;
+        // After substitution: input_files / output_files populated from
+        // ${files.*.NAME} tokens are visible to the identifier classification.
+        spec.validate_file_identifiers()?;
         Ok(())
     }
 
@@ -3328,6 +3440,22 @@ impl WorkflowSpec {
             .flat_map(|job| job.input_files.iter().flatten().map(String::as_str))
             .collect();
 
+        // Also collect compiled `input_file_regexes` so files whose names are
+        // matched only by a regex (rather than an exact `input_files` entry)
+        // still get classified as inputs -- both for the st_mtime stat and for
+        // the identifier pre-create below. Malformed regexes are surfaced by
+        // `resolve_names_and_regexes` later; tolerate them here so we don't
+        // double-report.
+        let input_file_regexes: Vec<Regex> = spec
+            .jobs
+            .iter()
+            .flat_map(|job| job.input_file_regexes.iter().flatten())
+            .filter_map(|p| Regex::new(p).ok())
+            .collect();
+        let is_input_name = |name: &str| {
+            input_file_names.contains(name) || input_file_regexes.iter().any(|re| re.is_match(name))
+        };
+
         // Build the full list of FileModels up front. file_name_to_id holds sentinel
         // zeros for every requested name; each batch's response replaces them with the
         // server-assigned ids. Looking the id up by the *returned* model's `name` field
@@ -3343,11 +3471,11 @@ impl WorkflowSpec {
             }
 
             // Use the spec-provided value when given; otherwise stat the path only for
-            // files used as inputs. Output-only files stay `None`, which is the marker
-            // the server uses to identify outputs.
+            // files used as inputs (exact name OR regex match). Output-only files
+            // stay `None`, which is the marker the server uses to identify outputs.
             let st_mtime = match file_spec.st_mtime {
                 Some(t) => Some(t),
-                None if input_file_names.contains(file_spec.name.as_str()) => {
+                None if is_input_name(file_spec.name.as_str()) => {
                     std::fs::metadata(&file_spec.path)
                         .and_then(|m| m.modified())
                         .ok()
@@ -3428,8 +3556,7 @@ impl WorkflowSpec {
             let Some(identifier) = file_spec.identifier.as_deref() else {
                 continue;
             };
-            let is_input =
-                file_model.st_mtime.is_some() || input_file_names.contains(file_spec.name.as_str());
+            let is_input = file_model.st_mtime.is_some() || is_input_name(file_spec.name.as_str());
             if !is_input {
                 continue;
             }
@@ -6409,6 +6536,66 @@ job "process" {
     }
 
     #[test]
+    fn test_kdl_file_identifier_round_trip() {
+        // KDL parser/serializer must round-trip the new `identifier` field so
+        // it doesn't regress independently of YAML/JSON support. Cover both the
+        // child-node form (block) and the property form (inline).
+        let kdl_block = r#"
+name "with_identifier"
+
+file "ref" {
+    path "/data/ref.csv"
+    identifier "urn:dataset:ref"
+}
+
+job "consume" {
+    command "echo"
+    input_files "ref"
+}
+"#;
+        let spec_from_block = WorkflowSpec::from_spec_file_content(kdl_block, "kdl")
+            .expect("Failed to parse KDL spec with child-node identifier");
+        let file = &spec_from_block.files.as_ref().unwrap()[0];
+        assert_eq!(file.identifier.as_deref(), Some("urn:dataset:ref"));
+
+        // Property form on the same line as `file "name"`.
+        let kdl_property = r#"
+name "with_identifier_property"
+
+file "ref" path="/data/ref.csv" identifier="urn:dataset:ref"
+
+job "consume" {
+    command "echo"
+    input_files "ref"
+}
+"#;
+        let spec_from_prop = WorkflowSpec::from_spec_file_content(kdl_property, "kdl")
+            .expect("Failed to parse KDL spec with property-form identifier");
+        let file_prop = &spec_from_prop.files.as_ref().unwrap()[0];
+        assert_eq!(file_prop.identifier.as_deref(), Some("urn:dataset:ref"));
+
+        // to_kdl_str → parse → check that identifier survives the round-trip.
+        let mut spec_emit =
+            WorkflowSpec::new("emit".to_string(), "tester".to_string(), None, vec![]);
+        let mut f = FileSpec::new("ref".to_string(), "/data/ref.csv".to_string());
+        f.identifier = Some("urn:dataset:ref".to_string());
+        spec_emit.files = Some(vec![f]);
+
+        let emitted = spec_emit.to_kdl_str();
+        assert!(
+            emitted.contains("identifier"),
+            "emitted KDL missing identifier: {}",
+            emitted
+        );
+        let reparsed = WorkflowSpec::from_spec_file_content(&emitted, "kdl")
+            .expect("Failed to re-parse emitted KDL");
+        assert_eq!(
+            reparsed.files.as_ref().unwrap()[0].identifier.as_deref(),
+            Some("urn:dataset:ref")
+        );
+    }
+
+    #[test]
     fn test_kdl_multi_dimensional_parameterization() {
         let kdl_content = r#"
 name "test_multi_param"
@@ -6709,7 +6896,9 @@ job "train_lr{lr:.4f}_bs{batch_size}" {
         // to half-honor.
         let mut f = FileSpec::new("a".to_string(), "/data/a.csv".to_string());
         f.identifier = Some("urn:dataset:abc".to_string());
-        let mut spec = WorkflowSpec::new("wf".to_string(), "tester".to_string(), None, vec![]);
+        let mut job = JobSpec::new("consume".to_string(), "process".to_string());
+        job.input_files = Some(vec!["a".to_string()]);
+        let mut spec = WorkflowSpec::new("wf".to_string(), "tester".to_string(), None, vec![job]);
         spec.files = Some(vec![f]);
         // enable_ro_crate is None by default
 
@@ -6751,9 +6940,13 @@ job "train_lr{lr:.4f}_bs{batch_size}" {
     }
 
     #[test]
-    fn test_validate_file_identifiers_allows_file_used_as_both_input_and_output() {
-        // A file referenced as both input and output (e.g. an in-place transform)
-        // is still an input from RO-Crate's perspective; identifier should be allowed.
+    fn test_validate_file_identifiers_rejects_dual_use_file() {
+        // A file referenced as both input AND output also has to be rejected.
+        // When the producing job completes, `create_ro_crate_entity_for_output_file`
+        // calls `build_file_entity_with_provenance` which always sets
+        // `entity_id = file.path`, clobbering the user's identifier in both
+        // the entity_id column and metadata. Allowing this would silently
+        // strip the identifier after the first job completes.
         let mut producer = JobSpec::new("producer".to_string(), "make".to_string());
         producer.output_files = Some(vec!["shared".to_string()]);
         let mut consumer = JobSpec::new("consumer".to_string(), "transform".to_string());
@@ -6771,19 +6964,91 @@ job "train_lr{lr:.4f}_bs{batch_size}" {
         spec.enable_ro_crate = Some(true);
         spec.files = Some(vec![shared]);
 
+        let err = spec
+            .validate_file_identifiers()
+            .expect_err("dual-use identifier should be rejected");
+        let msg = err.to_string();
+        assert!(msg.contains("'shared'"), "{}", msg);
+        assert!(msg.contains("output"), "{}", msg);
+    }
+
+    #[test]
+    fn test_validate_file_identifiers_accepts_input_via_regex() {
+        // A job that declares its inputs via `input_file_regexes` (rather than
+        // an exact `input_files` list) still classifies matching files as
+        // inputs, so identifiers on those files must validate cleanly.
+        let mut consumer = JobSpec::new("consumer".to_string(), "process".to_string());
+        consumer.input_file_regexes = Some(vec!["^input_.*$".to_string()]);
+
+        let mut f = FileSpec::new("input_a".to_string(), "/data/a.csv".to_string());
+        f.identifier = Some("urn:dataset:a".to_string());
+
+        let mut spec =
+            WorkflowSpec::new("wf".to_string(), "tester".to_string(), None, vec![consumer]);
+        spec.enable_ro_crate = Some(true);
+        spec.files = Some(vec![f]);
+
         spec.validate_file_identifiers()
-            .expect("identifier on a file used as both input and output should be allowed");
+            .expect("regex-matched input should be accepted");
+    }
+
+    #[test]
+    fn test_validate_file_identifiers_rejects_identifier_equal_to_other_path() {
+        // Identifier of file A equal to path of file B would collide in the
+        // (workflow_id, entity_id) unique index and silently drop one entity.
+        let mut a = FileSpec::new("a".to_string(), "/data/a.csv".to_string());
+        a.identifier = Some("/data/b.csv".to_string());
+        let b = FileSpec::new("b".to_string(), "/data/b.csv".to_string());
+
+        // Reference both as inputs so the dual-use / orphan checks don't fire first.
+        let mut job = JobSpec::new("consume".to_string(), "process".to_string());
+        job.input_files = Some(vec!["a".to_string(), "b".to_string()]);
+
+        let mut spec = WorkflowSpec::new("wf".to_string(), "tester".to_string(), None, vec![job]);
+        spec.enable_ro_crate = Some(true);
+        spec.files = Some(vec![a, b]);
+
+        let err = spec
+            .validate_file_identifiers()
+            .expect_err("identifier-equals-other-path should be rejected");
+        let msg = err.to_string();
+        assert!(msg.contains("'a'") && msg.contains("'b'"), "{}", msg);
+        assert!(msg.contains("/data/b.csv"), "{}", msg);
+    }
+
+    #[test]
+    fn test_validate_file_identifiers_rejects_orphan_identifier() {
+        // A file with an identifier that's not referenced by any job and has
+        // no `st_mtime` would create a dangling entity at export time. Reject
+        // so typos in input_files surface as a clear error.
+        let mut f = FileSpec::new("orphan".to_string(), "/data/orphan.csv".to_string());
+        f.identifier = Some("urn:dataset:orphan".to_string());
+
+        let mut spec = WorkflowSpec::new("wf".to_string(), "tester".to_string(), None, vec![]);
+        spec.enable_ro_crate = Some(true);
+        spec.files = Some(vec![f]);
+
+        let err = spec
+            .validate_file_identifiers()
+            .expect_err("orphan identifier should be rejected");
+        let msg = err.to_string();
+        assert!(msg.contains("'orphan'"), "{}", msg);
+        assert!(msg.contains("input"), "{}", msg);
     }
 
     #[test]
     fn test_validate_file_identifiers_rejects_reserved_prefixes() {
         // Identifiers starting with reserved prefixes would collide with Torc's own
         // provenance entities, which share the (workflow_id, entity_id) uniqueness
-        // index. Reject at spec load to surface a clear error.
+        // index, or with the synthetic root entities the exporter always emits.
+        // Reject at spec load to surface a clear error.
         for reserved in [
             "#torc-workflow",
             "#torc-run-id-1",
             "#software-torc-run-id-1",
+            "#job-42-attempt-1",
+            "ro-crate-metadata.json",
+            "./",
         ] {
             let mut f = FileSpec::new("a".to_string(), "/data/a.csv".to_string());
             f.identifier = Some(reserved.to_string());

--- a/tests/test_ro_crate_add_dataset_provenance.rs
+++ b/tests/test_ro_crate_add_dataset_provenance.rs
@@ -1,0 +1,285 @@
+//! Integration tests for `torc ro-crate add-dataset --job-id`.
+//!
+//! These verify the provenance wiring: that a CreateAction entity is created
+//! (or updated) for each producing job, that the dataset is added to the
+//! CreateAction's `result`, and that the dataset's `prov:wasGeneratedBy`
+//! references those CreateAction entities.
+
+mod common;
+
+use common::{ServerProcess, run_cli_command, start_server};
+use rstest::rstest;
+use std::fs;
+use std::path::Path;
+use torc::client::apis;
+use torc::models;
+
+/// Create a workflow with one job (no tracked files needed for these tests).
+/// Returns (workflow_id, job_id).
+fn create_workflow_with_job(config: &torc::client::Configuration, job_name: &str) -> (i64, i64) {
+    let workflow = models::WorkflowModel::new(
+        "test_add_dataset_provenance".to_string(),
+        "test_user".to_string(),
+    );
+    let created_workflow =
+        apis::workflows_api::create_workflow(config, workflow).expect("Failed to create workflow");
+    let workflow_id = created_workflow.id.unwrap();
+
+    let job = models::JobModel::new(workflow_id, job_name.to_string(), "echo hi".to_string());
+    let created_job = apis::jobs_api::create_job(config, job).expect("Failed to create job");
+    let job_id = created_job.id.unwrap();
+
+    (workflow_id, job_id)
+}
+
+/// Create a directory with a couple of files to register as a dataset.
+fn make_dataset_dir(base: &Path) -> String {
+    let dir = base.join("ds");
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join("part-0.parquet"), b"abc").unwrap();
+    fs::write(dir.join("part-1.parquet"), b"defg").unwrap();
+    dir.to_string_lossy().to_string()
+}
+
+fn list_entities(
+    config: &torc::client::Configuration,
+    workflow_id: i64,
+) -> Vec<models::RoCrateEntityModel> {
+    apis::ro_crate_api::list_ro_crate_entities(
+        config,
+        workflow_id,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .expect("Failed to list RO-Crate entities")
+    .items
+}
+
+#[rstest]
+fn test_add_dataset_creates_create_action_for_job(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+
+    let (workflow_id, job_id) = create_workflow_with_job(config, "produce_dataset");
+    let dataset_path = make_dataset_dir(temp_dir.path());
+
+    // The job never ran, so no CreateAction exists yet. add-dataset must create
+    // one and wire the bidirectional provenance link.
+    let workflow_id_str = workflow_id.to_string();
+    let job_id_str = job_id.to_string();
+    run_cli_command(
+        &[
+            "ro-crate",
+            "add-dataset",
+            &workflow_id_str,
+            "--name",
+            "training_output",
+            "--path",
+            &dataset_path,
+            "-j",
+            &job_id_str,
+        ],
+        start_server,
+        None,
+    )
+    .expect("add-dataset command failed");
+
+    let entities = list_entities(config, workflow_id);
+    let expected_action_id = format!("#job-{}-attempt-1", job_id);
+    let dataset_entity_id = format!("{}/", dataset_path);
+
+    // A CreateAction entity must exist for the producing job.
+    let action = entities
+        .iter()
+        .find(|e| e.entity_id == expected_action_id)
+        .unwrap_or_else(|| {
+            panic!(
+                "Expected a CreateAction entity '{}'. Found: {:?}",
+                expected_action_id,
+                entities.iter().map(|e| &e.entity_id).collect::<Vec<_>>()
+            )
+        });
+    assert_eq!(action.entity_type, "CreateAction");
+
+    let action_meta: serde_json::Value =
+        serde_json::from_str(&action.metadata).expect("CreateAction metadata is not valid JSON");
+    assert_eq!(action_meta["@type"][0], "CreateAction");
+    // The dataset must appear in the CreateAction's result array.
+    let result = action_meta["result"]
+        .as_array()
+        .expect("CreateAction should have a result array");
+    assert!(
+        result
+            .iter()
+            .any(|r| r["@id"] == serde_json::json!(dataset_entity_id)),
+        "CreateAction result should reference the dataset. result={:?}",
+        result
+    );
+
+    // The Dataset entity must point back at the CreateAction.
+    let dataset = entities
+        .iter()
+        .find(|e| e.entity_id == dataset_entity_id)
+        .expect("Dataset entity should exist");
+    assert_eq!(dataset.entity_type, "Dataset");
+    let dataset_meta: serde_json::Value =
+        serde_json::from_str(&dataset.metadata).expect("Dataset metadata is not valid JSON");
+    assert_eq!(
+        dataset_meta["prov:wasGeneratedBy"]["@id"],
+        serde_json::json!(expected_action_id),
+        "Dataset prov:wasGeneratedBy should reference the CreateAction"
+    );
+}
+
+#[rstest]
+fn test_add_dataset_multiple_jobs_creates_actions(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+
+    let (workflow_id, job1) = create_workflow_with_job(config, "writer_a");
+    // Add a second job to the same workflow.
+    let job2 = {
+        let j = models::JobModel::new(workflow_id, "writer_b".to_string(), "echo hi".to_string());
+        apis::jobs_api::create_job(config, j)
+            .expect("Failed to create job2")
+            .id
+            .unwrap()
+    };
+    let dataset_path = make_dataset_dir(temp_dir.path());
+
+    let workflow_id_str = workflow_id.to_string();
+    let job1_str = job1.to_string();
+    let job2_str = job2.to_string();
+    run_cli_command(
+        &[
+            "ro-crate",
+            "add-dataset",
+            &workflow_id_str,
+            "--name",
+            "shared_output",
+            "--path",
+            &dataset_path,
+            "-j",
+            &job1_str,
+            "-j",
+            &job2_str,
+        ],
+        start_server,
+        None,
+    )
+    .expect("add-dataset command failed");
+
+    let entities = list_entities(config, workflow_id);
+    let action1 = format!("#job-{}-attempt-1", job1);
+    let action2 = format!("#job-{}-attempt-1", job2);
+    let dataset_entity_id = format!("{}/", dataset_path);
+
+    for action_id in [&action1, &action2] {
+        assert!(
+            entities
+                .iter()
+                .any(|e| &e.entity_id == action_id && e.entity_type == "CreateAction"),
+            "Expected CreateAction entity '{}'",
+            action_id
+        );
+    }
+
+    let dataset = entities
+        .iter()
+        .find(|e| e.entity_id == dataset_entity_id)
+        .expect("Dataset entity should exist");
+    let dataset_meta: serde_json::Value =
+        serde_json::from_str(&dataset.metadata).expect("Dataset metadata is not valid JSON");
+    let generated_by = dataset_meta["prov:wasGeneratedBy"]
+        .as_array()
+        .expect("prov:wasGeneratedBy should be an array for multiple jobs");
+    let referenced: Vec<&str> = generated_by
+        .iter()
+        .filter_map(|v| v["@id"].as_str())
+        .collect();
+    assert!(referenced.contains(&action1.as_str()));
+    assert!(referenced.contains(&action2.as_str()));
+}
+
+#[rstest]
+fn test_add_dataset_updates_existing_create_action(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+
+    let (workflow_id, job_id) = create_workflow_with_job(config, "ran_already");
+    let dataset_path = make_dataset_dir(temp_dir.path());
+    let action_id = format!("#job-{}-attempt-1", job_id);
+
+    // Simulate a CreateAction that already exists from a prior run with a
+    // tracked output file in its result array.
+    let existing_meta = serde_json::json!({
+        "@id": action_id,
+        "@type": ["CreateAction", "prov:Activity"],
+        "name": "ran_already",
+        "result": [{ "@id": "output/existing.json" }]
+    });
+    let existing = models::RoCrateEntityModel::new(
+        workflow_id,
+        action_id.clone(),
+        "CreateAction".to_string(),
+        existing_meta.to_string(),
+    );
+    apis::ro_crate_entities_api::create_ro_crate_entity(config, existing)
+        .expect("Failed to pre-create CreateAction");
+
+    let workflow_id_str = workflow_id.to_string();
+    let job_id_str = job_id.to_string();
+    run_cli_command(
+        &[
+            "ro-crate",
+            "add-dataset",
+            &workflow_id_str,
+            "--name",
+            "training_output",
+            "--path",
+            &dataset_path,
+            "-j",
+            &job_id_str,
+        ],
+        start_server,
+        None,
+    )
+    .expect("add-dataset command failed");
+
+    let entities = list_entities(config, workflow_id);
+    let dataset_entity_id = format!("{}/", dataset_path);
+
+    // Still exactly one CreateAction for the job (updated, not duplicated).
+    let actions: Vec<_> = entities
+        .iter()
+        .filter(|e| e.entity_id == action_id)
+        .collect();
+    assert_eq!(
+        actions.len(),
+        1,
+        "CreateAction should be updated in place, not duplicated"
+    );
+
+    let action_meta: serde_json::Value =
+        serde_json::from_str(&actions[0].metadata).expect("CreateAction metadata invalid");
+    let result = action_meta["result"]
+        .as_array()
+        .expect("result should be an array");
+    let result_ids: Vec<&str> = result.iter().filter_map(|r| r["@id"].as_str()).collect();
+    // The pre-existing tracked output is preserved...
+    assert!(
+        result_ids.contains(&"output/existing.json"),
+        "Existing tracked output should be preserved. result={:?}",
+        result_ids
+    );
+    // ...and the dataset is appended.
+    assert!(
+        result_ids.contains(&dataset_entity_id.as_str()),
+        "Dataset should be appended to existing result. result={:?}",
+        result_ids
+    );
+}

--- a/tests/test_ro_crate_add_dataset_provenance.rs
+++ b/tests/test_ro_crate_add_dataset_provenance.rs
@@ -283,3 +283,75 @@ fn test_add_dataset_updates_existing_create_action(start_server: &ServerProcess)
         result_ids
     );
 }
+
+/// Invalid `--metadata` JSON must be rejected BEFORE any provenance side
+/// effects. Otherwise a malformed value would leave a CreateAction whose
+/// `result` references a Dataset entity that never got created. This
+/// guards the parse-up-front contract in `handle_add_dataset`.
+#[rstest]
+fn test_add_dataset_invalid_metadata_leaves_no_create_action(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+
+    let (workflow_id, job_id) =
+        create_workflow_with_job(config, "invalid_metadata_no_side_effects");
+    let dataset_path = make_dataset_dir(temp_dir.path());
+
+    // Sanity-check: no CreateAction exists for this job before the bad invocation.
+    let pre = list_entities(config, workflow_id);
+    let expected_action_id = format!("#job-{}-attempt-1", job_id);
+    assert!(
+        !pre.iter().any(|e| e.entity_id == expected_action_id),
+        "test setup: no CreateAction should exist yet"
+    );
+
+    let workflow_id_str = workflow_id.to_string();
+    let job_id_str = job_id.to_string();
+    let result = run_cli_command(
+        &[
+            "ro-crate",
+            "add-dataset",
+            &workflow_id_str,
+            "--name",
+            "training_output",
+            "--path",
+            &dataset_path,
+            "-j",
+            &job_id_str,
+            "--metadata",
+            "{not json",
+        ],
+        start_server,
+        None,
+    );
+
+    assert!(
+        result.is_err(),
+        "add-dataset with invalid --metadata should fail; got Ok({:?})",
+        result
+    );
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("--metadata"),
+        "error should mention --metadata; got: {}",
+        err_msg
+    );
+
+    // The critical assertion: no CreateAction must have been created. If
+    // metadata parsing ran after `wire_dataset_job_provenance`, we'd see a
+    // CreateAction here with a `result` pointing at a Dataset that doesn't
+    // exist -- a broken provenance graph.
+    let post = list_entities(config, workflow_id);
+    assert!(
+        !post.iter().any(|e| e.entity_id == expected_action_id),
+        "no CreateAction should exist after invalid --metadata; entities={:?}",
+        post.iter().map(|e| &e.entity_id).collect::<Vec<_>>()
+    );
+    // And no Dataset entity either.
+    let dataset_entity_id = format!("{}/", dataset_path);
+    assert!(
+        !post.iter().any(|e| e.entity_id == dataset_entity_id),
+        "no Dataset should exist after invalid --metadata; entities={:?}",
+        post.iter().map(|e| &e.entity_id).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Summary

- Adds optional `FileSpec.identifier` so workflow specs can carry a stable RO-Crate `@id` (DOI/PURL/URN) for input files instead of defaulting to the local filesystem path. The path is preserved as `sameAs`.
- Round-trip is achieved without a server change: `create_files` pre-creates the entity row with `entity_id = identifier`, the server's init-time upsert preserves `entity_id` (only rewriting `metadata["@id"]`), and the client-side rebuild reads `entity_id` back as an override so `@id` ends up at the user's identifier in the exported crate.
- Validation rejects duplicate identifiers at spec load with a clear error pointing at both files.
- Also bundles an unrelated stray commit `948dfb19` — "ro-crate add-dataset: validate `--metadata` before provenance side effects" — that was already on this branch.

## Scope notes

- Honored only for files Torc classifies as inputs (referenced as a job input, or with `st_mtime` set). Output files keep the path as `@id`; setting `identifier` on an output is silently ignored.
- Parameter substitution: `identifier` templates expand the same way `name` and `path` do (e.g. `urn:dataset:run-2026:{i}`), so parameterized files don't all collapse onto the same `@id`.

## Test plan

- [x] `cargo test --features client --lib` (325 passing, 4 new)
- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all --all-targets --all-features -- -D warnings`
- [x] `dprint check`
- [ ] Manual: create a workflow spec with `identifier: https://doi.org/...` on an input file, run, `torc ro-crate export`, confirm `@id` is the DOI and `sameAs` is the local path

🤖 Generated with [Claude Code](https://claude.com/claude-code)