### PR TITLE
Teach MCP server about RO-Crate provenance and offline-drain reconcile

### DIFF
--- a/src/client/offline_journal.rs
+++ b/src/client/offline_journal.rs
@@ -170,6 +170,20 @@ impl OfflineJournal {
         Self::read_all_from_conn(&conn)
     }
 
+    /// Count the journaled completions in the file at `path` without
+    /// deserializing each payload. Cheaper than [`read_file`] when only the
+    /// number of pending completions is needed (e.g. an advisory check).
+    pub fn count_file(path: &Path) -> Result<usize, String> {
+        let conn = Connection::open(path)
+            .map_err(|e| format!("Failed to open journal {}: {e}", path.display()))?;
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM journaled_completions", [], |row| {
+                row.get(0)
+            })
+            .map_err(|e| format!("Failed to count journal {}: {e}", path.display()))?;
+        Ok(count.max(0) as usize)
+    }
+
     /// Find every journal file for a `(workflow_id, run_id)` by recursively
     /// walking `base_dir`. Matching is by file name prefix, so journals written
     /// to per-node `output_dir`s nested anywhere under `base_dir` are all found.

--- a/src/mcp_server/server.rs
+++ b/src/mcp_server/server.rs
@@ -230,6 +230,20 @@ pub struct GetWorkflowSummaryParams {
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct CheckOfflineJournalsParams {
+    #[schemars(description = "The workflow ID")]
+    pub workflow_id: i64,
+    #[schemars(
+        description = "Run ID to match journals against (optional). Defaults to the workflow's current run_id, so only journals for the run the server still considers active are reported."
+    )]
+    pub run_id: Option<i64>,
+    #[schemars(
+        description = "Base directory to search recursively for journal files (optional). Defaults to the server's output directory. For Slurm runs this is typically the shared output directory passed to `torc run`."
+    )]
+    pub base_dir: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ListResultsParams {
     #[schemars(description = "The workflow ID")]
     pub workflow_id: i64,
@@ -475,6 +489,12 @@ FILES (use when user mentions input/output files, data flow):
 - "output_files": exact file names job writes
 - "input_file_regexes": regex patterns for FAN-IN (collecting many files into one job)
 - Files with parameters: {"name": "out_{i}", "path": "out_{i}.txt", "st_mtime": null, "parameters": {"i": "0:9"}}
+
+PROVENANCE / RO-CRATE (use when user mentions "provenance", "RO-Crate", "RO crate", or "research object"):
+- Set "enable_ro_crate": true at the TOP LEVEL of the spec.
+- Torc then automatically creates RO-Crate entities for workflow files: input files get entities during initialization, output files get entities on job completion.
+- Optionally give individual files a stable "identifier" (e.g. a DOI, PURL, or URN) in the files section; it is used as the RO-Crate @id while the path is preserved as sameAs.
+- Example: {"name": "wf", "enable_ro_crate": true, "files": [...], "jobs": [...]}
 
 PARAMETERIZATION (use for N similar jobs):
 - parameters: {"i": "0:9"} generates i=0,1,2,...,9
@@ -744,6 +764,36 @@ USE CASES:
         tokio::task::spawn_blocking(move || tools::list_failed_jobs(&config, workflow_id))
             .await
             .map_err(|e| McpError::internal_error(format!("Task join error: {}", e), None))?
+    }
+
+    /// Detect offline-drain journals and advise whether reconcile is needed.
+    #[tool(
+        description = "Check for offline-drain journal databases for a workflow and determine whether \
+        `torc workflows reconcile` should be run. When a job runner loses contact with the server it enters \
+        offline-drain mode and records job completions to local SQLite journals named \
+        offline_results_wf<workflow_id>_r<run_id>_<label>.db. Those completions are NOT reflected on the \
+        server until replayed. ALWAYS call this tool when debugging a workflow whose jobs appear to have run \
+        but show as not completed, or after any server outage. If journals are found for the current run_id, \
+        tell the user how many journals and pending completions exist and prompt them to run the \
+        reconcile_command returned in the result (reconcile is idempotent and rejects completions from a \
+        superseded run). Do NOT run reconcile without the user's confirmation. This tool is read-only."
+    )]
+    async fn check_offline_journals(
+        &self,
+        Parameters(params): Parameters<CheckOfflineJournalsParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let config = self.config.clone();
+        let base_dir = params
+            .base_dir
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|| self.output_dir.clone());
+        let workflow_id = params.workflow_id;
+        let run_id = params.run_id;
+        tokio::task::spawn_blocking(move || {
+            tools::check_offline_journals(&config, &base_dir, workflow_id, run_id)
+        })
+        .await
+        .map_err(|e| McpError::internal_error(format!("Task join error: {}", e), None))?
     }
 
     /// Check resource utilization for a workflow.
@@ -1179,8 +1229,19 @@ impl ServerHandler for TorcMcpServer {
                  3. Add 'output_files' to jobs that write files (exact names)\n\
                  4. For FAN-IN (aggregating multiple files into one job), use 'input_file_regexes' with a regex pattern\n\
                  Example: input_file_regexes: [\"^work_out_\\\\d+$\"] matches work_out_0, work_out_1, etc.\n\n\
+                 PROVENANCE / RO-CRATE:\n\
+                 - If the user asks for provenance tracking or the RO-Crate (RO crate / research object) \
+                 feature, set 'enable_ro_crate': true at the top level of the spec. Torc then creates \
+                 RO-Crate entities for input files at initialization and output files on job completion.\n\n\
+                 DEBUGGING - CHECK FOR OFFLINE JOURNALS:\n\
+                 - When debugging a workflow (jobs that ran but appear incomplete, or after a server outage), \
+                 call check_offline_journals. It finds offline-drain journal databases and tells you whether \
+                 completions still need to be replayed for the current run_id.\n\
+                 - If journals are found, tell the user how many pending completions exist and prompt them to \
+                 run the suggested 'torc workflows reconcile' command. Do NOT run reconcile without confirmation.\n\n\
                  Tools: get_execution_plan (preview execution), get_workflow_status (check progress), \
                  list_failed_jobs, get_job_logs, analyze_workflow_logs (scan all logs for errors), \
+                 check_offline_journals (detect offline-drain journals / whether reconcile is needed), \
                  check_resource_utilization, update_job_resources, \
                  analyze_resource_usage (per-job resource data for cluster analysis), \
                  regroup_job_resources (reassign jobs to new resource groups), \

--- a/src/mcp_server/tools.rs
+++ b/src/mcp_server/tools.rs
@@ -1000,6 +1000,22 @@ pub fn check_offline_journals(
 ) -> Result<CallToolResult, McpError> {
     use crate::client::offline_journal::OfflineJournal;
 
+    // Build a "nothing to reconcile" success response. Used both when the
+    // workflow has never run and when no journals are found.
+    let no_journals = |run_id: Option<i64>, summary: String| {
+        let response = serde_json::json!({
+            "workflow_id": workflow_id,
+            "run_id": run_id,
+            "base_dir": base_dir.display().to_string(),
+            "journals_found": 0,
+            "reconcile_needed": false,
+            "summary": summary,
+        });
+        Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+            serde_json::to_string_pretty(&response).unwrap_or_default(),
+        )]))
+    };
+
     // Resolve the run_id to match journals against. Default to the workflow's
     // current generation so we only recommend replaying journals for the run the
     // server still considers active (reconcile rejects superseded runs anyway).
@@ -1008,29 +1024,77 @@ pub fn check_offline_journals(
         None => {
             let workflow = apis::workflows_api::get_workflow(config, workflow_id)
                 .map_err(|e| internal_error(format!("Failed to get workflow: {}", e)))?;
-            workflow.run_id.ok_or_else(|| {
-                internal_error(format!(
-                    "Workflow {} has no run_id (it has not been run yet); nothing to reconcile",
-                    workflow_id
-                ))
-            })?
+            match workflow.run_id {
+                Some(rid) => rid,
+                // A workflow that has not been run yet has no run_id. This is a
+                // normal state, not an error: there is simply nothing to reconcile.
+                None => {
+                    return no_journals(
+                        None,
+                        format!(
+                            "Workflow {} has not been run yet (no run_id), so there are no offline-drain \
+                             journals to reconcile.",
+                            workflow_id
+                        ),
+                    );
+                }
+            }
         }
     };
 
     let files = OfflineJournal::discover(base_dir, workflow_id, run_id);
 
     if files.is_empty() {
-        let response = serde_json::json!({
-            "workflow_id": workflow_id,
-            "run_id": run_id,
-            "base_dir": base_dir.display().to_string(),
-            "journals_found": 0,
-            "reconcile_needed": false,
-            "summary": format!(
+        return no_journals(
+            Some(run_id),
+            format!(
                 "No offline-drain journals found for workflow_id={} run_id={} under {}. No reconcile needed.",
                 workflow_id,
                 run_id,
                 base_dir.display()
+            ),
+        );
+    }
+
+    // Count pending completions per journal (via SELECT COUNT(*), no payload
+    // deserialization) so the user can see how much work is waiting to be
+    // replayed. Unreadable journals are reported with a null count rather than
+    // failing the whole check.
+    let mut journal_details = Vec::new();
+    let mut total_completions = 0usize;
+    let mut unreadable = 0usize;
+    for path in &files {
+        let completions = OfflineJournal::count_file(path).ok();
+        match completions {
+            Some(n) => total_completions += n,
+            None => unreadable += 1,
+        }
+        journal_details.push(serde_json::json!({
+            "path": path.display().to_string(),
+            "completions": completions,
+        }));
+    }
+
+    // Only recommend reconcile when there is actually pending work, or when a
+    // journal could not be read (so its contents are unknown and worth checking).
+    // Empty journals (e.g. already flushed) need no action.
+    let reconcile_needed = total_completions > 0 || unreadable > 0;
+
+    if !reconcile_needed {
+        let response = serde_json::json!({
+            "workflow_id": workflow_id,
+            "run_id": run_id,
+            "base_dir": base_dir.display().to_string(),
+            "journals_found": files.len(),
+            "total_pending_completions": 0,
+            "journals": journal_details,
+            "reconcile_needed": false,
+            "summary": format!(
+                "Found {} offline-drain journal(s) for workflow_id={} run_id={}, but all are empty \
+                 (completions already flushed). No reconcile needed.",
+                files.len(),
+                workflow_id,
+                run_id
             ),
         });
         return Ok(CallToolResult::success(vec![rmcp::model::Content::text(
@@ -1038,27 +1102,11 @@ pub fn check_offline_journals(
         )]));
     }
 
-    // Count pending completions per journal so the user can see how much work is
-    // waiting to be replayed. Unreadable journals are reported with a null count
-    // rather than failing the whole check.
-    let mut journal_details = Vec::new();
-    let mut total_completions = 0usize;
-    for path in &files {
-        let count = OfflineJournal::read_file(path).map(|entries| entries.len());
-        if let Ok(n) = count {
-            total_completions += n;
-        }
-        journal_details.push(serde_json::json!({
-            "path": path.display().to_string(),
-            "completions": count.ok(),
-        }));
-    }
-
     let reconcile_command = format!(
         "torc workflows reconcile {} {} --base-dir {}",
         workflow_id,
         run_id,
-        base_dir.display()
+        shell_quote(&base_dir.display().to_string())
     );
 
     let response = serde_json::json!({
@@ -1067,6 +1115,7 @@ pub fn check_offline_journals(
         "base_dir": base_dir.display().to_string(),
         "journals_found": files.len(),
         "total_pending_completions": total_completions,
+        "unreadable_journals": unreadable,
         "journals": journal_details,
         "reconcile_needed": true,
         "reconcile_command": reconcile_command,
@@ -1091,6 +1140,20 @@ pub fn check_offline_journals(
     Ok(CallToolResult::success(vec![rmcp::model::Content::text(
         serde_json::to_string_pretty(&response).unwrap_or_default(),
     )]))
+}
+
+/// Quote a string for safe inclusion in a copy-pasteable POSIX shell command.
+/// Paths without shell-special characters are returned unchanged; otherwise the
+/// value is wrapped in single quotes with embedded single quotes escaped.
+fn shell_quote(s: &str) -> String {
+    let safe = !s.is_empty()
+        && s.bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-' | b'.' | b'/'));
+    if safe {
+        s.to_string()
+    } else {
+        format!("'{}'", s.replace('\'', "'\\''"))
+    }
 }
 
 /// Get workflow summary.

--- a/src/mcp_server/tools.rs
+++ b/src/mcp_server/tools.rs
@@ -984,6 +984,115 @@ pub fn analyze_workflow_logs(
     )]))
 }
 
+/// Detect offline-drain journals for a workflow and advise whether
+/// `torc workflows reconcile` should be run.
+///
+/// When a job runner loses contact with the server it journals completions to
+/// local SQLite files (see [`crate::client::offline_journal`]). Those completions
+/// are not reflected on the server until replayed, so a workflow can look stalled
+/// or partially failed when it actually finished offline. This tool only inspects
+/// the filesystem; it never replays anything.
+pub fn check_offline_journals(
+    config: &Configuration,
+    base_dir: &Path,
+    workflow_id: i64,
+    run_id: Option<i64>,
+) -> Result<CallToolResult, McpError> {
+    use crate::client::offline_journal::OfflineJournal;
+
+    // Resolve the run_id to match journals against. Default to the workflow's
+    // current generation so we only recommend replaying journals for the run the
+    // server still considers active (reconcile rejects superseded runs anyway).
+    let run_id = match run_id {
+        Some(rid) => rid,
+        None => {
+            let workflow = apis::workflows_api::get_workflow(config, workflow_id)
+                .map_err(|e| internal_error(format!("Failed to get workflow: {}", e)))?;
+            workflow.run_id.ok_or_else(|| {
+                internal_error(format!(
+                    "Workflow {} has no run_id (it has not been run yet); nothing to reconcile",
+                    workflow_id
+                ))
+            })?
+        }
+    };
+
+    let files = OfflineJournal::discover(base_dir, workflow_id, run_id);
+
+    if files.is_empty() {
+        let response = serde_json::json!({
+            "workflow_id": workflow_id,
+            "run_id": run_id,
+            "base_dir": base_dir.display().to_string(),
+            "journals_found": 0,
+            "reconcile_needed": false,
+            "summary": format!(
+                "No offline-drain journals found for workflow_id={} run_id={} under {}. No reconcile needed.",
+                workflow_id,
+                run_id,
+                base_dir.display()
+            ),
+        });
+        return Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+            serde_json::to_string_pretty(&response).unwrap_or_default(),
+        )]));
+    }
+
+    // Count pending completions per journal so the user can see how much work is
+    // waiting to be replayed. Unreadable journals are reported with a null count
+    // rather than failing the whole check.
+    let mut journal_details = Vec::new();
+    let mut total_completions = 0usize;
+    for path in &files {
+        let count = OfflineJournal::read_file(path).map(|entries| entries.len());
+        if let Ok(n) = count {
+            total_completions += n;
+        }
+        journal_details.push(serde_json::json!({
+            "path": path.display().to_string(),
+            "completions": count.ok(),
+        }));
+    }
+
+    let reconcile_command = format!(
+        "torc workflows reconcile {} {} --base-dir {}",
+        workflow_id,
+        run_id,
+        base_dir.display()
+    );
+
+    let response = serde_json::json!({
+        "workflow_id": workflow_id,
+        "run_id": run_id,
+        "base_dir": base_dir.display().to_string(),
+        "journals_found": files.len(),
+        "total_pending_completions": total_completions,
+        "journals": journal_details,
+        "reconcile_needed": true,
+        "reconcile_command": reconcile_command,
+        "summary": format!(
+            "Found {} offline-drain journal(s) with {} pending completion(s) for workflow_id={} run_id={}. \
+             These are job completions recorded locally while the server was unreachable and may not yet be \
+             reflected on the server.",
+            files.len(),
+            total_completions,
+            workflow_id,
+            run_id
+        ),
+        "recommendation": [
+            "These journals indicate the workflow ran (at least partly) in offline-drain mode.",
+            "Tell the user how many journals and pending completions were found.",
+            format!("Ask the user to confirm, then have them run: {}", reconcile_command),
+            "reconcile is idempotent and safe: the server rejects completions from a superseded run_id.",
+            "Do NOT run reconcile automatically without the user's confirmation."
+        ],
+    });
+
+    Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+        serde_json::to_string_pretty(&response).unwrap_or_default(),
+    )]))
+}
+
 /// Get workflow summary.
 pub fn get_workflow_summary(
     config: &Configuration,


### PR DESCRIPTION
## Summary

Closes two gaps in the guidance the MCP server gives to LLM clients.

### 1. RO-Crate / provenance on workflow creation
When a user asks for the **provenance** or **RO-Crate** feature, the generated workflow spec should set `enable_ro_crate: true` (a top-level `WorkflowSpec` field that already exists). Added this guidance to:
- the `create_workflow` tool description (new PROVENANCE / RO-CRATE block, including the optional per-file `identifier`)
- the server-level `with_instructions(...)` block

### 2. Offline-drain journals / `torc workflows reconcile` when debugging
When a runner loses contact with the server it enters offline-drain mode and journals completions to local SQLite files (`offline_results_wf<id>_r<run>_<label>.db`). Those completions aren't on the server until replayed, so a workflow can look stalled/incomplete when it actually finished.

Added a new **read-only** `check_offline_journals` MCP tool that:
- resolves the run_id (defaults to the workflow's current `run_id`)
- discovers journals under a base dir (defaults to the server output dir) via `OfflineJournal::discover`
- counts pending completions per journal
- returns the exact `torc workflows reconcile <id> <run> --base-dir <dir>` command and a recommendation to **prompt the user** before running it

The tool never runs reconcile itself. Server instructions now tell the agent to call it when debugging and to prompt the user if journals are found.

## Testing
- `cargo clippy --features mcp-server --bin torc-mcp-server -- -D warnings` ✅
- `cargo fmt -- --check` ✅
- pre-commit hooks (fmt, full clippy, dprint) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)