### PR TITLE
api-stats: count actual transferred bytes via http_body adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5095,6 +5095,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bcrypt",
+ "bytes",
  "cargo-husky",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ mime_guess = "2.0"
 hyper = { version = "1", features = ["full"] }
 http-body = "1"
 http-body-util = "0.1"
+bytes = "1"
 serde_ignored = "0.1.1"
 percent-encoding = "2.1.0"
 regex = "1.3"
@@ -185,6 +186,7 @@ server = [
     "dep:hyper-util",
     "dep:http-body",
     "dep:http-body-util",
+    "dep:bytes",
     "dep:serde_ignored",
     "dep:percent-encoding",
     "dep:regex",
@@ -325,6 +327,7 @@ async-stream = { workspace = true, optional = true }
 hyper = { workspace = true, optional = true }
 http-body = { workspace = true, optional = true }
 http-body-util = { workspace = true, optional = true }
+bytes = { workspace = true, optional = true }
 serde_ignored = { workspace = true, optional = true }
 percent-encoding = { workspace = true, optional = true }
 regex = { workspace = true, optional = true }

--- a/src/server/api_stats.rs
+++ b/src/server/api_stats.rs
@@ -190,7 +190,7 @@ impl Default for ApiStatsRing {
 pub struct CountingBody<B> {
     inner: B,
     counter: Arc<AtomicU64>,
-    on_end: Option<Box<dyn FnOnce(u64) + Send + Sync>>,
+    on_end: Option<Box<dyn FnOnce(u64) + Send>>,
 }
 
 impl<B> CountingBody<B> {
@@ -213,7 +213,7 @@ impl<B> CountingBody<B> {
     /// whose size isn't known up front.
     pub fn with_on_end<F>(inner: B, counter: Arc<AtomicU64>, on_end: F) -> Self
     where
-        F: FnOnce(u64) + Send + Sync + 'static,
+        F: FnOnce(u64) + Send + 'static,
     {
         Self {
             inner,

--- a/src/server/api_stats.rs
+++ b/src/server/api_stats.rs
@@ -1,22 +1,27 @@
 //! Lightweight per-second ring buffer of HTTP request stats.
 //!
-//! Tracks request count, request/response bytes (from `Content-Length`
-//! headers — see caveats below), and a 2xx/4xx/5xx breakdown for the
-//! last hour. Used by the `GET /admin/api-stats` endpoint and the
-//! `torc admin api-stats` CLI to answer "how busy is the server right
-//! now?" without streaming individual events.
+//! Tracks request count, request/response bytes, and a 2xx/4xx/5xx
+//! breakdown for the last hour. Used by the `GET /admin/api-stats`
+//! endpoint and the `torc admin api-stats` CLI to answer "how busy is
+//! the server right now?" without streaming individual events.
 //!
-//! ## Caveats
+//! Byte counts are tallied by [`CountingBody`], an `http_body::Body`
+//! adapter that increments an atomic counter as data frames flow
+//! through; the per-request total is fed into [`ApiStatsRing::record`]
+//! once the response body completes (or is dropped). This captures
+//! chunked / streaming payloads — including the SSE event streams —
+//! that `Content-Length` headers would miss.
 //!
-//! * Byte counts come from `Content-Length` request and response headers
-//!   only. Chunked / streaming responses (notably the SSE event streams)
-//!   do not advertise a length and will be reported as 0 bytes; the
-//!   request *count* is still recorded.
-//! * Stats are in-memory only. The buffer is cleared on server restart.
+//! Stats are in-memory only; the buffer is cleared on server restart.
 
+use bytes::Buf;
+use http_body::{Body as HttpBody, Frame, SizeHint};
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
+use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::task::{Context, Poll};
 
 /// Number of 1-second buckets retained. One hour of history.
 pub const BUCKET_COUNT: usize = 3600;
@@ -34,9 +39,9 @@ pub struct ApiStatsBucket {
     pub start_ms: i64,
     /// Total requests handled during this bucket.
     pub request_count: u64,
-    /// Sum of `Content-Length` from inbound requests.
+    /// Sum of data frame bytes received in inbound requests.
     pub bytes_in: u64,
-    /// Sum of `Content-Length` from outbound responses.
+    /// Sum of data frame bytes written in outbound responses.
     pub bytes_out: u64,
     /// Requests that returned a 2xx status.
     pub status_2xx: u64,
@@ -175,6 +180,96 @@ impl Default for ApiStatsRing {
     }
 }
 
+/// `http_body::Body` adapter that counts the bytes of each data frame
+/// as it passes through. Wrapping a request body lets us tally actual
+/// inbound bytes (chunked uploads included); wrapping a response body
+/// with [`CountingBody::with_on_end`] additionally fires a callback
+/// when the body finishes — either by yielding `Poll::Ready(None)` or
+/// by being dropped — making it the right place to call
+/// [`ApiStatsRing::record`] with the final byte total.
+pub struct CountingBody<B> {
+    inner: B,
+    counter: Arc<AtomicU64>,
+    on_end: Option<Box<dyn FnOnce(u64) + Send + Sync>>,
+}
+
+impl<B> CountingBody<B> {
+    /// Wrap `inner`, accumulating the size of each data frame into
+    /// `counter`. Use this for request bodies, where the consuming
+    /// middleware reads the final count directly from `counter` after
+    /// the handler returns.
+    pub fn new(inner: B, counter: Arc<AtomicU64>) -> Self {
+        Self {
+            inner,
+            counter,
+            on_end: None,
+        }
+    }
+
+    /// Like [`CountingBody::new`], but also fires `on_end(total)`
+    /// exactly once when the body completes or is dropped. Use this
+    /// for response bodies, so the recording happens once the stream
+    /// has actually been sent — including for SSE / chunked responses
+    /// whose size isn't known up front.
+    pub fn with_on_end<F>(inner: B, counter: Arc<AtomicU64>, on_end: F) -> Self
+    where
+        F: FnOnce(u64) + Send + Sync + 'static,
+    {
+        Self {
+            inner,
+            counter,
+            on_end: Some(Box::new(on_end)),
+        }
+    }
+
+    fn fire_on_end(&mut self) {
+        if let Some(cb) = self.on_end.take() {
+            cb(self.counter.load(Ordering::Relaxed));
+        }
+    }
+}
+
+impl<B> HttpBody for CountingBody<B>
+where
+    B: HttpBody + Unpin,
+{
+    type Data = B::Data;
+    type Error = B::Error;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        let this = self.as_mut().get_mut();
+        let polled = Pin::new(&mut this.inner).poll_frame(cx);
+        match &polled {
+            Poll::Ready(Some(Ok(frame))) => {
+                if let Some(data) = frame.data_ref() {
+                    this.counter
+                        .fetch_add(data.remaining() as u64, Ordering::Relaxed);
+                }
+            }
+            Poll::Ready(None) => this.fire_on_end(),
+            _ => {}
+        }
+        polled
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        self.inner.size_hint()
+    }
+}
+
+impl<B> Drop for CountingBody<B> {
+    fn drop(&mut self) {
+        self.fire_on_end();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -252,5 +347,71 @@ mod tests {
         let ring = ApiStatsRing::new();
         let snap = ring.snapshot(1_700_000_000_000, 1_000_000, 60);
         assert!(snap.window_seconds <= BUCKET_COUNT as u64);
+    }
+
+    use http_body_util::{BodyExt, Full};
+    use std::sync::atomic::AtomicBool;
+
+    #[tokio::test]
+    async fn counting_body_sums_data_frame_bytes() {
+        let counter = Arc::new(AtomicU64::new(0));
+        let body = CountingBody::new(Full::<bytes::Bytes>::from("hello world"), counter.clone());
+        let _ = body.collect().await.expect("collect body");
+        assert_eq!(counter.load(Ordering::Relaxed), 11);
+    }
+
+    #[tokio::test]
+    async fn counting_body_on_end_fires_when_drained() {
+        let counter = Arc::new(AtomicU64::new(0));
+        let fired = Arc::new(AtomicU64::new(0));
+        let fired_clone = fired.clone();
+        let body = CountingBody::with_on_end(
+            Full::<bytes::Bytes>::from("abcdef"),
+            counter.clone(),
+            move |total| {
+                fired_clone.store(total, Ordering::Relaxed);
+            },
+        );
+        let _ = body.collect().await.expect("collect body");
+        assert_eq!(fired.load(Ordering::Relaxed), 6);
+    }
+
+    #[tokio::test]
+    async fn counting_body_on_end_fires_on_drop_when_not_drained() {
+        let counter = Arc::new(AtomicU64::new(0));
+        let fired = Arc::new(AtomicBool::new(false));
+        let fired_clone = fired.clone();
+        {
+            let _body = CountingBody::with_on_end(
+                Full::<bytes::Bytes>::from("never read"),
+                counter.clone(),
+                move |_| {
+                    fired_clone.store(true, Ordering::Relaxed);
+                },
+            );
+        }
+        assert!(
+            fired.load(Ordering::Relaxed),
+            "on_end should fire from Drop even if the body is never polled",
+        );
+    }
+
+    #[tokio::test]
+    async fn counting_body_on_end_fires_exactly_once() {
+        let counter = Arc::new(AtomicU64::new(0));
+        let count = Arc::new(AtomicU64::new(0));
+        let count_clone = count.clone();
+        {
+            let body = CountingBody::with_on_end(
+                Full::<bytes::Bytes>::from("xyz"),
+                counter.clone(),
+                move |_| {
+                    count_clone.fetch_add(1, Ordering::Relaxed);
+                },
+            );
+            let _ = body.collect().await.expect("collect body");
+            // Body now dropped at end of scope; on_end must not fire again.
+        }
+        assert_eq!(count.load(Ordering::Relaxed), 1);
     }
 }

--- a/src/server/live_router.rs
+++ b/src/server/live_router.rs
@@ -6,7 +6,7 @@ use crate::server::api_event_stream::{
     body_capture_limit,
 };
 use crate::server::api_stats::{
-    ApiStatsRing, ApiStatsSnapshot, DEFAULT_INTERVAL_SECONDS, DEFAULT_WINDOW_SECONDS,
+    ApiStatsRing, ApiStatsSnapshot, CountingBody, DEFAULT_INTERVAL_SECONDS, DEFAULT_WINDOW_SECONDS,
 };
 use crate::server::auth::{SharedCredentialCache, SharedHtpasswd};
 use crate::server::authorization::AccessCheckResult;
@@ -4385,16 +4385,33 @@ async fn record_api_stats(
     request: Request,
     next: Next,
 ) -> Response<Body> {
-    let bytes_in = content_length_header(request.headers());
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicU64;
+
+    let bytes_in = Arc::new(AtomicU64::new(0));
+    let bytes_in_counter = bytes_in.clone();
+    let request = request.map(|body| Body::new(CountingBody::new(body, bytes_in_counter)));
+
     let response = next.run(request).await;
-    let bytes_out = content_length_header(response.headers());
-    stats.record(
-        chrono::Utc::now().timestamp_millis(),
-        response.status().as_u16(),
-        bytes_in,
-        bytes_out,
-    );
-    response
+    let status = response.status().as_u16();
+
+    let bytes_out = Arc::new(AtomicU64::new(0));
+    let stats_for_callback = stats.clone();
+    let bytes_in_for_callback = bytes_in.clone();
+    response.map(|body| {
+        Body::new(CountingBody::with_on_end(
+            body,
+            bytes_out,
+            move |bytes_out_total| {
+                stats_for_callback.record(
+                    chrono::Utc::now().timestamp_millis(),
+                    status,
+                    bytes_in_for_callback.load(std::sync::atomic::Ordering::Relaxed),
+                    bytes_out_total,
+                );
+            },
+        ))
+    })
 }
 
 async fn capture_api_event(
@@ -4474,14 +4491,6 @@ async fn capture_api_event(
 
     bus.broadcast(event);
     response
-}
-
-fn content_length_header(headers: &axum::http::HeaderMap) -> u64 {
-    headers
-        .get(axum::http::header::CONTENT_LENGTH)
-        .and_then(|v| v.to_str().ok())
-        .and_then(|s| s.parse::<u64>().ok())
-        .unwrap_or(0)
 }
 
 /// Outcome of attempting to capture a request body.
@@ -4835,6 +4844,43 @@ mod live_router_tests {
     }
 
     #[tokio::test]
+    async fn api_stats_counts_actual_response_body_bytes() {
+        // Ping has no Content-Length set on the response in axum's
+        // default path — exercising the streaming-counter path that
+        // the old Content-Length-header reader would have missed.
+        let server = test_server_with_schema().await;
+        let stats = server.api_stats.clone();
+        let router = test_router(server);
+
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/torc-service/v1/ping")
+                    .body(Body::empty())
+                    .expect("valid request"),
+            )
+            .await
+            .expect("router response");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body_bytes = resp
+            .into_body()
+            .collect()
+            .await
+            .expect("collect body")
+            .to_bytes();
+        let body_len = body_bytes.len() as u64;
+        assert!(body_len > 0, "ping should return a non-empty body");
+
+        let snap = stats.snapshot(chrono::Utc::now().timestamp_millis(), 60, 60);
+        let total_bytes_out: u64 = snap.buckets.iter().map(|b| b.bytes_out).sum();
+        assert_eq!(
+            total_bytes_out, body_len,
+            "stats ring should account for every byte streamed out"
+        );
+    }
+
+    #[tokio::test]
     async fn api_stats_records_unauthenticated_requests() {
         let server = test_server_with_schema().await;
         let stats = server.api_stats.clone();
@@ -4851,6 +4897,10 @@ mod live_router_tests {
             .await
             .expect("router response");
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        // Recording fires from the response body's Drop / completion;
+        // drop the response so the stats ring sees this request before
+        // we snapshot.
+        drop(response);
 
         let snap = stats.snapshot(chrono::Utc::now().timestamp_millis(), 60, 60);
         let total: u64 = snap.buckets.iter().map(|b| b.request_count).sum();

--- a/src/server/live_router.rs
+++ b/src/server/live_router.rs
@@ -4872,7 +4872,10 @@ mod live_router_tests {
         let body_len = body_bytes.len() as u64;
         assert!(body_len > 0, "ping should return a non-empty body");
 
-        let snap = stats.snapshot(chrono::Utc::now().timestamp_millis(), 60, 60);
+        // 120s window so a record landing in the previous minute is
+        // still covered if `now` has just rolled into a new minute
+        // (snapshot buckets align to `floor(now / interval)`).
+        let snap = stats.snapshot(chrono::Utc::now().timestamp_millis(), 120, 60);
         let total_bytes_out: u64 = snap.buckets.iter().map(|b| b.bytes_out).sum();
         assert_eq!(
             total_bytes_out, body_len,
@@ -4902,7 +4905,9 @@ mod live_router_tests {
         // we snapshot.
         drop(response);
 
-        let snap = stats.snapshot(chrono::Utc::now().timestamp_millis(), 60, 60);
+        // 120s window so a record landing in the previous minute is
+        // still covered if `now` has just rolled into a new minute.
+        let snap = stats.snapshot(chrono::Utc::now().timestamp_millis(), 120, 60);
         let total: u64 = snap.buckets.iter().map(|b| b.request_count).sum();
         let total_4xx: u64 = snap.buckets.iter().map(|b| b.status_4xx).sum();
         assert_eq!(total, 1, "the 401 should still be recorded");


### PR DESCRIPTION
Replaces the `Content-Length` header lookup in the `record_api_stats` middleware with a `CountingBody` adapter that tallies bytes from each `http_body::Frame::Data` as it flows through. Recording fires from the response body's completion / drop, so chunked uploads and streaming responses (notably the SSE event streams) now contribute to `bytes_in` / `bytes_out` instead of being reported as zero.

Per-frame cost is a single relaxed atomic add; no buffering.