### PR TITLE
Add access_groups field to workflow specs (#319)

### DIFF
--- a/api/openapi.codegen.yaml
+++ b/api/openapi.codegen.yaml
@@ -7407,6 +7407,20 @@ components:
       - name
       - user
       properties:
+        access_groups:
+          type:
+          - array
+          - 'null'
+          items:
+            type: string
+          description: |-
+            Access group names granted shared access to this workflow.
+            Projection of the `workflow_access_group` join table (which remains the
+            source of truth). On create, names are resolved to group IDs and join
+            rows are inserted in the same transaction as the workflow row; an
+            unknown name fails the whole create. On read, populated from the join
+            table. Use `add_workflow_to_group` / `remove_workflow_from_group` for
+            post-creation changes.
         compute_node_expiration_buffer_seconds:
           type:
           - integer

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -7407,6 +7407,20 @@ components:
       - name
       - user
       properties:
+        access_groups:
+          type:
+          - array
+          - 'null'
+          items:
+            type: string
+          description: |-
+            Access group names granted shared access to this workflow.
+            Projection of the `workflow_access_group` join table (which remains the
+            source of truth). On create, names are resolved to group IDs and join
+            rows are inserted in the same transaction as the workflow row; an
+            unknown name fails the whole create. On read, populated from the join
+            table. Use `add_workflow_to_group` / `remove_workflow_from_group` for
+            post-creation changes.
         compute_node_expiration_buffer_seconds:
           type:
           - integer

--- a/docs/src/core/reference/workflow-spec.md
+++ b/docs/src/core/reference/workflow-spec.md
@@ -32,6 +32,7 @@ The top-level container for a complete workflow definition.
 | `compute_node_ignore_workflow_completion`        | boolean                                                 | false        | Compute nodes hold allocations even after workflow completes              |
 | `compute_node_wait_for_healthy_database_minutes` | integer                                                 | none         | Compute nodes wait this many minutes for database recovery                |
 | `enable_ro_crate`                                | boolean                                                 | false        | Enable automatic [RO-Crate](../concepts/ro-crate.md) provenance tracking  |
+| `access_groups`                                  | [string]                                                | none         | Access group names granted shared access to this workflow on creation     |
 
 ### Examples with project, metadata, and shared environment
 
@@ -86,6 +87,26 @@ jobs:
   ]
 }
 ```
+
+### Sharing a workflow with access groups
+
+Declare `access_groups` on the spec to grant teammates access at creation time instead of running
+`torc access-groups add-workflow` afterwards. Each name must match an existing group; an unknown
+name fails the create with a 422 and the workflow row is not created.
+
+```yaml
+name: shared_workflow
+access_groups:
+  - naerm
+  - data-team
+jobs:
+  - name: analyze
+    command: python analyze.py
+```
+
+Use [`torc access-groups add-workflow`](../../specialized/admin/access-groups.md) /
+`remove-workflow` for post-creation changes; the YAML field is a declarative shortcut, not the
+ongoing-management API.
 
 ## JobSpec
 

--- a/julia_client/Torc/src/api/models/model_WorkflowModel.jl
+++ b/julia_client/Torc/src/api/models/model_WorkflowModel.jl
@@ -5,6 +5,7 @@
 @doc raw"""WorkflowModel
 
     WorkflowModel(;
+        access_groups=nothing,
         compute_node_expiration_buffer_seconds=nothing,
         compute_node_ignore_workflow_completion=nothing,
         compute_node_min_time_for_new_jobs_seconds=nothing,
@@ -29,6 +30,7 @@
         user=nothing,
     )
 
+    - access_groups::Vector{String} : Access group names granted shared access to this workflow. Projection of the &#x60;workflow_access_group&#x60; join table (which remains the source of truth). On create, names are resolved to group IDs and join rows are inserted in the same transaction as the workflow row; an unknown name fails the whole create. On read, populated from the join table. Use &#x60;add_workflow_to_group&#x60; / &#x60;remove_workflow_from_group&#x60; for post-creation changes.
     - compute_node_expiration_buffer_seconds::Int64
     - compute_node_ignore_workflow_completion::Bool
     - compute_node_min_time_for_new_jobs_seconds::Int64
@@ -53,6 +55,7 @@
     - user::String
 """
 Base.@kwdef mutable struct WorkflowModel <: OpenAPI.APIModel
+    access_groups::Union{Nothing, Vector{String}} = nothing
     compute_node_expiration_buffer_seconds::Union{Nothing, Int64} = nothing
     compute_node_ignore_workflow_completion::Union{Nothing, Bool} = nothing
     compute_node_min_time_for_new_jobs_seconds::Union{Nothing, Int64} = nothing
@@ -76,14 +79,14 @@ Base.@kwdef mutable struct WorkflowModel <: OpenAPI.APIModel
     use_pending_failed::Union{Nothing, Bool} = nothing
     user::Union{Nothing, String} = nothing
 
-    function WorkflowModel(compute_node_expiration_buffer_seconds, compute_node_ignore_workflow_completion, compute_node_min_time_for_new_jobs_seconds, compute_node_wait_for_healthy_database_minutes, compute_node_wait_for_new_jobs_seconds, description, dynamic_jobs, enable_ro_crate, env, execution_config, id, is_archived, is_canceled, metadata, name, project, resource_monitor_config, run_id, slurm_defaults, timestamp, use_pending_failed, user, )
-        o = new(compute_node_expiration_buffer_seconds, compute_node_ignore_workflow_completion, compute_node_min_time_for_new_jobs_seconds, compute_node_wait_for_healthy_database_minutes, compute_node_wait_for_new_jobs_seconds, description, dynamic_jobs, enable_ro_crate, env, execution_config, id, is_archived, is_canceled, metadata, name, project, resource_monitor_config, run_id, slurm_defaults, timestamp, use_pending_failed, user, )
+    function WorkflowModel(access_groups, compute_node_expiration_buffer_seconds, compute_node_ignore_workflow_completion, compute_node_min_time_for_new_jobs_seconds, compute_node_wait_for_healthy_database_minutes, compute_node_wait_for_new_jobs_seconds, description, dynamic_jobs, enable_ro_crate, env, execution_config, id, is_archived, is_canceled, metadata, name, project, resource_monitor_config, run_id, slurm_defaults, timestamp, use_pending_failed, user, )
+        o = new(access_groups, compute_node_expiration_buffer_seconds, compute_node_ignore_workflow_completion, compute_node_min_time_for_new_jobs_seconds, compute_node_wait_for_healthy_database_minutes, compute_node_wait_for_new_jobs_seconds, description, dynamic_jobs, enable_ro_crate, env, execution_config, id, is_archived, is_canceled, metadata, name, project, resource_monitor_config, run_id, slurm_defaults, timestamp, use_pending_failed, user, )
         OpenAPI.validate_properties(o)
         return o
     end
 end # type WorkflowModel
 
-const _property_types_WorkflowModel = Dict{Symbol,String}(Symbol("compute_node_expiration_buffer_seconds")=>"Int64", Symbol("compute_node_ignore_workflow_completion")=>"Bool", Symbol("compute_node_min_time_for_new_jobs_seconds")=>"Int64", Symbol("compute_node_wait_for_healthy_database_minutes")=>"Int64", Symbol("compute_node_wait_for_new_jobs_seconds")=>"Int64", Symbol("description")=>"String", Symbol("dynamic_jobs")=>"DynamicJobsConfig", Symbol("enable_ro_crate")=>"Bool", Symbol("env")=>"Dict{String, String}", Symbol("execution_config")=>"ExecutionConfig", Symbol("id")=>"Int64", Symbol("is_archived")=>"Bool", Symbol("is_canceled")=>"Bool", Symbol("metadata")=>"Dict{String, Any}", Symbol("name")=>"String", Symbol("project")=>"String", Symbol("resource_monitor_config")=>"ResourceMonitorConfig", Symbol("run_id")=>"Int64", Symbol("slurm_defaults")=>"Dict{String, Any}", Symbol("timestamp")=>"String", Symbol("use_pending_failed")=>"Bool", Symbol("user")=>"String", )
+const _property_types_WorkflowModel = Dict{Symbol,String}(Symbol("access_groups")=>"Vector{String}", Symbol("compute_node_expiration_buffer_seconds")=>"Int64", Symbol("compute_node_ignore_workflow_completion")=>"Bool", Symbol("compute_node_min_time_for_new_jobs_seconds")=>"Int64", Symbol("compute_node_wait_for_healthy_database_minutes")=>"Int64", Symbol("compute_node_wait_for_new_jobs_seconds")=>"Int64", Symbol("description")=>"String", Symbol("dynamic_jobs")=>"DynamicJobsConfig", Symbol("enable_ro_crate")=>"Bool", Symbol("env")=>"Dict{String, String}", Symbol("execution_config")=>"ExecutionConfig", Symbol("id")=>"Int64", Symbol("is_archived")=>"Bool", Symbol("is_canceled")=>"Bool", Symbol("metadata")=>"Dict{String, Any}", Symbol("name")=>"String", Symbol("project")=>"String", Symbol("resource_monitor_config")=>"ResourceMonitorConfig", Symbol("run_id")=>"Int64", Symbol("slurm_defaults")=>"Dict{String, Any}", Symbol("timestamp")=>"String", Symbol("use_pending_failed")=>"Bool", Symbol("user")=>"String", )
 OpenAPI.property_type(::Type{ WorkflowModel }, name::Symbol) = Union{Nothing,eval(Base.Meta.parse(_property_types_WorkflowModel[name]))}
 
 function OpenAPI.check_required(o::WorkflowModel)
@@ -93,6 +96,7 @@ function OpenAPI.check_required(o::WorkflowModel)
 end
 
 function OpenAPI.validate_properties(o::WorkflowModel)
+    OpenAPI.validate_property(WorkflowModel, Symbol("access_groups"), o.access_groups)
     OpenAPI.validate_property(WorkflowModel, Symbol("compute_node_expiration_buffer_seconds"), o.compute_node_expiration_buffer_seconds)
     OpenAPI.validate_property(WorkflowModel, Symbol("compute_node_ignore_workflow_completion"), o.compute_node_ignore_workflow_completion)
     OpenAPI.validate_property(WorkflowModel, Symbol("compute_node_min_time_for_new_jobs_seconds"), o.compute_node_min_time_for_new_jobs_seconds)
@@ -118,6 +122,7 @@ function OpenAPI.validate_properties(o::WorkflowModel)
 end
 
 function OpenAPI.validate_property(::Type{ WorkflowModel }, name::Symbol, val)
+
 
     if name === Symbol("compute_node_expiration_buffer_seconds")
         OpenAPI.validate_param(name, "WorkflowModel", :format, val, "int64")

--- a/julia_client/julia_client/docs/WorkflowModel.md
+++ b/julia_client/julia_client/docs/WorkflowModel.md
@@ -4,6 +4,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**access_groups** | **Vector{String}** | Access group names granted shared access to this workflow. Projection of the &#x60;workflow_access_group&#x60; join table (which remains the source of truth). On create, names are resolved to group IDs and join rows are inserted in the same transaction as the workflow row; an unknown name fails the whole create. On read, populated from the join table. Use &#x60;add_workflow_to_group&#x60; / &#x60;remove_workflow_from_group&#x60; for post-creation changes. | [optional] [default to nothing]
 **compute_node_expiration_buffer_seconds** | **Int64** |  | [optional] [default to nothing]
 **compute_node_ignore_workflow_completion** | **Bool** |  | [optional] [default to nothing]
 **compute_node_min_time_for_new_jobs_seconds** | **Int64** |  | [optional] [default to nothing]

--- a/python_client/src/torc/openapi_client/models/workflow_model.py
+++ b/python_client/src/torc/openapi_client/models/workflow_model.py
@@ -29,6 +29,7 @@ class WorkflowModel(BaseModel):
     """
     WorkflowModel
     """ # noqa: E501
+    access_groups: Optional[List[StrictStr]] = Field(default=None, description="Access group names granted shared access to this workflow. Projection of the `workflow_access_group` join table (which remains the source of truth). On create, names are resolved to group IDs and join rows are inserted in the same transaction as the workflow row; an unknown name fails the whole create. On read, populated from the join table. Use `add_workflow_to_group` / `remove_workflow_from_group` for post-creation changes.")
     compute_node_expiration_buffer_seconds: Optional[StrictInt] = None
     compute_node_ignore_workflow_completion: Optional[StrictBool] = None
     compute_node_min_time_for_new_jobs_seconds: Optional[StrictInt] = None
@@ -51,7 +52,7 @@ class WorkflowModel(BaseModel):
     timestamp: Optional[StrictStr] = None
     use_pending_failed: Optional[StrictBool] = None
     user: StrictStr
-    __properties: ClassVar[List[str]] = ["compute_node_expiration_buffer_seconds", "compute_node_ignore_workflow_completion", "compute_node_min_time_for_new_jobs_seconds", "compute_node_wait_for_healthy_database_minutes", "compute_node_wait_for_new_jobs_seconds", "description", "dynamic_jobs", "enable_ro_crate", "env", "execution_config", "id", "is_archived", "is_canceled", "metadata", "name", "project", "resource_monitor_config", "run_id", "slurm_defaults", "timestamp", "use_pending_failed", "user"]
+    __properties: ClassVar[List[str]] = ["access_groups", "compute_node_expiration_buffer_seconds", "compute_node_ignore_workflow_completion", "compute_node_min_time_for_new_jobs_seconds", "compute_node_wait_for_healthy_database_minutes", "compute_node_wait_for_new_jobs_seconds", "description", "dynamic_jobs", "enable_ro_crate", "env", "execution_config", "id", "is_archived", "is_canceled", "metadata", "name", "project", "resource_monitor_config", "run_id", "slurm_defaults", "timestamp", "use_pending_failed", "user"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -107,6 +108,11 @@ class WorkflowModel(BaseModel):
         # override the default output from pydantic by calling `to_dict()` of resource_monitor_config
         if self.resource_monitor_config:
             _dict['resource_monitor_config'] = self.resource_monitor_config.to_dict()
+        # set to None if access_groups (nullable) is None
+        # and model_fields_set contains the field
+        if self.access_groups is None and "access_groups" in self.model_fields_set:
+            _dict['access_groups'] = None
+
         # set to None if compute_node_expiration_buffer_seconds (nullable) is None
         # and model_fields_set contains the field
         if self.compute_node_expiration_buffer_seconds is None and "compute_node_expiration_buffer_seconds" in self.model_fields_set:
@@ -189,6 +195,7 @@ class WorkflowModel(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
+            "access_groups": obj.get("access_groups"),
             "compute_node_expiration_buffer_seconds": obj.get("compute_node_expiration_buffer_seconds"),
             "compute_node_ignore_workflow_completion": obj.get("compute_node_ignore_workflow_completion"),
             "compute_node_min_time_for_new_jobs_seconds": obj.get("compute_node_min_time_for_new_jobs_seconds"),

--- a/src/client/workflow_spec.rs
+++ b/src/client/workflow_spec.rs
@@ -1274,6 +1274,11 @@ pub struct WorkflowSpec {
     /// resource limits, termination signals, and timeouts.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub execution_config: Option<ExecutionConfig>,
+    /// Names of access groups granted shared access to this workflow.
+    /// Names are resolved to group IDs at workflow-creation time; an unknown
+    /// name fails the whole create with a clear error.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub access_groups: Option<Vec<String>>,
 }
 
 impl WorkflowSpec {
@@ -1311,6 +1316,7 @@ impl WorkflowSpec {
             project: None,
             metadata: None,
             execution_config: None,
+            access_groups: None,
         }
     }
 
@@ -3169,6 +3175,12 @@ impl WorkflowSpec {
         // Set metadata if present
         if let Some(ref value) = spec.metadata {
             workflow_model.metadata = Some(value.clone());
+        }
+
+        // Pass through declared access groups; the server resolves names to
+        // group IDs in the same transaction as the workflow create.
+        if let Some(ref groups) = spec.access_groups {
+            workflow_model.access_groups = Some(groups.clone());
         }
 
         let created_workflow = apis::workflows_api::create_workflow(config, workflow_model)
@@ -7153,6 +7165,7 @@ user_data:
             project: None,
             metadata: None,
             execution_config: None,
+            access_groups: None,
         };
 
         spec.expand_parameters()

--- a/src/models.rs
+++ b/src/models.rs
@@ -582,6 +582,15 @@ pub struct WorkflowModel {
     /// workflow creation.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dynamic_jobs: Option<DynamicJobsConfig>,
+    /// Access group names granted shared access to this workflow.
+    /// Projection of the `workflow_access_group` join table (which remains the
+    /// source of truth). On create, names are resolved to group IDs and join
+    /// rows are inserted in the same transaction as the workflow row; an
+    /// unknown name fails the whole create. On read, populated from the join
+    /// table. Use `add_workflow_to_group` / `remove_workflow_from_group` for
+    /// post-creation changes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub access_groups: Option<Vec<String>>,
 }
 
 /// Dynamic job spawning configuration. Used both as the user-authored
@@ -1946,6 +1955,7 @@ impl WorkflowModel {
             is_canceled: None,
             is_archived: None,
             dynamic_jobs: None,
+            access_groups: None,
         }
     }
 }
@@ -2370,6 +2380,7 @@ mod tests {
             is_canceled: Some(false),
             is_archived: Some(false),
             dynamic_jobs: None,
+            access_groups: None,
         };
         let serialized = serde_json::to_value(&workflow).unwrap();
         assert_eq!(serialized["name"], "wf");

--- a/src/server/api/workflows.rs
+++ b/src/server/api/workflows.rs
@@ -66,6 +66,75 @@ fn parse_optional_json<T: serde::de::DeserializeOwned>(raw: Option<String>) -> O
     raw.as_deref().and_then(|s| serde_json::from_str(s).ok())
 }
 
+/// Fetch the access group names associated with a workflow, in `name` order.
+/// Returns `None` if the workflow has no associated groups so the field is
+/// omitted from JSON responses; otherwise returns `Some(names)`.
+async fn fetch_workflow_access_groups(
+    pool: &sqlx::SqlitePool,
+    workflow_id: i64,
+) -> Result<Option<Vec<String>>, ApiError> {
+    let rows = sqlx::query_scalar::<_, String>(
+        r#"
+        SELECT g.name
+        FROM access_group g
+        INNER JOIN workflow_access_group w ON g.id = w.group_id
+        WHERE w.workflow_id = $1
+        ORDER BY g.name
+        "#,
+    )
+    .bind(workflow_id)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| database_error_with_msg(e, "Failed to fetch workflow access groups"))?;
+    if rows.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(rows))
+    }
+}
+
+/// Fetch access group names for a set of workflow IDs in one query. Returns a
+/// map from `workflow_id` to its (sorted) group names; workflows with no
+/// associated groups are absent from the map.
+async fn fetch_workflow_access_groups_batch(
+    pool: &sqlx::SqlitePool,
+    workflow_ids: &[i64],
+) -> Result<std::collections::HashMap<i64, Vec<String>>, ApiError> {
+    let mut map: std::collections::HashMap<i64, Vec<String>> = std::collections::HashMap::new();
+    if workflow_ids.is_empty() {
+        return Ok(map);
+    }
+    let placeholders = workflow_ids
+        .iter()
+        .map(|_| "?")
+        .collect::<Vec<_>>()
+        .join(", ");
+    let query = format!(
+        r#"
+        SELECT w.workflow_id, g.name
+        FROM workflow_access_group w
+        INNER JOIN access_group g ON g.id = w.group_id
+        WHERE w.workflow_id IN ({})
+        ORDER BY w.workflow_id, g.name
+        "#,
+        placeholders
+    );
+    let mut q = sqlx::query(&query);
+    for id in workflow_ids {
+        q = q.bind(id);
+    }
+    let rows = q
+        .fetch_all(pool)
+        .await
+        .map_err(|e| database_error_with_msg(e, "Failed to fetch workflow access groups"))?;
+    for row in rows {
+        let wid: i64 = row.get("workflow_id");
+        let name: String = row.get("name");
+        map.entry(wid).or_default().push(name);
+    }
+    Ok(map)
+}
+
 /// Trait defining workflow-related API operations
 #[async_trait]
 pub trait WorkflowsApi<C> {
@@ -408,10 +477,15 @@ impl WorkflowsApiImpl {
             }
         };
 
+        let workflow_ids: Vec<i64> = records.iter().map(|r| r.get("id")).collect();
+        let mut access_groups_map =
+            fetch_workflow_access_groups_batch(self.context.pool.as_ref(), &workflow_ids).await?;
+
         let mut items: Vec<models::WorkflowModel> = Vec::new();
         for record in records {
+            let workflow_id: i64 = record.get("id");
             items.push(models::WorkflowModel {
-                id: Some(record.get("id")),
+                id: Some(workflow_id),
                 name: record.get("name"),
                 user: record.get("user"),
                 description: record.get("description"),
@@ -471,6 +545,7 @@ impl WorkflowsApiImpl {
                         .try_get::<Option<String>, _>("dynamic_jobs")
                         .unwrap_or(None),
                 ),
+                access_groups: access_groups_map.remove(&workflow_id),
             });
         }
 
@@ -603,7 +678,30 @@ where
         let use_pending_failed_int = body.use_pending_failed.map(|v| if v { 1 } else { 0 });
         let enable_ro_crate_int = body.enable_ro_crate.map(|v| if v { 1 } else { 0 });
 
-        let workflow_result = sqlx::query!(
+        // Validate access_groups for duplicates up front so we can return a
+        // 422 before opening a transaction.
+        if let Some(ref names) = body.access_groups {
+            let mut seen = std::collections::HashSet::new();
+            for name in names {
+                if !seen.insert(name.as_str()) {
+                    return Ok(CreateWorkflowResponse::UnprocessableContentErrorResponse(
+                        message_error_response(format!(
+                            "access_groups contains duplicate entry '{}'",
+                            name
+                        )),
+                    ));
+                }
+            }
+        }
+
+        let mut tx = self
+            .context
+            .pool
+            .begin()
+            .await
+            .map_err(|e| database_error_with_msg(e, "Failed to begin transaction"))?;
+
+        let workflow_result = match sqlx::query!(
             r#"
             INSERT INTO workflow
             (
@@ -651,12 +749,76 @@ where
             execution_config_json,
             dynamic_jobs_json,
         )
-        .fetch_one(self.context.pool.as_ref())
+        .fetch_one(&mut *tx)
         .await
-        .map_err(|e| database_error_with_msg(e, "Failed to create workflow record"))?;
+        {
+            Ok(row) => row,
+            Err(e) => {
+                let _ = tx.rollback().await;
+                return Err(database_error_with_msg(e, "Failed to create workflow record"));
+            }
+        };
 
         let workflow_id = workflow_result.id;
         debug!("Workflow inserted with id: {:?}", workflow_id);
+
+        // Resolve access group names to IDs and insert join rows in the same
+        // transaction. An unknown name fails the entire create.
+        if let Some(ref names) = body.access_groups {
+            for name in names {
+                let group_id: Option<i64> = match sqlx::query_scalar::<_, i64>(
+                    "SELECT id FROM access_group WHERE name = ?",
+                )
+                .bind(name)
+                .fetch_optional(&mut *tx)
+                .await
+                {
+                    Ok(id) => id,
+                    Err(e) => {
+                        let _ = tx.rollback().await;
+                        return Err(database_error_with_msg(
+                            e,
+                            "Failed to resolve access group name",
+                        ));
+                    }
+                };
+                let group_id = match group_id {
+                    Some(id) => id,
+                    None => {
+                        let _ = tx.rollback().await;
+                        return Ok(CreateWorkflowResponse::UnprocessableContentErrorResponse(
+                            message_error_response(format!(
+                                "Unknown access group '{}': create the group before referencing it",
+                                name
+                            )),
+                        ));
+                    }
+                };
+
+                if let Err(e) = sqlx::query(
+                    r#"
+                    INSERT INTO workflow_access_group (workflow_id, group_id)
+                    VALUES ($1, $2)
+                    "#,
+                )
+                .bind(workflow_id)
+                .bind(group_id)
+                .execute(&mut *tx)
+                .await
+                {
+                    let _ = tx.rollback().await;
+                    return Err(database_error_with_msg(
+                        e,
+                        "Failed to associate workflow with access group",
+                    ));
+                }
+            }
+        }
+
+        if let Err(e) = tx.commit().await {
+            return Err(database_error_with_msg(e, "Failed to commit transaction"));
+        }
+
         body.id = Some(workflow_id);
         let response = CreateWorkflowResponse::SuccessfulResponse(body);
         Ok(response)
@@ -901,64 +1063,69 @@ where
         .fetch_optional(self.context.pool.as_ref())
         .await
         {
-            Ok(Some(row)) => Ok(GetWorkflowResponse::SuccessfulResponse(
-                models::WorkflowModel {
-                    id: Some(row.get("id")),
-                    name: row.get("name"),
-                    user: row.get("user"),
-                    description: row.get("description"),
-                    env: deserialize_env_map(row.get("env"), "workflow env")?,
-                    timestamp: Some(row.get("timestamp")),
-                    compute_node_expiration_buffer_seconds: row
-                        .try_get::<Option<i64>, _>("compute_node_expiration_buffer_seconds")
-                        .unwrap_or(None),
-                    compute_node_wait_for_new_jobs_seconds: Some(
-                        row.get("compute_node_wait_for_new_jobs_seconds"),
-                    ),
-                    compute_node_ignore_workflow_completion: Some(
-                        row.get::<i64, _>("compute_node_ignore_workflow_completion") != 0,
-                    ),
-                    compute_node_wait_for_healthy_database_minutes: Some(
-                        row.get("compute_node_wait_for_healthy_database_minutes"),
-                    ),
-                    compute_node_min_time_for_new_jobs_seconds: Some(
-                        row.get("compute_node_min_time_for_new_jobs_seconds"),
-                    ),
-                    resource_monitor_config: parse_optional_json(
-                        row.try_get::<Option<String>, _>("resource_monitor_config")
+            Ok(Some(row)) => {
+                let access_groups =
+                    fetch_workflow_access_groups(self.context.pool.as_ref(), id).await?;
+                Ok(GetWorkflowResponse::SuccessfulResponse(
+                    models::WorkflowModel {
+                        id: Some(row.get("id")),
+                        name: row.get("name"),
+                        user: row.get("user"),
+                        description: row.get("description"),
+                        env: deserialize_env_map(row.get("env"), "workflow env")?,
+                        timestamp: Some(row.get("timestamp")),
+                        compute_node_expiration_buffer_seconds: row
+                            .try_get::<Option<i64>, _>("compute_node_expiration_buffer_seconds")
                             .unwrap_or(None),
-                    ),
-                    slurm_defaults: parse_optional_json(
-                        row.try_get::<Option<String>, _>("slurm_defaults")
-                            .unwrap_or(None),
-                    ),
-                    use_pending_failed: row
-                        .try_get::<Option<i64>, _>("use_pending_failed")
-                        .ok()
-                        .flatten()
-                        .map(|v| v != 0),
-                    enable_ro_crate: row
-                        .try_get::<Option<i64>, _>("enable_ro_crate")
-                        .ok()
-                        .flatten()
-                        .map(|v| v != 0),
-                    project: row.get("project"),
-                    metadata: parse_optional_json(
-                        row.try_get::<Option<String>, _>("metadata").unwrap_or(None),
-                    ),
-                    execution_config: parse_optional_json(
-                        row.try_get::<Option<String>, _>("execution_config")
-                            .unwrap_or(None),
-                    ),
-                    run_id: Some(row.get("run_id")),
-                    is_canceled: Some(row.get::<i64, _>("is_canceled") != 0),
-                    is_archived: Some(row.get::<i64, _>("is_archived") != 0),
-                    dynamic_jobs: parse_dynamic_jobs(
-                        row.try_get::<Option<String>, _>("dynamic_jobs")
-                            .unwrap_or(None),
-                    ),
-                },
-            )),
+                        compute_node_wait_for_new_jobs_seconds: Some(
+                            row.get("compute_node_wait_for_new_jobs_seconds"),
+                        ),
+                        compute_node_ignore_workflow_completion: Some(
+                            row.get::<i64, _>("compute_node_ignore_workflow_completion") != 0,
+                        ),
+                        compute_node_wait_for_healthy_database_minutes: Some(
+                            row.get("compute_node_wait_for_healthy_database_minutes"),
+                        ),
+                        compute_node_min_time_for_new_jobs_seconds: Some(
+                            row.get("compute_node_min_time_for_new_jobs_seconds"),
+                        ),
+                        resource_monitor_config: parse_optional_json(
+                            row.try_get::<Option<String>, _>("resource_monitor_config")
+                                .unwrap_or(None),
+                        ),
+                        slurm_defaults: parse_optional_json(
+                            row.try_get::<Option<String>, _>("slurm_defaults")
+                                .unwrap_or(None),
+                        ),
+                        use_pending_failed: row
+                            .try_get::<Option<i64>, _>("use_pending_failed")
+                            .ok()
+                            .flatten()
+                            .map(|v| v != 0),
+                        enable_ro_crate: row
+                            .try_get::<Option<i64>, _>("enable_ro_crate")
+                            .ok()
+                            .flatten()
+                            .map(|v| v != 0),
+                        project: row.get("project"),
+                        metadata: parse_optional_json(
+                            row.try_get::<Option<String>, _>("metadata").unwrap_or(None),
+                        ),
+                        execution_config: parse_optional_json(
+                            row.try_get::<Option<String>, _>("execution_config")
+                                .unwrap_or(None),
+                        ),
+                        run_id: Some(row.get("run_id")),
+                        is_canceled: Some(row.get::<i64, _>("is_canceled") != 0),
+                        is_archived: Some(row.get::<i64, _>("is_archived") != 0),
+                        dynamic_jobs: parse_dynamic_jobs(
+                            row.try_get::<Option<String>, _>("dynamic_jobs")
+                                .unwrap_or(None),
+                        ),
+                        access_groups,
+                    },
+                ))
+            }
             Ok(None) => Ok(GetWorkflowResponse::NotFoundErrorResponse(
                 resource_not_found_response("Workflow", id),
             )),
@@ -1192,6 +1359,17 @@ where
             return Ok(UpdateWorkflowResponse::UnprocessableContentErrorResponse(
                 message_error_response(
                     "Cannot modify dynamic_jobs - this field is immutable after workflow creation",
+                ),
+            ));
+        }
+        // `access_groups` lives in the `workflow_access_group` join table,
+        // not the workflow row. Use POST /workflows/{id}/access_groups/{group_id}
+        // and DELETE /workflows/{id}/access_groups/{group_id} for mutations;
+        // accepting it here would silently no-op. Same-value passes through.
+        if body.access_groups.is_some() && body.access_groups != current_workflow.access_groups {
+            return Ok(UpdateWorkflowResponse::UnprocessableContentErrorResponse(
+                message_error_response(
+                    "Cannot modify access_groups via update - use add_workflow_to_group / remove_workflow_from_group",
                 ),
             ));
         }

--- a/src/server/api/workflows.rs
+++ b/src/server/api/workflows.rs
@@ -93,9 +93,16 @@ async fn fetch_workflow_access_groups(
     }
 }
 
-/// Fetch access group names for a set of workflow IDs in one query. Returns a
-/// map from `workflow_id` to its (sorted) group names; workflows with no
-/// associated groups are absent from the map.
+/// Chunk size for `IN (...)` lookups. Each id consumes one bound variable, so
+/// stay well below `SQLITE_MAX_VARIABLE_NUMBER` (32766 since 3.32, 999 in
+/// older builds). `list_workflows` allows up to `MAX_RECORD_TRANSFER_COUNT`
+/// (100k) ids per page, which would blow the limit without chunking.
+const ACCESS_GROUPS_IN_CHUNK: usize = 256;
+
+/// Fetch access group names for a set of workflow IDs. Returns a map from
+/// `workflow_id` to its (sorted) group names; workflows with no associated
+/// groups are absent from the map. The `IN (...)` lookup is chunked under
+/// `ACCESS_GROUPS_IN_CHUNK` to stay below `SQLITE_MAX_VARIABLE_NUMBER`.
 async fn fetch_workflow_access_groups_batch(
     pool: &sqlx::SqlitePool,
     workflow_ids: &[i64],
@@ -104,33 +111,31 @@ async fn fetch_workflow_access_groups_batch(
     if workflow_ids.is_empty() {
         return Ok(map);
     }
-    let placeholders = workflow_ids
-        .iter()
-        .map(|_| "?")
-        .collect::<Vec<_>>()
-        .join(", ");
-    let query = format!(
-        r#"
-        SELECT w.workflow_id, g.name
-        FROM workflow_access_group w
-        INNER JOIN access_group g ON g.id = w.group_id
-        WHERE w.workflow_id IN ({})
-        ORDER BY w.workflow_id, g.name
-        "#,
-        placeholders
-    );
-    let mut q = sqlx::query(&query);
-    for id in workflow_ids {
-        q = q.bind(id);
-    }
-    let rows = q
-        .fetch_all(pool)
-        .await
-        .map_err(|e| database_error_with_msg(e, "Failed to fetch workflow access groups"))?;
-    for row in rows {
-        let wid: i64 = row.get("workflow_id");
-        let name: String = row.get("name");
-        map.entry(wid).or_default().push(name);
+    for chunk in workflow_ids.chunks(ACCESS_GROUPS_IN_CHUNK) {
+        let placeholders = vec!["?"; chunk.len()].join(", ");
+        let query = format!(
+            r#"
+            SELECT w.workflow_id, g.name
+            FROM workflow_access_group w
+            INNER JOIN access_group g ON g.id = w.group_id
+            WHERE w.workflow_id IN ({})
+            ORDER BY w.workflow_id, g.name
+            "#,
+            placeholders
+        );
+        let mut q = sqlx::query(&query);
+        for id in chunk {
+            q = q.bind(id);
+        }
+        let rows = q
+            .fetch_all(pool)
+            .await
+            .map_err(|e| database_error_with_msg(e, "Failed to fetch workflow access groups"))?;
+        for row in rows {
+            let wid: i64 = row.get("workflow_id");
+            let name: String = row.get("name");
+            map.entry(wid).or_default().push(name);
+        }
     }
     Ok(map)
 }
@@ -820,6 +825,16 @@ where
         }
 
         body.id = Some(workflow_id);
+        // Normalize the access_groups response to match what GET returns: sort
+        // by name and collapse an empty list to None (matches the omit-when-no-
+        // groups semantics on read).
+        body.access_groups = match body.access_groups.take() {
+            Some(mut names) if !names.is_empty() => {
+                names.sort();
+                Some(names)
+            }
+            _ => None,
+        };
         let response = CreateWorkflowResponse::SuccessfulResponse(body);
         Ok(response)
     }

--- a/tests/test_access_groups.rs
+++ b/tests/test_access_groups.rs
@@ -408,6 +408,105 @@ fn test_list_workflow_groups(start_server: &ServerProcess) {
 }
 
 #[rstest]
+fn test_create_workflow_with_access_groups(start_server: &ServerProcess) {
+    let config = &start_server.config;
+
+    // Pre-create two access groups.
+    for name in ["create-with-ag-1", "create-with-ag-2"] {
+        let group = models::AccessGroupModel {
+            id: None,
+            name: name.to_string(),
+            description: None,
+            created_at: None,
+        };
+        apis::access_control_api::create_access_group(config, group)
+            .expect("Failed to create access group");
+    }
+
+    // Create the workflow with access_groups declared inline.
+    let mut workflow =
+        models::WorkflowModel::new("wf-with-access-groups".to_string(), "wf-user".to_string());
+    workflow.access_groups = Some(vec![
+        "create-with-ag-1".to_string(),
+        "create-with-ag-2".to_string(),
+    ]);
+    let created = apis::workflows_api::create_workflow(config, workflow)
+        .expect("Failed to create workflow with access_groups");
+    let workflow_id = created.id.expect("Created workflow missing ID");
+
+    // GET should round-trip the field, sorted by group name.
+    let fetched =
+        apis::workflows_api::get_workflow(config, workflow_id).expect("Failed to fetch workflow");
+    assert_eq!(
+        fetched.access_groups,
+        Some(vec![
+            "create-with-ag-1".to_string(),
+            "create-with-ag-2".to_string(),
+        ])
+    );
+
+    // The join-table API agrees with the projection.
+    let groups = apis::access_control_api::list_workflow_groups(config, workflow_id, None, None)
+        .expect("Failed to list workflow groups");
+    let names: Vec<&str> = groups.items.iter().map(|g| g.name.as_str()).collect();
+    assert!(names.contains(&"create-with-ag-1"));
+    assert!(names.contains(&"create-with-ag-2"));
+}
+
+#[rstest]
+fn test_create_workflow_with_unknown_access_group_fails(start_server: &ServerProcess) {
+    let config = &start_server.config;
+
+    let mut workflow =
+        models::WorkflowModel::new("wf-unknown-access-group".to_string(), "wf-user".to_string());
+    workflow.access_groups = Some(vec!["this-group-does-not-exist".to_string()]);
+
+    let result = apis::workflows_api::create_workflow(config, workflow);
+    let err = result.expect_err("Expected create_workflow to fail for unknown access group");
+    let msg = format!("{:?}", err);
+    assert!(
+        msg.contains("Unknown access group"),
+        "Error message did not mention unknown access group: {}",
+        msg
+    );
+
+    // The workflow row must not exist (transaction rolled back). Listing
+    // filtered by name should not return anything.
+    let listing = apis::workflows_api::list_workflows(
+        config,
+        None,
+        None,
+        None,
+        None,
+        Some("wf-unknown-access-group"),
+        None,
+        None,
+        None,
+    )
+    .expect("Failed to list workflows");
+    assert!(
+        listing.items.is_empty(),
+        "Workflow row leaked after access_groups validation failure: {:?}",
+        listing.items.iter().map(|w| &w.name).collect::<Vec<_>>(),
+    );
+}
+
+#[rstest]
+fn test_get_workflow_without_access_groups_omits_field(start_server: &ServerProcess) {
+    let config = &start_server.config;
+
+    let workflow = create_workflow_with_user(config, "wf-no-access-groups", "wf-user");
+    let workflow_id = workflow.id.unwrap();
+
+    let fetched =
+        apis::workflows_api::get_workflow(config, workflow_id).expect("Failed to fetch workflow");
+    assert!(
+        fetched.access_groups.is_none(),
+        "Expected access_groups to be None for a workflow with no group associations"
+    );
+}
+
+#[rstest]
 fn test_remove_workflow_from_group(start_server: &ServerProcess) {
     let config = &start_server.config;
 

--- a/tests/test_access_groups.rs
+++ b/tests/test_access_groups.rs
@@ -423,27 +423,32 @@ fn test_create_workflow_with_access_groups(start_server: &ServerProcess) {
             .expect("Failed to create access group");
     }
 
-    // Create the workflow with access_groups declared inline.
+    // Create the workflow with access_groups declared inline (reversed order
+    // to verify the server normalizes to sorted-by-name on the response).
     let mut workflow =
         models::WorkflowModel::new("wf-with-access-groups".to_string(), "wf-user".to_string());
     workflow.access_groups = Some(vec![
-        "create-with-ag-1".to_string(),
         "create-with-ag-2".to_string(),
+        "create-with-ag-1".to_string(),
     ]);
     let created = apis::workflows_api::create_workflow(config, workflow)
         .expect("Failed to create workflow with access_groups");
     let workflow_id = created.id.expect("Created workflow missing ID");
 
-    // GET should round-trip the field, sorted by group name.
-    let fetched =
-        apis::workflows_api::get_workflow(config, workflow_id).expect("Failed to fetch workflow");
+    // POST response should already be sorted by name, matching GET.
     assert_eq!(
-        fetched.access_groups,
+        created.access_groups,
         Some(vec![
             "create-with-ag-1".to_string(),
             "create-with-ag-2".to_string(),
-        ])
+        ]),
+        "POST response should normalize access_groups to sorted-by-name order"
     );
+
+    // GET should round-trip the field, sorted by group name.
+    let fetched =
+        apis::workflows_api::get_workflow(config, workflow_id).expect("Failed to fetch workflow");
+    assert_eq!(fetched.access_groups, created.access_groups);
 
     // The join-table API agrees with the projection.
     let groups = apis::access_control_api::list_workflow_groups(config, workflow_id, None, None)
@@ -451,6 +456,29 @@ fn test_create_workflow_with_access_groups(start_server: &ServerProcess) {
     let names: Vec<&str> = groups.items.iter().map(|g| g.name.as_str()).collect();
     assert!(names.contains(&"create-with-ag-1"));
     assert!(names.contains(&"create-with-ag-2"));
+}
+
+#[rstest]
+fn test_create_workflow_with_empty_access_groups_normalizes_to_none(start_server: &ServerProcess) {
+    let config = &start_server.config;
+
+    // Sending an explicitly empty list should be treated the same as omitting
+    // the field, both in the POST response and in subsequent GETs.
+    let mut workflow =
+        models::WorkflowModel::new("wf-empty-access-groups".to_string(), "wf-user".to_string());
+    workflow.access_groups = Some(vec![]);
+
+    let created = apis::workflows_api::create_workflow(config, workflow)
+        .expect("Failed to create workflow with empty access_groups");
+    assert!(
+        created.access_groups.is_none(),
+        "POST response should normalize an empty access_groups list to None"
+    );
+
+    let workflow_id = created.id.expect("Created workflow missing ID");
+    let fetched =
+        apis::workflows_api::get_workflow(config, workflow_id).expect("Failed to fetch workflow");
+    assert!(fetched.access_groups.is_none());
 }
 
 #[rstest]

--- a/tests/test_workflow_metadata_project.rs
+++ b/tests/test_workflow_metadata_project.rs
@@ -34,6 +34,7 @@ fn test_create_workflow_with_project_and_metadata(start_server: &ServerProcess) 
         is_canceled: None,
         is_archived: None,
         dynamic_jobs: None,
+        access_groups: None,
     };
 
     // Create the workflow
@@ -77,6 +78,7 @@ fn test_create_workflow_without_fields_then_update(start_server: &ServerProcess)
         is_canceled: None,
         is_archived: None,
         dynamic_jobs: None,
+        access_groups: None,
     };
 
     let created =
@@ -131,6 +133,7 @@ fn test_create_workflow_with_fields_then_change(start_server: &ServerProcess) {
         is_canceled: None,
         is_archived: None,
         dynamic_jobs: None,
+        access_groups: None,
     };
 
     let created =
@@ -188,6 +191,7 @@ fn test_partial_update_preserves_fields(start_server: &ServerProcess) {
         is_canceled: None,
         is_archived: None,
         dynamic_jobs: None,
+        access_groups: None,
     };
 
     let created =

--- a/tests/test_workflow_spec.rs
+++ b/tests/test_workflow_spec.rs
@@ -94,6 +94,31 @@ fn test_workflow_specification_new() {
 }
 
 #[test]
+fn test_workflow_specification_access_groups_round_trip() {
+    let json = serde_json::json!({
+        "name": "shared-wf",
+        "user": "alice",
+        "access_groups": ["naerm", "data-team"],
+        "jobs": [{
+            "name": "only-job",
+            "command": "echo hi",
+        }],
+    });
+    let spec = WorkflowSpec::from_json_value(json).expect("Failed to parse spec");
+
+    assert_eq!(
+        spec.access_groups,
+        Some(vec!["naerm".to_string(), "data-team".to_string()]),
+    );
+
+    // Round-trip through JSON should preserve the field with the same ordering.
+    let serialized = serde_json::to_string(&spec).expect("Failed to serialize");
+    let deserialized: WorkflowSpec =
+        serde_json::from_str(&serialized).expect("Failed to deserialize");
+    assert_eq!(spec.access_groups, deserialized.access_groups);
+}
+
+#[test]
 fn test_workflow_specification_minimal_serialization() {
     let jobs = vec![JobSpec::new("simple_job".to_string(), "ls".to_string())];
     let workflow = WorkflowSpec::new(


### PR DESCRIPTION
## Summary

Closes #319.

- Adds `access_groups: Option<Vec<String>>` to `WorkflowSpec` (YAML/JSON) and `WorkflowModel` (API) as a projection of the existing `workflow_access_group` join table — no new column.
- `POST /workflows` resolves each name to a group ID and inserts the join rows in the same transaction as the workflow row. Unknown name → 422 with rollback; duplicate name → 422.
- `GET /workflows/{id}` and `GET /workflows` populate the field from the join table (single batched query for the list path).
- `PUT /workflows/{id}` rejects `access_groups` mutations (parallels the `dynamic_jobs` immutability guard). Continue to use `add_workflow_to_group` / `remove_workflow_from_group` for post-creation changes.
- Regenerated OpenAPI spec + Python / Julia clients; docs + reference table updated.

Design follows the plan in [issue #319](https://github.com/NatLabRockies/torc/issues/319#issuecomment-4451841380).

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all --all-targets --all-features -- -D warnings`
- [x] `dprint check`
- [x] New integration tests in `tests/test_access_groups.rs`:
  - `test_create_workflow_with_access_groups` — happy path; GET round-trips names.
  - `test_create_workflow_with_unknown_access_group_fails` — 422 + transaction rollback (no workflow row leaked).
  - `test_get_workflow_without_access_groups_omits_field` — field absent when no groups.
- [x] New round-trip test in `tests/test_workflow_spec.rs` for YAML/JSON spec serialization.
- [x] Full suite: `cargo nextest run --all-features --no-fail-fast` → 1473 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)