### PR TITLE
Backport offline-drain + reconcile to v0.30.4 (client-only)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5087,7 +5087,7 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "torc"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.30.3"
+version = "0.30.4"
 authors = [
   "Daniel Thom",
   "Joseph McKinsey",
@@ -20,7 +20,7 @@ description = "Workflow management system"
 
 [workspace.dependencies]
 # Self-reference for sub-crates (version only specified here)
-torc = { version = "0.30.3", path = "." }
+torc = { version = "0.30.4", path = "." }
 
 # Shared dependencies
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Usage:
 #   # Download and extract release binaries
-#   VERSION=0.30.3
+#   VERSION=0.30.4
 #   mkdir -p artifact
 #   curl -fsSL "https://github.com/NatLabRockies/torc/releases/download/v${VERSION}/torc-x86_64-unknown-linux-musl.tar.gz" \
 #     | tar xz -C artifact/

--- a/docs/src/core/concepts/job-runners.md
+++ b/docs/src/core/concepts/job-runners.md
@@ -173,6 +173,75 @@ flowchart TD
 
 The runner continues until the workflow is complete or canceled.
 
+## Surviving Server Outages (Offline Drain)
+
+Job runners need the server to claim work, report completions, and unblock dependents. But a running
+job is an ordinary subprocess on the compute node — it does not need the server to keep running.
+Killing in-flight jobs because the server is briefly unreachable would throw away expensive compute
+(imagine a 5-day job killed on the 4th night by a server outage that can be repaired the next day).
+
+To avoid this, every API call first retries for up to
+`compute_node_wait_for_healthy_database_minutes` (default 20). If the server is still unreachable
+after that window, the runner enters **offline-drain mode** instead of exiting:
+
+1. **Stop claiming new jobs.** Claiming requires a server-side write lock that prevents two nodes
+   from grabbing the same job, so no new work can start while the server is down.
+2. **Let running jobs finish.** The runner keeps monitoring its subprocesses to completion.
+3. **Journal results locally.** Each completion is written to a per-node SQLite file under
+   `<output_dir>/offline_journal/`, named `offline_results_wf<workflow_id>_r<run_id>_<label>.db`.
+4. **Watch for recovery.** The runner pings the server every `drain_ping_interval_secs` (default
+   120). If the server comes back **while jobs are still running**, the runner flushes the journal,
+   brings the server's view up to date, and resumes normal operation — claiming new work again with
+   no lost results.
+5. **Exit when drained.** If all running jobs finish while the server is still down, the runner
+   writes its final results to the journal and exits.
+
+This behavior is on by default. It can be tuned (or disabled in favor of the legacy kill-and-exit
+behavior) via the [`[client.offline]`](../reference/configuration.md) configuration section.
+
+```mermaid
+flowchart TD
+    Down{Server unreachable<br/>past retry window?} -->|No| Normal[Normal loop]
+    Down -->|Yes| Drain[Offline drain:<br/>stop claiming, journal completions]
+    Drain --> Ping{Server back<br/>while jobs running?}
+    Ping -->|Yes| Flush[Flush journal,<br/>resume normal loop]
+    Ping -->|No| AllDone{All running<br/>jobs finished?}
+    AllDone -->|No| Drain
+    AllDone -->|Yes| Exit([Write journal, exit])
+    Flush --> Normal
+
+    style Down fill:#f59e0b,stroke:#d97706,color:#fff
+    style Ping fill:#f59e0b,stroke:#d97706,color:#fff
+    style AllDone fill:#f59e0b,stroke:#d97706,color:#fff
+    style Drain fill:#3b82f6,stroke:#2563eb,color:#fff
+    style Flush fill:#3b82f6,stroke:#2563eb,color:#fff
+    style Normal fill:#10b981,stroke:#059669,color:#fff
+    style Exit fill:#ef4444,stroke:#dc2626,color:#fff
+```
+
+### Reconciling Journals After an Outage
+
+When runners exit while the server is down (for example, a long outage where every node finishes its
+work before the server returns), replay their journals once the server is healthy:
+
+```bash
+# Reconcile every node's journal for workflow 42, run 1, found under the current directory
+torc workflows reconcile 42 1
+
+# Point at the shared output root used by all compute nodes
+torc workflows reconcile 42 1 --base-dir /scratch/run42
+```
+
+`torc workflows reconcile` discovers **all** journal files for that `(workflow_id, run_id)` beneath
+the base directory — so a 1000-node run is recovered with one command, not one per node — and
+replays the completions to the server in bulk. The `run_id` is shown by `torc workflows status 42`
+and encoded in each journal's file name.
+
+Replay is idempotent and safe. The server validates each completion's `run_id` against the
+workflow's current generation, so completions from a superseded run (for example, after a manual
+restart) are rejected rather than applied; `torc workflows reconcile` reports these as rejected and
+exits without error.
+
 ## Resource Management (Resource-Based Allocation Only)
 
 When using resource-based allocation (default), the local job runner tracks:

--- a/docs/src/core/reference/configuration.md
+++ b/docs/src/core/reference/configuration.md
@@ -51,6 +51,23 @@ Settings for `torc run` command.
 | `memory_gb`         | float | (none)        | Available memory (GB) for resource-based scheduling |
 | `num_gpus`          | int   | (none)        | Available GPUs for resource-based scheduling        |
 
+### `[client.offline]` Section
+
+Settings for offline-drain behavior when a job runner loses contact with the server.
+
+By default, if a runner cannot reach the server for longer than the workflow's
+`compute_node_wait_for_healthy_database_minutes` retry window, it enters a "drain" state instead of
+killing its running jobs: it stops claiming new jobs, lets the jobs it already started run to
+completion, and journals their results to a local SQLite file under `<output_dir>/offline_journal/`.
+If the server recovers while jobs are still running, the runner flushes the journal and resumes
+normal operation; otherwise it exits once all running jobs finish. Replay the journals afterward
+with `torc workflows reconcile <workflow_id> <run_id>`.
+
+| Option                     | Type | Default | Description                                                        |
+| -------------------------- | ---- | ------- | ------------------------------------------------------------------ |
+| `enabled`                  | bool | `true`  | Drain (vs. kill jobs and exit) when the server becomes unreachable |
+| `drain_ping_interval_secs` | int  | `120`   | How often to ping the server while draining to check for recovery  |
+
 ### `[client.tls]` Section
 
 Settings for client-side TLS when connecting to an HTTPS server.
@@ -80,6 +97,10 @@ max_parallel_jobs = 4
 num_cpus = 8
 memory_gb = 32.0
 num_gpus = 1
+
+[client.offline]
+enabled = true
+drain_ping_interval_secs = 120
 ```
 
 ### `[client.hpc]` Section

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -53,9 +53,9 @@ listed below.
 
 ```
 /scratch/dthom/torc/
-├── 0.30.3/
+├── 0.30.4/
 ├── ...
-└── latest -> 0.30.3  (symlink to current version)
+└── latest -> 0.30.4  (symlink to current version)
 ```
 
 > **Recommended**: Use the `latest` directory. Torc maintains backwards compatibility, so you'll

--- a/python_client/pyproject.toml
+++ b/python_client/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "torc-client"
 # Note: Do not update manually. Use cargo-release from the repo root, such as
 # $ cargo release minor --execute
-version = "0.30.3"
+version = "0.30.4"
 description = "Workflow management system"
 requires-python = ">=3.11,<3.14"
 license = "BSD-3-Clause"

--- a/src/client.rs
+++ b/src/client.rs
@@ -23,6 +23,7 @@ pub mod execution_plan;
 pub mod hpc;
 pub mod job_runner;
 pub mod log_paths;
+pub mod offline_journal;
 pub mod parameter_expansion;
 pub mod remote;
 pub mod report_models;

--- a/src/client/commands.rs
+++ b/src/client/commands.rs
@@ -12,6 +12,7 @@ pub mod logs;
 pub mod orphan_detection;
 pub mod output;
 pub mod pagination;
+pub mod reconcile;
 pub mod recover;
 pub mod remote;
 pub mod reports;

--- a/src/client/commands/reconcile.rs
+++ b/src/client/commands/reconcile.rs
@@ -1,0 +1,133 @@
+//! `torc workflows reconcile` — replay offline-drain journals back to the server.
+//!
+//! When job runners lose contact with the server they drain (run their jobs to
+//! completion) and journal the results to local SQLite files (see
+//! [`crate::client::offline_journal`]). Once the server is healthy again, this
+//! command discovers every journal for a `(workflow_id, run_id)` under a base
+//! directory and replays the completions in bulk so a user does not have to run
+//! one command per compute node.
+//!
+//! Replay is idempotent and safe: the server validates each completion's
+//! `run_id` against the workflow's current generation, so completions from a
+//! superseded run (e.g. after a manual reset) are rejected rather than applied.
+
+use log::{info, warn};
+
+use crate::client::apis;
+use crate::client::apis::configuration::Configuration;
+use crate::client::offline_journal::{FLUSH_BATCH_SIZE, OfflineJournal};
+use crate::models::BatchCompleteJobsRequest;
+
+/// Outcome of a reconcile run, returned for testing and JSON output.
+#[derive(Debug, Default)]
+pub struct ReconcileSummary {
+    pub files: usize,
+    pub total_completions: usize,
+    pub accepted: usize,
+    pub rejected: usize,
+}
+
+/// Discover and replay all offline journals for `(workflow_id, run_id)` found
+/// under `base_dir`.
+pub fn reconcile(
+    config: &Configuration,
+    workflow_id: i64,
+    run_id: i64,
+    base_dir: &std::path::Path,
+    format: &str,
+) -> Result<ReconcileSummary, Box<dyn std::error::Error>> {
+    let files = OfflineJournal::discover(base_dir, workflow_id, run_id);
+    if files.is_empty() {
+        println!(
+            "No offline journals found for workflow_id={} run_id={} under {}",
+            workflow_id,
+            run_id,
+            base_dir.display()
+        );
+        return Ok(ReconcileSummary::default());
+    }
+
+    info!(
+        "Found {} offline journal file(s) for workflow_id={} run_id={}",
+        files.len(),
+        workflow_id,
+        run_id
+    );
+
+    let mut summary = ReconcileSummary {
+        files: files.len(),
+        ..Default::default()
+    };
+
+    for path in &files {
+        let entries = match OfflineJournal::read_file(path) {
+            Ok(entries) => entries,
+            Err(e) => {
+                warn!("Skipping unreadable journal {}: {}", path.display(), e);
+                continue;
+            }
+        };
+        if entries.is_empty() {
+            continue;
+        }
+        summary.total_completions += entries.len();
+        info!(
+            "Replaying {} completion(s) from {}",
+            entries.len(),
+            path.display()
+        );
+
+        for chunk in entries.chunks(FLUSH_BATCH_SIZE) {
+            let request = BatchCompleteJobsRequest {
+                completions: chunk.to_vec(),
+            };
+            match apis::workflows_api::batch_complete_jobs(config, workflow_id, request) {
+                Ok(response) => {
+                    summary.accepted += response.completed.len();
+                    for err in &response.errors {
+                        summary.rejected += 1;
+                        warn!(
+                            "Rejected completion job_id={} message={}",
+                            err.job_id, err.message
+                        );
+                    }
+                }
+                Err(e) => {
+                    return Err(format!(
+                        "Failed to submit completions from {}: {}. \
+                         Re-run reconcile once the server is healthy.",
+                        path.display(),
+                        e
+                    )
+                    .into());
+                }
+            }
+        }
+    }
+
+    if format == "json" {
+        println!(
+            r#"{{"files": {}, "total_completions": {}, "accepted": {}, "rejected": {}}}"#,
+            summary.files, summary.total_completions, summary.accepted, summary.rejected
+        );
+    } else {
+        println!(
+            "Reconciled workflow_id={} run_id={}: {} file(s), {} completion(s) \
+             ({} accepted, {} rejected)",
+            workflow_id,
+            run_id,
+            summary.files,
+            summary.total_completions,
+            summary.accepted,
+            summary.rejected
+        );
+        if summary.rejected > 0 {
+            println!(
+                "Rejected completions are usually from a superseded run (run_id no longer \
+                 current after a manual retry/reset); this is expected and safe."
+            );
+        }
+    }
+
+    Ok(summary)
+}

--- a/src/client/commands/workflows.rs
+++ b/src/client/commands/workflows.rs
@@ -18,6 +18,7 @@ const WORKFLOWS_HELP_TEMPLATE: &str = "\
   \x1b[1;36mreset-status\x1b[0m     Reset workflow and job statuses
   \x1b[1;36mis-complete\x1b[0m      Check if workflow is complete
   \x1b[1;36msync-status\x1b[0m      Detect orphaned jobs from ended Slurm allocations
+  \x1b[1;36mreconcile\x1b[0m        Replay offline-drain journals after a server outage
 
 \x1b[1;32mListing & Query:\x1b[0m
   \x1b[1;36mlist\x1b[0m             List workflows
@@ -665,6 +666,29 @@ TYPICAL WORKFLOW:
         /// Preview changes without applying them
         #[arg(long)]
         dry_run: bool,
+    },
+    /// Replay offline-drain journals back to the server
+    #[command(after_long_help = "\
+When job runners lose contact with the server they finish their running jobs and
+journal the results to local SQLite files instead of killing the jobs. After the
+server is healthy again, this command finds every journal for a workflow run
+under a base directory and uploads the completions in bulk.
+
+EXAMPLES:
+    # Reconcile journals written under the current directory
+    torc workflows reconcile 42 1
+
+    # Point at a shared output root used by all compute nodes
+    torc workflows reconcile 42 1 --base-dir /scratch/run42
+")]
+    Reconcile {
+        /// Workflow ID whose journals should be replayed
+        workflow_id: i64,
+        /// Run ID (workflow generation) whose journals should be replayed
+        run_id: i64,
+        /// Directory to search recursively for journal files
+        #[arg(long, default_value = ".")]
+        base_dir: std::path::PathBuf,
     },
 }
 
@@ -3112,6 +3136,22 @@ pub fn handle_workflow_commands(config: &Configuration, command: &WorkflowComman
             dry_run,
         } => {
             handle_sync_status(config, *workflow_id, *dry_run, &current_user, format);
+        }
+        WorkflowCommands::Reconcile {
+            workflow_id,
+            run_id,
+            base_dir,
+        } => {
+            if let Err(e) = crate::client::commands::reconcile::reconcile(
+                config,
+                *workflow_id,
+                *run_id,
+                base_dir,
+                format,
+            ) {
+                eprintln!("Error reconciling offline journals: {}", e);
+                std::process::exit(1);
+            }
         }
     }
 }

--- a/src/client/job_runner.rs
+++ b/src/client/job_runner.rs
@@ -38,6 +38,7 @@ use std::time::{Duration, Instant};
 use crate::client::apis;
 use crate::client::apis::configuration::Configuration;
 use crate::client::async_cli_command::AsyncCliCommand;
+use crate::client::offline_journal::{FLUSH_BATCH_SIZE, OfflineJournal};
 use crate::client::resource_correction::format_duration_iso8601;
 use crate::client::resource_monitor::{
     ResourceMonitor, ResourceMonitorConfig, SystemMetricsSummary,
@@ -380,6 +381,31 @@ pub struct JobRunner {
     had_terminations: bool,
     /// When this job runner started (for calculating duration_seconds)
     start_instant: Instant,
+    /// Per-node label (e.g. `wf123_h<host>_r<run>`) used to build unique output
+    /// file names, including the offline-drain journal.
+    unique_label: String,
+    /// Whether offline-drain mode is enabled (from `[client.offline]` config).
+    /// When false, an unreachable server causes the runner to kill jobs and exit.
+    offline_enabled: bool,
+    /// How often to ping the server while draining to check for recovery.
+    drain_ping_interval: Duration,
+    /// True while the runner is draining: the server is unreachable, no new jobs
+    /// are claimed, and completions are written to `offline_journal`.
+    offline: bool,
+    /// Journal of job completions recorded while offline. Opened lazily when the
+    /// runner first enters drain mode; cleared and dropped on resume.
+    offline_journal: Option<OfflineJournal>,
+    /// Monotonic timestamp of the last drain-mode resume ping.
+    last_drain_ping: Option<Instant>,
+    /// Probe used by `maybe_try_resume` to ask whether the server is reachable.
+    /// In production this pings the server; tests override it to drive the
+    /// drain/resume state machine deterministically without a real server.
+    server_reachable_probe: fn(&Configuration) -> bool,
+}
+
+/// Production server-reachability probe: a successful ping means reachable.
+fn default_server_reachable_probe(config: &Configuration) -> bool {
+    apis::system_api::ping(config).is_ok()
 }
 
 impl JobRunner {
@@ -536,6 +562,9 @@ impl JobRunner {
             workflow.compute_node_wait_for_healthy_database_minutes,
             workflow.compute_node_min_time_for_new_jobs_seconds,
         );
+        let offline_enabled = torc_config.client.offline.enabled;
+        let drain_ping_interval =
+            Duration::from_secs(torc_config.client.offline.drain_ping_interval_secs.max(1));
         let execution_config = ExecutionConfig::from_workflow_model(&workflow);
         if execution_config.effective_mode() == ExecutionMode::Slurm
             && std::env::var("SLURM_JOB_ID").is_err()
@@ -580,31 +609,34 @@ impl JobRunner {
         };
 
         // Initialize resource monitoring if configured
-        let resource_monitor = if let Some(ref monitor_config_json) =
-            workflow.resource_monitor_config
-        {
-            match serde_json::from_str::<ResourceMonitorConfig>(monitor_config_json) {
-                Ok(monitor_config) if monitor_config.is_enabled() => {
-                    match ResourceMonitor::new(monitor_config, output_dir.clone(), unique_label) {
-                        Ok(monitor) => {
-                            info!("Resource monitoring enabled");
-                            Some(monitor)
-                        }
-                        Err(e) => {
-                            error!("Failed to initialize resource monitor: {}", e);
-                            None
+        let resource_monitor =
+            if let Some(ref monitor_config_json) = workflow.resource_monitor_config {
+                match serde_json::from_str::<ResourceMonitorConfig>(monitor_config_json) {
+                    Ok(monitor_config) if monitor_config.is_enabled() => {
+                        match ResourceMonitor::new(
+                            monitor_config,
+                            output_dir.clone(),
+                            unique_label.clone(),
+                        ) {
+                            Ok(monitor) => {
+                                info!("Resource monitoring enabled");
+                                Some(monitor)
+                            }
+                            Err(e) => {
+                                error!("Failed to initialize resource monitor: {}", e);
+                                None
+                            }
                         }
                     }
+                    Ok(_) => None,
+                    Err(e) => {
+                        error!("Failed to parse resource monitor config: {}", e);
+                        None
+                    }
                 }
-                Ok(_) => None,
-                Err(e) => {
-                    error!("Failed to parse resource monitor config: {}", e);
-                    None
-                }
-            }
-        } else {
-            None
-        };
+            } else {
+                None
+            };
 
         JobRunner {
             config,
@@ -642,6 +674,13 @@ impl JobRunner {
             had_failures: false,
             had_terminations: false,
             start_instant: Instant::now(),
+            unique_label,
+            offline_enabled,
+            drain_ping_interval,
+            offline: false,
+            offline_journal: None,
+            last_drain_ping: None,
+            server_reachable_probe: default_server_reachable_probe,
         }
     }
 
@@ -832,48 +871,82 @@ impl JobRunner {
         self.execute_worker_start_actions();
 
         loop {
-            match self.send_with_retries(|| {
-                Self::box_retry_error(apis::workflows_api::is_workflow_complete(
-                    &self.config,
-                    self.workflow_id,
-                ))
-            }) {
-                Ok(response) => {
-                    if response.is_canceled {
-                        info!("Workflow canceled workflow_id={}", self.workflow_id);
-                        self.cancel_jobs();
-                        break;
-                    }
-                    if response.is_complete {
-                        if self.rules.compute_node_ignore_workflow_completion {
-                            info!(
-                                "Workflow complete (ignoring) workflow_id={}",
-                                self.workflow_id
-                            );
-                        } else {
-                            info!("Workflow complete workflow_id={}", self.workflow_id);
-                            self.execute_workflow_complete_actions();
+            // While draining, periodically check whether the server has come
+            // back so we can flush the journal and resume normal operation.
+            if self.offline {
+                self.maybe_try_resume();
+            }
+
+            // Skip the server-side workflow-completion check while offline; the
+            // server is unreachable and we are only reaping the jobs we already
+            // started.
+            if !self.offline {
+                match self.send_with_retries(|| {
+                    Self::box_retry_error(apis::workflows_api::is_workflow_complete(
+                        &self.config,
+                        self.workflow_id,
+                    ))
+                }) {
+                    Ok(response) => {
+                        if response.is_canceled {
+                            info!("Workflow canceled workflow_id={}", self.workflow_id);
+                            self.cancel_jobs();
                             break;
                         }
+                        if response.is_complete {
+                            if self.rules.compute_node_ignore_workflow_completion {
+                                info!(
+                                    "Workflow complete (ignoring) workflow_id={}",
+                                    self.workflow_id
+                                );
+                            } else {
+                                info!("Workflow complete workflow_id={}", self.workflow_id);
+                                self.execute_workflow_complete_actions();
+                                break;
+                            }
+                        }
                     }
-                }
-                Err(retry_err) => {
-                    error!(
-                        "Failed to check workflow completion after retries: {}",
-                        retry_err
-                    );
-                    self.kill_running_jobs();
-                    return Err(
-                        format!("Unable to check workflow completion: {}", retry_err).into(),
-                    );
+                    Err(retry_err) => {
+                        if self.offline_enabled {
+                            // The server has been unreachable past the retry
+                            // window. Rather than killing in-flight jobs, drain:
+                            // finish them and journal their results.
+                            self.enter_drain_mode();
+                        } else {
+                            error!(
+                                "Failed to check workflow completion after retries: {}",
+                                retry_err
+                            );
+                            self.kill_running_jobs();
+                            return Err(format!(
+                                "Unable to check workflow completion: {}",
+                                retry_err
+                            )
+                            .into());
+                        }
+                    }
                 }
             }
 
             let completions = match self.check_job_status() {
                 Ok(count) => count,
                 Err(e) => {
-                    self.kill_running_jobs();
-                    return Err(e);
+                    // While offline, completions are journaled locally and this
+                    // should not fail on server errors. If offline-drain is
+                    // enabled, switch into drain rather than killing jobs.
+                    if self.offline {
+                        error!(
+                            "Error reaping jobs while offline (continuing to drain): {}",
+                            e
+                        );
+                        0
+                    } else if self.offline_enabled {
+                        self.enter_drain_mode();
+                        0
+                    } else {
+                        self.kill_running_jobs();
+                        return Err(e);
+                    }
                 }
             };
             if self.execution_config.limit_resources()
@@ -883,29 +956,51 @@ impl JobRunner {
                 self.kill_running_jobs();
                 return Err(e);
             }
-            self.check_and_execute_actions();
-
-            debug!("Check for new jobs");
-            if let Some(max) = self.max_parallel_jobs {
-                // Parallelism-based mode: skip if already at max parallel jobs
-                if (self.running_jobs.len() as i64) < max {
-                    self.run_ready_jobs_based_on_user_parallelism();
-                } else {
-                    debug!(
-                        "Skipping job claim: at max parallel jobs ({}/{})",
-                        self.running_jobs.len(),
-                        max
+            // While offline we never claim new jobs (claiming requires the
+            // server's write lock to avoid double-allocation across nodes) and
+            // we do not run workflow actions. Once everything we were already
+            // running has drained, exit; the journal is reconciled later.
+            if self.offline {
+                if self.running_jobs.is_empty() {
+                    let journal_path = self
+                        .offline_journal
+                        .as_ref()
+                        .map(|j| j.path().display().to_string())
+                        .unwrap_or_else(|| "<none>".to_string());
+                    info!(
+                        "Offline drain complete: all running jobs finished. Exiting job runner. \
+                         Results journaled to {}. Reconcile them with \
+                         `torc workflows reconcile {} {}` once the server is back. \
+                         workflow_id={} run_id={}",
+                        journal_path, self.workflow_id, self.run_id, self.workflow_id, self.run_id
                     );
+                    break;
                 }
             } else {
-                // Resource-based mode: skip if no CPUs available or memory nearly exhausted
-                if self.resources.num_cpus > 0 && self.resources.memory_gb >= 0.1 {
-                    self.run_ready_jobs_based_on_resources();
+                self.check_and_execute_actions();
+
+                debug!("Check for new jobs");
+                if let Some(max) = self.max_parallel_jobs {
+                    // Parallelism-based mode: skip if already at max parallel jobs
+                    if (self.running_jobs.len() as i64) < max {
+                        self.run_ready_jobs_based_on_user_parallelism();
+                    } else {
+                        debug!(
+                            "Skipping job claim: at max parallel jobs ({}/{})",
+                            self.running_jobs.len(),
+                            max
+                        );
+                    }
                 } else {
-                    debug!(
-                        "Skipping job claim: no capacity (cpus={}, memory_gb={:.2})",
-                        self.resources.num_cpus, self.resources.memory_gb
-                    );
+                    // Resource-based mode: skip if no CPUs available or memory nearly exhausted
+                    if self.resources.num_cpus > 0 && self.resources.memory_gb >= 0.1 {
+                        self.run_ready_jobs_based_on_resources();
+                    } else {
+                        debug!(
+                            "Skipping job claim: no capacity (cpus={}, memory_gb={:.2})",
+                            self.resources.num_cpus, self.resources.memory_gb
+                        );
+                    }
                 }
             }
 
@@ -995,7 +1090,10 @@ impl JobRunner {
             }
         }
 
-        self.execute_worker_complete_actions();
+        // Worker-complete actions run on the server; skip them when offline.
+        if !self.offline {
+            self.execute_worker_complete_actions();
+        }
 
         // Shutdown resource monitor if enabled. Capture the plot request before shutdown
         // consumes the monitor.
@@ -1015,8 +1113,18 @@ impl JobRunner {
             self.generate_resource_plots(&db_path);
         }
 
-        // Deactivate compute node and set duration
-        self.deactivate_compute_node(system_metrics_summary);
+        // Deactivate compute node and set duration. Skip when offline: the
+        // server is unreachable, so the node is left active and will be
+        // reconciled (or expire) once connectivity returns.
+        if self.offline {
+            warn!(
+                "Exiting in offline-drain mode; skipping compute node deactivation \
+                 workflow_id={} run_id={} compute_node_id={}",
+                self.workflow_id, self.run_id, self.compute_node_id
+            );
+        } else {
+            self.deactivate_compute_node(system_metrics_summary);
+        }
 
         info!(
             "Job runner completed workflow_id={} run_id={} compute_node_id={} had_failures={} had_terminations={}",
@@ -1055,6 +1163,213 @@ impl JobRunner {
                 );
             }
         }
+    }
+
+    /// Transition into offline-drain mode: stop claiming new jobs, let running
+    /// jobs finish, and journal their completions locally. Idempotent — calling
+    /// it again while already draining is a no-op.
+    fn enter_drain_mode(&mut self) {
+        if self.offline {
+            return;
+        }
+        self.offline = true;
+        // Wait a full ping interval before the first resume attempt.
+        self.last_drain_ping = Some(Instant::now());
+
+        match OfflineJournal::open_or_create(
+            &self.output_dir,
+            self.workflow_id,
+            self.run_id,
+            &self.unique_label,
+        ) {
+            Ok(journal) => {
+                warn!(
+                    "Server unreachable past the retry window: entering offline-drain mode. \
+                     Running jobs will finish and their results will be journaled to {}. \
+                     workflow_id={} run_id={} running_jobs={}",
+                    journal.path().display(),
+                    self.workflow_id,
+                    self.run_id,
+                    self.running_jobs.len()
+                );
+                self.offline_journal = Some(journal);
+            }
+            Err(e) => {
+                error!(
+                    "Failed to open offline journal: {}. Draining without a journal; \
+                     completions during the outage will not be recorded and affected jobs \
+                     will need to be retried manually. workflow_id={}",
+                    e, self.workflow_id
+                );
+            }
+        }
+    }
+
+    /// While draining, ping the server at most once per `drain_ping_interval`.
+    /// If it responds and the journal flushes cleanly, leave drain mode and
+    /// resume normal operation.
+    fn maybe_try_resume(&mut self) {
+        let due = self
+            .last_drain_ping
+            .map(|t| t.elapsed() >= self.drain_ping_interval)
+            .unwrap_or(true);
+        if !due {
+            return;
+        }
+        self.last_drain_ping = Some(Instant::now());
+
+        if !(self.server_reachable_probe)(&self.config) {
+            debug!(
+                "Offline-drain: server still unreachable workflow_id={}",
+                self.workflow_id
+            );
+            return;
+        }
+
+        info!(
+            "Offline-drain: server is reachable again. Flushing journal and resuming workflow_id={}",
+            self.workflow_id
+        );
+        match self.flush_offline_journal() {
+            Ok(count) => {
+                info!(
+                    "Flushed {} journaled completion(s); resuming online operation workflow_id={}",
+                    count, self.workflow_id
+                );
+                self.offline = false;
+                self.offline_journal = None;
+            }
+            Err(e) => {
+                warn!(
+                    "Failed to flush offline journal on resume; staying in drain mode: {}",
+                    e
+                );
+            }
+        }
+    }
+
+    /// Upload journaled completions to the server, then clear the journal.
+    /// Returns the number of completions flushed. Completions are already
+    /// finalized locally (removed from `running_jobs`); this only brings the
+    /// server's view up to date so dependent jobs can unblock.
+    ///
+    /// Sent in bounded chunks so a node that drained many jobs does not produce
+    /// an oversized request. Each accepted chunk is recorded server-side, so if
+    /// a later chunk fails we leave the journal intact and stay offline; the
+    /// next resume attempt re-sends everything, and already-recorded jobs are
+    /// harmlessly rejected as duplicates by the server's run_id validation.
+    fn flush_offline_journal(&self) -> Result<usize, Box<dyn std::error::Error>> {
+        let journal = match &self.offline_journal {
+            Some(j) => j,
+            None => return Ok(0),
+        };
+        let entries = journal
+            .read_all()
+            .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+        if entries.is_empty() {
+            return Ok(0);
+        }
+        let count = entries.len();
+        for chunk in entries.chunks(FLUSH_BATCH_SIZE) {
+            let request = BatchCompleteJobsRequest {
+                completions: chunk.to_vec(),
+            };
+            let response = self.send_with_retries(|| {
+                Self::box_retry_error(apis::workflows_api::batch_complete_jobs(
+                    &self.config,
+                    self.workflow_id,
+                    request.clone(),
+                ))
+            })?;
+            for err in &response.errors {
+                warn!(
+                    "Resume flush: server rejected completion workflow_id={} job_id={} message={}",
+                    self.workflow_id, err.job_id, err.message
+                );
+            }
+        }
+        journal
+            .clear()
+            .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+        Ok(count)
+    }
+
+    /// Offline variant of completion handling: journal each completion (no
+    /// server call, no failure-handler recovery) and finalize local state.
+    fn journal_completions_offline(
+        &mut self,
+        completions: Vec<(i64, ResultModel)>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        for (job_id, result) in completions {
+            // Take sacct stats so resource fields are backfilled in the journaled
+            // result; the stats themselves are not uploaded while offline.
+            let slurm_stats = self
+                .running_jobs
+                .get_mut(&job_id)
+                .and_then(|j| j.take_slurm_stats());
+            let mut final_result = result;
+            if let Some(ref stats) = slurm_stats {
+                backfill_sacct_into_result(&mut final_result, stats);
+            }
+
+            match final_result.status {
+                JobStatus::Failed | JobStatus::PendingFailed => self.had_failures = true,
+                JobStatus::Terminated => self.had_terminations = true,
+                _ => {}
+            }
+
+            let entry = JobCompletionEntry {
+                job_id,
+                status: final_result.status,
+                run_id: final_result.run_id,
+                result: final_result,
+            };
+            self.journal_entry(&entry);
+        }
+        Ok(())
+    }
+
+    /// Append one completion to the journal and finalize its local state
+    /// (release resources, clean up stdio on success, drop from `running_jobs`).
+    /// Mirrors the success path of `report_completions_batch` minus server calls.
+    fn journal_entry(&mut self, entry: &JobCompletionEntry) {
+        let job_id = entry.job_id;
+        if let Some(journal) = &self.offline_journal {
+            match journal.append(entry) {
+                Ok(()) => info!(
+                    "Journaled completion (offline) workflow_id={} job_id={} run_id={} status={:?}",
+                    self.workflow_id, job_id, entry.run_id, entry.status
+                ),
+                Err(e) => error!(
+                    "Failed to journal completion workflow_id={} job_id={}: {}",
+                    self.workflow_id, job_id, e
+                ),
+            }
+        } else {
+            error!(
+                "No offline journal available; completion not recorded workflow_id={} job_id={}",
+                self.workflow_id, job_id
+            );
+        }
+
+        if let Some(job_rr) = self.job_resources.get(&job_id).cloned() {
+            self.increment_node_resources(job_id, &job_rr);
+            self.increment_resources(&job_rr);
+        }
+        self.last_job_claimed_time = Some(Instant::now());
+
+        if entry.result.return_code == 0
+            && let Some(cmd) = self.running_jobs.get(&job_id)
+        {
+            let job_name = &cmd.job.name;
+            if self.execution_config.delete_stdio_on_success(job_name) {
+                Self::cleanup_stdio_files(cmd);
+            }
+        }
+
+        self.running_jobs.remove(&job_id);
+        self.job_resources.remove(&job_id);
+        self.release_gpu_devices(job_id);
     }
 
     /// Generate HTML resource plots from the time-series metrics DB produced by the
@@ -1736,6 +2051,11 @@ impl JobRunner {
         &mut self,
         completions: Vec<(i64, ResultModel)>,
     ) -> Result<(), Box<dyn std::error::Error>> {
+        // While draining, the server is unreachable: journal completions locally
+        // instead of running the server-backed recovery + report pipeline.
+        if self.offline {
+            return self.journal_completions_offline(completions);
+        }
         let prepared: Vec<PreparedCompletion> = completions
             .into_iter()
             .filter_map(|(job_id, result)| self.prepare_job_completion(job_id, result))
@@ -1873,6 +2193,29 @@ impl JobRunner {
         }) {
             Ok(response) => response,
             Err(e) => {
+                if self.offline_enabled {
+                    // The server became unreachable mid-iteration. Rather than
+                    // dropping these finished jobs, enter drain mode and journal
+                    // them so they can be reconciled later.
+                    warn!(
+                        "batch_complete_jobs failed after retries; entering offline-drain and \
+                         journaling {} completion(s) workflow_id={} error={}",
+                        prepared.len(),
+                        self.workflow_id,
+                        e
+                    );
+                    self.enter_drain_mode();
+                    for p in prepared {
+                        let entry = JobCompletionEntry {
+                            job_id: p.job_id,
+                            status: p.final_result.status,
+                            run_id: p.final_result.run_id,
+                            result: p.final_result,
+                        };
+                        self.journal_entry(&entry);
+                    }
+                    return Ok(());
+                }
                 error!(
                     "batch_complete_jobs failed after retries workflow_id={} count={} error={}",
                     self.workflow_id,
@@ -3354,6 +3697,146 @@ mod tests {
         )
     }
 
+    /// Build a runner whose output (and therefore offline journal) lives under a
+    /// temp dir. The caller must keep the returned `TempDir` alive.
+    fn make_offline_runner(tmp: &tempfile::TempDir) -> JobRunner {
+        let mut runner = make_runner(ComputeNodesResources::new(1, 1.0, 0, 1));
+        runner.output_dir = tmp.path().to_path_buf();
+        runner
+    }
+
+    fn failed_result(job_id: i64, run_id: i64) -> ResultModel {
+        ResultModel::new(
+            job_id,
+            1, // workflow_id
+            run_id,
+            1, // attempt_id
+            1, // compute_node_id
+            1, // return_code (failure)
+            0.1,
+            "2026-01-01T00:00:00Z".to_string(),
+            JobStatus::Failed,
+        )
+    }
+
+    #[test]
+    #[serial] // constructs a runner, which reads GPU env vars mutated by other serial tests
+    fn drain_mode_opens_journal_and_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut runner = make_offline_runner(&tmp);
+
+        assert!(!runner.offline);
+        assert!(runner.offline_journal.is_none());
+
+        runner.enter_drain_mode();
+        assert!(runner.offline, "enter_drain_mode should set offline");
+        let path = runner
+            .offline_journal
+            .as_ref()
+            .expect("journal should be open")
+            .path()
+            .to_path_buf();
+        assert!(path.exists(), "journal file should exist on disk");
+
+        // Calling again while already draining is a no-op: same journal, still offline.
+        runner.enter_drain_mode();
+        assert!(runner.offline);
+        assert_eq!(
+            runner.offline_journal.as_ref().unwrap().path(),
+            path,
+            "second enter_drain_mode must not replace the journal"
+        );
+    }
+
+    #[test]
+    #[serial] // constructs a runner, which reads GPU env vars mutated by other serial tests
+    fn offline_completions_are_journaled_not_sent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut runner = make_offline_runner(&tmp);
+        runner.enter_drain_mode();
+
+        // While offline this routes to the journal; if it tried the network
+        // (Configuration::default points nowhere) it would error, so Ok proves
+        // the drain path engaged.
+        runner
+            .handle_completions_batch(vec![(42, failed_result(42, 1))])
+            .expect("offline completion handling should succeed without the server");
+
+        assert!(
+            runner.had_failures,
+            "failed completion should set had_failures"
+        );
+        assert!(
+            !runner.running_jobs.contains_key(&42),
+            "finalization should drop the job from running_jobs"
+        );
+
+        let entries = runner.offline_journal.as_ref().unwrap().read_all().unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].job_id, 42);
+        assert_eq!(entries[0].status, JobStatus::Failed);
+    }
+
+    #[test]
+    #[serial] // constructs a runner, which reads GPU env vars mutated by other serial tests
+    fn resume_stays_offline_when_server_unreachable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut runner = make_offline_runner(&tmp);
+        runner.enter_drain_mode();
+
+        runner.server_reachable_probe = |_| false;
+        runner.last_drain_ping = None; // force a probe this iteration
+
+        runner.maybe_try_resume();
+        assert!(
+            runner.offline,
+            "should stay offline while server is unreachable"
+        );
+        assert!(runner.offline_journal.is_some());
+    }
+
+    #[test]
+    #[serial] // constructs a runner, which reads GPU env vars mutated by other serial tests
+    fn resume_returns_online_when_server_reachable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut runner = make_offline_runner(&tmp);
+        runner.enter_drain_mode();
+
+        // Reachable + empty journal => flush is a no-op (no network), so the
+        // full resume transition runs deterministically.
+        runner.server_reachable_probe = |_| true;
+        runner.last_drain_ping = None; // force a probe this iteration
+
+        runner.maybe_try_resume();
+        assert!(
+            !runner.offline,
+            "should resume online when the server is reachable"
+        );
+        assert!(
+            runner.offline_journal.is_none(),
+            "journal handle should be dropped after resuming"
+        );
+    }
+
+    #[test]
+    #[serial] // constructs a runner, which reads GPU env vars mutated by other serial tests
+    fn resume_is_not_attempted_before_ping_interval() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut runner = make_offline_runner(&tmp);
+        runner.enter_drain_mode(); // sets last_drain_ping = now
+
+        // Even though the server is reachable, the recent ping + long interval
+        // means no probe should happen yet, so we remain offline.
+        runner.server_reachable_probe = |_| true;
+        runner.drain_ping_interval = Duration::from_secs(3600);
+
+        runner.maybe_try_resume();
+        assert!(
+            runner.offline,
+            "resume must respect the drain ping interval before probing"
+        );
+    }
+
     #[test]
     fn test_backfill_sacct_memory_takes_max() {
         // sacct reports higher peak than sstat: use sacct value
@@ -3618,6 +4101,7 @@ mod tests {
     /// The original bug: a single-node GPU job followed by a multi-node job
     /// would over-decrement GPUs and panic on the assertion.
     #[test]
+    #[serial] // constructs a runner, which reads GPU env vars mutated by other serial tests
     fn test_single_node_then_multi_node_no_panic() {
         // 2 nodes, 4 GPUs total (2 per node), 16 CPUs, 64 GB
         let resources = ComputeNodesResources::new(16, 64.0, 4, 2);
@@ -3712,6 +4196,7 @@ mod tests {
 
     /// Two multi-node jobs run sequentially without resource corruption.
     #[test]
+    #[serial] // constructs a runner, which reads GPU env vars mutated by other serial tests
     fn test_sequential_multi_node_jobs() {
         // 4 nodes, 8 GPUs total (2 per node)
         let resources = ComputeNodesResources::new(32, 128.0, 8, 4);

--- a/src/client/offline_journal.rs
+++ b/src/client/offline_journal.rs
@@ -1,0 +1,294 @@
+//! Local journal of job completions recorded while the server is unreachable.
+//!
+//! When a job runner enters offline-drain mode (see [`crate::client::job_runner`]),
+//! it can no longer report job completions to the server. Instead it appends each
+//! completion to a per-node SQLite journal on local (typically shared) storage.
+//! Two readers consume these journals:
+//!
+//! 1. The runner itself, when the server comes back while jobs are still running:
+//!    it flushes the journal via `batch_complete_jobs` and resumes normal operation.
+//! 2. The `torc workflows reconcile` command, which discovers every journal for a given
+//!    `(workflow_id, run_id)` under a base directory and replays them in bulk so a
+//!    user does not have to run one command per compute node.
+//!
+//! The journal file name encodes both `workflow_id` and `run_id` so reconcile can
+//! locate the right files by glob, plus the runner's `unique_label` for per-node
+//! uniqueness. Completions are keyed by `job_id` (a job completes at most once per
+//! run), so re-appending is an idempotent upsert.
+
+use crate::models::JobCompletionEntry;
+use log::{debug, info};
+use rusqlite::Connection;
+use std::path::{Path, PathBuf};
+
+/// Subdirectory under the runner's `output_dir` where journals are written.
+const JOURNAL_SUBDIR: &str = "offline_journal";
+const FILENAME_PREFIX: &str = "offline_results";
+
+/// Maximum completions to send in a single `batch_complete_jobs` request when
+/// replaying a journal. Bounds request body size and lets replay make partial
+/// progress. Shared by the runner's resume flush and `torc workflows reconcile`.
+pub const FLUSH_BATCH_SIZE: usize = 500;
+
+/// Build the journal file name for a runner. The `workflow_id` / `run_id` prefix
+/// is what [`OfflineJournal::discover`] globs on; `unique_label` makes the name
+/// unique across the compute nodes participating in a run.
+fn journal_filename(workflow_id: i64, run_id: i64, unique_label: &str) -> String {
+    format!("{FILENAME_PREFIX}_wf{workflow_id}_r{run_id}_{unique_label}.db")
+}
+
+/// Filename prefix shared by every journal belonging to a `(workflow_id, run_id)`.
+fn journal_filename_prefix(workflow_id: i64, run_id: i64) -> String {
+    format!("{FILENAME_PREFIX}_wf{workflow_id}_r{run_id}_")
+}
+
+/// Returns the path of the journal file that would be created for the given
+/// runner identity, mirroring the layout used by [`OfflineJournal::open_or_create`].
+pub fn journal_path(
+    output_dir: &Path,
+    workflow_id: i64,
+    run_id: i64,
+    unique_label: &str,
+) -> PathBuf {
+    output_dir
+        .join(JOURNAL_SUBDIR)
+        .join(journal_filename(workflow_id, run_id, unique_label))
+}
+
+/// A handle to a single compute node's offline completion journal.
+pub struct OfflineJournal {
+    conn: Connection,
+    path: PathBuf,
+}
+
+impl OfflineJournal {
+    /// Open (creating if necessary) the journal for this runner. Uses the same
+    /// WAL + `synchronous=NORMAL` durability settings as the resource monitor so
+    /// finished results survive a process kill or node crash during the outage.
+    pub fn open_or_create(
+        output_dir: &Path,
+        workflow_id: i64,
+        run_id: i64,
+        unique_label: &str,
+    ) -> rusqlite::Result<Self> {
+        let dir = output_dir.join(JOURNAL_SUBDIR);
+        if let Err(e) = std::fs::create_dir_all(&dir) {
+            log::error!("Failed to create offline journal directory: {}", e);
+            return Err(rusqlite::Error::InvalidPath(dir));
+        }
+
+        let path = journal_path(output_dir, workflow_id, run_id, unique_label);
+        info!("Opening offline completion journal at: {}", path.display());
+
+        let conn = Connection::open(&path)?;
+        conn.pragma_update(None, "journal_mode", "WAL")?;
+        conn.pragma_update(None, "synchronous", "NORMAL")?;
+
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS journaled_completions (
+                job_id INTEGER PRIMARY KEY,
+                run_id INTEGER NOT NULL,
+                status INTEGER NOT NULL,
+                payload TEXT NOT NULL,
+                journaled_at INTEGER NOT NULL
+            )",
+            [],
+        )?;
+
+        Ok(Self { conn, path })
+    }
+
+    /// Path to the underlying SQLite file.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Append (or replace) a completion. Keyed by `job_id`, so re-journaling the
+    /// same job is idempotent.
+    pub fn append(&self, entry: &JobCompletionEntry) -> Result<(), String> {
+        let payload = serde_json::to_string(entry)
+            .map_err(|e| format!("Failed to serialize completion: {e}"))?;
+        let now = chrono::Utc::now().timestamp();
+        self.conn
+            .execute(
+                "INSERT OR REPLACE INTO journaled_completions
+                 (job_id, run_id, status, payload, journaled_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                rusqlite::params![
+                    entry.job_id,
+                    entry.run_id,
+                    entry.status as i64,
+                    payload,
+                    now,
+                ],
+            )
+            .map_err(|e| format!("Failed to journal completion: {e}"))?;
+        debug!(
+            "Journaled completion job_id={} run_id={} status={:?}",
+            entry.job_id, entry.run_id, entry.status
+        );
+        Ok(())
+    }
+
+    /// Read every journaled completion from this file.
+    pub fn read_all(&self) -> Result<Vec<JobCompletionEntry>, String> {
+        Self::read_all_from_conn(&self.conn)
+    }
+
+    /// Delete all journaled completions. Called after a successful flush to the
+    /// server so a subsequent outage does not re-submit already-recorded jobs.
+    pub fn clear(&self) -> Result<(), String> {
+        self.conn
+            .execute("DELETE FROM journaled_completions", [])
+            .map_err(|e| format!("Failed to clear journal: {e}"))?;
+        Ok(())
+    }
+
+    fn read_all_from_conn(conn: &Connection) -> Result<Vec<JobCompletionEntry>, String> {
+        let mut stmt = conn
+            .prepare("SELECT payload FROM journaled_completions ORDER BY job_id")
+            .map_err(|e| format!("Failed to prepare journal query: {e}"))?;
+        let rows = stmt
+            .query_map([], |row| row.get::<_, String>(0))
+            .map_err(|e| format!("Failed to query journal: {e}"))?;
+
+        let mut entries = Vec::new();
+        for row in rows {
+            let payload = row.map_err(|e| format!("Failed to read journal row: {e}"))?;
+            let entry: JobCompletionEntry = serde_json::from_str(&payload)
+                .map_err(|e| format!("Failed to deserialize journaled completion: {e}"))?;
+            entries.push(entry);
+        }
+        Ok(entries)
+    }
+
+    /// Read all completions from a journal file at `path` without holding a
+    /// long-lived handle. Used by `torc workflows reconcile`.
+    pub fn read_file(path: &Path) -> Result<Vec<JobCompletionEntry>, String> {
+        let conn = Connection::open(path)
+            .map_err(|e| format!("Failed to open journal {}: {e}", path.display()))?;
+        Self::read_all_from_conn(&conn)
+    }
+
+    /// Find every journal file for a `(workflow_id, run_id)` by recursively
+    /// walking `base_dir`. Matching is by file name prefix, so journals written
+    /// to per-node `output_dir`s nested anywhere under `base_dir` are all found.
+    pub fn discover(base_dir: &Path, workflow_id: i64, run_id: i64) -> Vec<PathBuf> {
+        let prefix = journal_filename_prefix(workflow_id, run_id);
+        let mut found = Vec::new();
+        walk(base_dir, &prefix, &mut found);
+        found.sort();
+        found
+    }
+}
+
+/// Recursively collect files whose name starts with `prefix` and ends with `.db`.
+/// Symlinks are not followed to avoid cycles. Unreadable directories are skipped.
+fn walk(dir: &Path, prefix: &str, found: &mut Vec<PathBuf>) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let file_type = match entry.file_type() {
+            Ok(ft) => ft,
+            Err(_) => continue,
+        };
+        if file_type.is_symlink() {
+            continue;
+        }
+        if file_type.is_dir() {
+            walk(&path, prefix, found);
+        } else if let Some(name) = path.file_name().and_then(|n| n.to_str())
+            && name.starts_with(prefix)
+            && name.ends_with(".db")
+        {
+            found.push(path);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{JobStatus, ResultModel};
+
+    fn sample_entry(job_id: i64, run_id: i64) -> JobCompletionEntry {
+        JobCompletionEntry {
+            job_id,
+            status: JobStatus::Completed,
+            run_id,
+            result: ResultModel {
+                id: None,
+                job_id,
+                workflow_id: 1,
+                run_id,
+                attempt_id: Some(1),
+                compute_node_id: 7,
+                return_code: 0,
+                exec_time_minutes: 1.0,
+                completion_time: "2026-05-23T00:00:00Z".to_string(),
+                peak_memory_bytes: None,
+                avg_memory_bytes: None,
+                peak_cpu_percent: None,
+                avg_cpu_percent: None,
+                status: JobStatus::Completed,
+            },
+        }
+    }
+
+    #[test]
+    fn test_append_read_and_idempotent_upsert() {
+        let dir = tempfile::tempdir().unwrap();
+        let journal = OfflineJournal::open_or_create(dir.path(), 1, 42, "wf1_h_node_r42").unwrap();
+        journal.append(&sample_entry(10, 42)).unwrap();
+        journal.append(&sample_entry(11, 42)).unwrap();
+        // Re-appending the same job_id replaces rather than duplicates.
+        journal.append(&sample_entry(10, 42)).unwrap();
+
+        let entries = journal.read_all().unwrap();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].job_id, 10);
+        assert_eq!(entries[1].job_id, 11);
+    }
+
+    #[test]
+    fn test_discover_finds_nested_journals_for_wf_run() {
+        let base = tempfile::tempdir().unwrap();
+        // Two nodes write into separate nested output dirs.
+        let node_a = base.path().join("node_a").join("torc_output");
+        let node_b = base.path().join("node_b").join("torc_output");
+        OfflineJournal::open_or_create(&node_a, 5, 3, "node_a")
+            .unwrap()
+            .append(&sample_entry(100, 3))
+            .unwrap();
+        OfflineJournal::open_or_create(&node_b, 5, 3, "node_b")
+            .unwrap()
+            .append(&sample_entry(200, 3))
+            .unwrap();
+        // A journal for a different run must not match.
+        OfflineJournal::open_or_create(&node_b, 5, 4, "node_b")
+            .unwrap()
+            .append(&sample_entry(300, 4))
+            .unwrap();
+
+        let found = OfflineJournal::discover(base.path(), 5, 3);
+        assert_eq!(found.len(), 2, "expected exactly the two run_id=3 journals");
+
+        let total: usize = found
+            .iter()
+            .map(|p| OfflineJournal::read_file(p).unwrap().len())
+            .sum();
+        assert_eq!(total, 2);
+    }
+
+    #[test]
+    fn test_clear_empties_journal() {
+        let dir = tempfile::tempdir().unwrap();
+        let journal = OfflineJournal::open_or_create(dir.path(), 1, 1, "label").unwrap();
+        journal.append(&sample_entry(1, 1)).unwrap();
+        journal.clear().unwrap();
+        assert!(journal.read_all().unwrap().is_empty());
+    }
+}

--- a/src/config/client.rs
+++ b/src/config/client.rs
@@ -20,6 +20,9 @@ pub struct ClientConfig {
     /// Run command configuration
     pub run: ClientRunConfig,
 
+    /// Offline-drain configuration for job runners
+    pub offline: ClientOfflineConfig,
+
     /// Slurm scheduler configuration
     pub slurm: ClientSlurmConfig,
 
@@ -40,6 +43,7 @@ impl Default for ClientConfig {
             format: "table".to_string(),
             log_level: "info".to_string(),
             run: ClientRunConfig::default(),
+            offline: ClientOfflineConfig::default(),
             slurm: ClientSlurmConfig::default(),
             hpc: ClientHpcConfig::default(),
             watch: ClientWatchConfig::default(),
@@ -91,6 +95,38 @@ impl Default for ClientRunConfig {
             num_cpus: None,
             memory_gb: None,
             num_gpus: None,
+        }
+    }
+}
+
+/// Configuration for offline-drain behavior when the server becomes unreachable.
+///
+/// When a job runner cannot reach the server for longer than the workflow's
+/// `compute_node_wait_for_healthy_database_minutes` retry window, it enters a
+/// "drain" state instead of killing its running jobs: it stops claiming new
+/// jobs, lets the jobs it already started run to completion, and journals their
+/// results to a local SQLite file. If the server comes back while jobs are
+/// still running, the runner flushes the journal and resumes normal operation;
+/// otherwise it exits once all running jobs finish. The journal can be replayed
+/// later with `torc workflows reconcile`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ClientOfflineConfig {
+    /// Whether to drain (run jobs to completion + journal results) when the
+    /// server becomes unreachable. When false, the runner reverts to the legacy
+    /// behavior of killing all running jobs and exiting.
+    pub enabled: bool,
+
+    /// While draining, how often (in seconds) to ping the server to check
+    /// whether it has recovered so the runner can flush its journal and resume.
+    pub drain_ping_interval_secs: u64,
+}
+
+impl Default for ClientOfflineConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            drain_ping_interval_secs: 120,
         }
     }
 }

--- a/tests/test_offline_reconcile.rs
+++ b/tests/test_offline_reconcile.rs
@@ -1,0 +1,296 @@
+//! Integration test for the offline-drain → local journal → `torc workflows reconcile` flow.
+//!
+//! Simulates what happens when the server is unreachable: job runners drain (run
+//! their jobs to completion) and journal the results to per-node SQLite files
+//! instead of killing the jobs. After the server recovers, `torc reconcile`
+//! discovers every journal for a `(workflow_id, run_id)` under a base directory
+//! and replays the completions in bulk.
+//!
+//! Rather than killing a live server mid-run (flaky), this test writes journals
+//! exactly as a drained runner would, then drives the real `reconcile` function
+//! against a real server and asserts the server's state converges.
+
+mod common;
+
+use common::{
+    create_test_compute_node, create_test_workflow, ensure_test_binaries_built, get_exe_path,
+    get_server_url,
+};
+use serial_test::serial;
+use std::net::TcpListener;
+use std::process::{Child, Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+use torc::client::apis;
+use torc::client::apis::configuration::Configuration;
+use torc::client::commands::reconcile::reconcile;
+use torc::client::offline_journal::OfflineJournal;
+use torc::client::workflow_manager::WorkflowManager;
+use torc::config::TorcConfig;
+use torc::models;
+use torc::models::JobStatus;
+
+struct TestServer {
+    child: Child,
+    config: Configuration,
+}
+
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn find_available_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .expect("Failed to bind to random port")
+        .local_addr()
+        .expect("Failed to get local address")
+        .port()
+}
+
+fn wait_for_ready(child: &mut Child, port: u16, timeout: Duration) -> Result<(), String> {
+    let url = get_server_url(port);
+    let client = reqwest::blocking::Client::new();
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if client.get(&url).send().is_ok() {
+            return Ok(());
+        }
+        if let Some(status) = child.try_wait().map_err(|e| format!("poll failed: {e}"))? {
+            return Err(format!("server exited before ready: {status}"));
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    Err(format!("server not ready within {:?}", timeout))
+}
+
+fn start_server() -> TestServer {
+    ensure_test_binaries_built();
+    let port = find_available_port();
+    let mut child = Command::new(get_exe_path("./target/debug/torc-server"))
+        .arg("run")
+        .arg("--port")
+        .arg(port.to_string())
+        .arg("--database")
+        .arg(":memory:")
+        .arg("--completion-check-interval-secs")
+        .arg("0.1")
+        .env("RUST_LOG", "warn")
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("failed to spawn torc-server");
+
+    if let Err(e) = wait_for_ready(&mut child, port, Duration::from_secs(15)) {
+        let _ = child.kill();
+        let _ = child.wait();
+        panic!("Test server failed to start: {e}");
+    }
+
+    let mut config = Configuration::new();
+    config.base_path = get_server_url(port);
+    config.client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .build()
+        .expect("Failed to build blocking reqwest client");
+    TestServer { child, config }
+}
+
+/// Build a successful-completion entry the way a drained runner would.
+fn completion_entry(
+    workflow_id: i64,
+    run_id: i64,
+    compute_node_id: i64,
+    job_id: i64,
+) -> models::JobCompletionEntry {
+    let result = models::ResultModel::new(
+        job_id,
+        workflow_id,
+        run_id,
+        1, // attempt_id
+        compute_node_id,
+        0,   // return_code (success)
+        0.1, // exec_time_minutes
+        chrono::Utc::now().to_rfc3339(),
+        JobStatus::Completed,
+    );
+    models::JobCompletionEntry {
+        job_id,
+        status: JobStatus::Completed,
+        run_id,
+        result,
+    }
+}
+
+fn is_complete(config: &Configuration, workflow_id: i64) -> bool {
+    apis::workflows_api::is_workflow_complete(config, workflow_id)
+        .expect("is_workflow_complete failed")
+        .is_complete
+}
+
+/// Poll `is_workflow_complete` for up to `timeout`, since completions unblock
+/// dependents via a background task that runs on an interval.
+fn wait_until_complete(config: &Configuration, workflow_id: i64, timeout: Duration) -> bool {
+    let start = Instant::now();
+    loop {
+        if is_complete(config, workflow_id) {
+            return true;
+        }
+        if start.elapsed() >= timeout {
+            return false;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+}
+
+#[test]
+#[serial(offline_reconcile)]
+fn test_offline_drain_journal_reconcile_round_trip() {
+    let server = start_server();
+    let config = &server.config;
+
+    // Create a workflow with four independent jobs and initialize it.
+    let workflow = create_test_workflow(config, "offline_reconcile_round_trip");
+    let workflow_id = workflow.id.unwrap();
+
+    let mut job_ids = Vec::new();
+    for i in 0..4 {
+        let job = models::JobModel::new(workflow_id, format!("job{}", i), format!("echo job{}", i));
+        let created = apis::jobs_api::create_job(config, job).expect("Failed to create job");
+        job_ids.push(created.id.unwrap());
+    }
+
+    let torc_config = TorcConfig::load().unwrap_or_default();
+    let manager = WorkflowManager::new(config.clone(), torc_config, workflow);
+    manager.initialize(true).expect("Failed to initialize");
+    let run_id = 1; // initialize() sets the first generation to run_id=1
+    let compute_node_id = create_test_compute_node(config, workflow_id).id.unwrap();
+
+    // Simulate two drained compute nodes writing journals into separate, nested
+    // output directories under a shared base dir (the HPC shared-filesystem case).
+    let base = tempfile::tempdir().expect("tempdir");
+    let node_a_out = base.path().join("nodeA").join("torc_output");
+    let node_b_out = base.path().join("nodeB").join("torc_output");
+
+    let journal_a = OfflineJournal::open_or_create(&node_a_out, workflow_id, run_id, "nodeA")
+        .expect("open journal A");
+    let journal_b = OfflineJournal::open_or_create(&node_b_out, workflow_id, run_id, "nodeB")
+        .expect("open journal B");
+
+    // Split the four completions across the two node journals.
+    for &job_id in &job_ids[..2] {
+        journal_a
+            .append(&completion_entry(
+                workflow_id,
+                run_id,
+                compute_node_id,
+                job_id,
+            ))
+            .expect("append A");
+    }
+    for &job_id in &job_ids[2..] {
+        journal_b
+            .append(&completion_entry(
+                workflow_id,
+                run_id,
+                compute_node_id,
+                job_id,
+            ))
+            .expect("append B");
+    }
+
+    // Before reconciling, the server has seen no completions.
+    assert!(
+        !is_complete(config, workflow_id),
+        "workflow should not be complete before reconcile"
+    );
+
+    // Reconcile: discover both journals and replay them against the server.
+    let summary = reconcile(config, workflow_id, run_id, base.path(), "table")
+        .expect("reconcile should succeed");
+    assert_eq!(summary.files, 2, "should discover both node journals");
+    assert_eq!(summary.total_completions, 4);
+    assert_eq!(
+        summary.accepted, 4,
+        "all four completions should be accepted"
+    );
+    assert_eq!(summary.rejected, 0);
+
+    // The server now reflects every completion, and the workflow is complete.
+    for &job_id in &job_ids {
+        let job = apis::jobs_api::get_job(config, job_id).expect("get_job");
+        assert_eq!(
+            job.status.unwrap(),
+            JobStatus::Completed,
+            "job_id={} should be Completed after reconcile",
+            job_id
+        );
+    }
+    assert!(
+        wait_until_complete(config, workflow_id, Duration::from_secs(5)),
+        "workflow should be complete after all jobs reconciled"
+    );
+
+    // Re-running reconcile is safe: the jobs are already terminal, so the server
+    // rejects the duplicates rather than erroring, and reconcile still succeeds.
+    let summary_again = reconcile(config, workflow_id, run_id, base.path(), "table")
+        .expect("re-running reconcile must not error");
+    assert_eq!(summary_again.accepted, 0, "no new completions on re-run");
+    for &job_id in &job_ids {
+        let job = apis::jobs_api::get_job(config, job_id).expect("get_job");
+        assert_eq!(job.status.unwrap(), JobStatus::Completed);
+    }
+}
+
+#[test]
+#[serial(offline_reconcile)]
+fn test_reconcile_rejects_stale_run_id() {
+    let server = start_server();
+    let config = &server.config;
+
+    let workflow = create_test_workflow(config, "offline_reconcile_stale_run");
+    let workflow_id = workflow.id.unwrap();
+
+    let job = models::JobModel::new(workflow_id, "only_job".to_string(), "echo hi".to_string());
+    let job_id = apis::jobs_api::create_job(config, job)
+        .expect("create_job")
+        .id
+        .unwrap();
+
+    let torc_config = TorcConfig::load().unwrap_or_default();
+    let manager = WorkflowManager::new(config.clone(), torc_config, workflow);
+    manager.initialize(true).expect("initialize");
+    let compute_node_id = create_test_compute_node(config, workflow_id).id.unwrap();
+
+    // Journal a completion for a run that is NOT the workflow's current generation
+    // (current run_id is 1). This mirrors a journal from a superseded run.
+    let stale_run_id = 999;
+    let base = tempfile::tempdir().expect("tempdir");
+    let out = base.path().join("torc_output");
+    let journal = OfflineJournal::open_or_create(&out, workflow_id, stale_run_id, "stale")
+        .expect("open journal");
+    journal
+        .append(&completion_entry(
+            workflow_id,
+            stale_run_id,
+            compute_node_id,
+            job_id,
+        ))
+        .expect("append");
+
+    let summary = reconcile(config, workflow_id, stale_run_id, base.path(), "table")
+        .expect("reconcile should not error on stale completions");
+    assert_eq!(summary.files, 1);
+    assert_eq!(summary.accepted, 0, "stale completion must not be accepted");
+    assert_eq!(summary.rejected, 1, "stale completion must be rejected");
+
+    // The job is untouched by the rejected stale completion.
+    let job = apis::jobs_api::get_job(config, job_id).expect("get_job");
+    assert_ne!(
+        job.status.unwrap(),
+        JobStatus::Completed,
+        "job must not be completed by a stale-run reconcile"
+    );
+}


### PR DESCRIPTION
## Summary

Client-only backport of the offline-drain + `torc workflows reconcile` fix
(squashed PR #336, `e99873d`) onto the `0.30.x` maintenance line, for sites
running the **v0.30.3 server that cannot be upgraded**.

When a job runner loses contact with the server past its retry window, instead
of killing in-flight jobs it now drains (runs them to completion), journals the
results to a local SQLite file, and either flushes on server recovery or exits
for later replay via `torc workflows reconcile <workflow_id> <run_id>`.

## Why this is safe against a v0.30.3 server

Verified wire-compatible — the offline path only uses endpoints that already
exist in v0.30.3:

- `batch_complete_jobs` and `ping` are both present in v0.30.3.
- The completion models (`JobCompletionEntry`, `BatchCompleteJobs{Request,Response}`,
  `JobCompletionError`) are byte-identical between v0.30.3 and main.
- v0.30.3's server already does per-completion `run_id` validation and collects
  per-entry errors, so stale-run completions are safely rejected (not applied).

**No server or migration changes** — diff is purely client + docs + version bump.

## Backport mechanics

- Cherry-picked `e99873d` (`-x` recorded) onto a branch off the `v0.30.3` tag.
- One conflict in `job_runner.rs`: v0.30.3 stores `resource_monitor_config` as a
  JSON string parsed inline, vs. pre-deserialized on main. Kept v0.30.3's
  structure and applied the feature's only real change there
  (`unique_label` → `unique_label.clone()`, since the label now also feeds the
  journal filename).

## Verification

- `cargo fmt --check`, `clippy --all --all-targets --all-features`, `dprint check` — clean.
- Unit tests: offline_journal (3) + drain/resume/offline (5) — pass.
- Integration test `test_offline_reconcile` — **builds and runs the actual
  server from this branch (unmodified v0.30.3 server code)** and drives the full
  drain → journal → reconcile round-trip plus stale-run-id rejection. Passes.
- Build note: the worktree has no generated `dev.db`, so server-side
  `sqlx::query!` macros require `SQLX_OFFLINE=true` (uses the checked-in `.sqlx`
  cache).

## Deployment note

This protects runs **launched or restarted** after the new client is deployed;
already-in-flight runners cannot be hot-swapped. Ship only the client artifacts
(`torc` CLI / slurm-runner); leave `torc-server` at v0.30.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)