### PR TITLE
TUI runtime column + results CPU/log-path fixes

### DIFF
--- a/src/bin/torc-slurm-job-runner.rs
+++ b/src/bin/torc-slurm-job-runner.rs
@@ -405,10 +405,17 @@ mod unix_main {
         };
 
         let job_id_int: i64 = job_id.parse().unwrap_or(0);
+        // Record SLURM_NODEID and SLURM_TASK_PID alongside slurm_job_id so report
+        // tooling can rebuild log paths that match what was written above. The
+        // log filename uses these IDs, but compute_node.hostname/pid do not (hostname
+        // is the OS hostname, pid is the runner process — neither matches when
+        // SLURM_NODEID is something like "0" and SLURM_TASK_PID differs from PID).
         let scheduler = serde_json::json!({
             "scheduler_id": scheduler_id,
             "type": "slurm",
             "slurm_job_id": job_id_int,
+            "slurm_node_id": node_id,
+            "slurm_task_pid": task_pid,
         });
         let compute_node =
             create_compute_node(&config, args.workflow_id, &resources, &hostname, scheduler);

--- a/src/client/commands/reports.rs
+++ b/src/client/commands/reports.rs
@@ -719,16 +719,28 @@ pub fn build_results_report(
                         {
                             slurm_job_id = Some(slurm_job_id_str.to_string());
 
-                            // Build slurm job runner log path
-                            // Use hostname as node_id and pid as task_pid for the log path
-                            let node_id = &compute_node.hostname;
-                            let task_pid = compute_node.pid as usize;
+                            // Prefer the SLURM identifiers stored in the scheduler JSON
+                            // (added by torc-slurm-job-runner so the path matches what
+                            // it wrote). Fall back to hostname/pid for compute nodes
+                            // created before those fields were recorded.
+                            let node_id_owned = scheduler_value
+                                .get("slurm_node_id")
+                                .and_then(|v| {
+                                    v.as_str()
+                                        .map(|s| s.to_string())
+                                        .or_else(|| v.as_i64().map(|n| n.to_string()))
+                                })
+                                .unwrap_or_else(|| compute_node.hostname.clone());
+                            let task_pid = scheduler_value
+                                .get("slurm_task_pid")
+                                .and_then(|v| v.as_u64().map(|n| n as usize))
+                                .unwrap_or(compute_node.pid as usize);
 
                             let log_path = get_slurm_job_runner_log_file(
                                 output_dir.to_path_buf(),
                                 wf_id,
                                 slurm_job_id_str,
-                                node_id,
+                                &node_id_owned,
                                 task_pid,
                             );
                             check_log_file_exists(&log_path, "slurm job runner", job_id);

--- a/src/client/commands/results.rs
+++ b/src/client/commands/results.rs
@@ -76,8 +76,8 @@ struct ResultTableRow {
     exec_time: String,
     #[tabled(rename = "Peak Mem")]
     peak_memory: String,
-    #[tabled(rename = "Avg CPU %")]
-    avg_cpu: String,
+    #[tabled(rename = "Peak CPU %")]
+    peak_cpu: String,
     #[tabled(rename = "Completion Time")]
     completion_time: String,
     #[tabled(rename = "Status")]
@@ -283,7 +283,7 @@ pub fn handle_result_commands(config: &Configuration, command: &ResultCommands, 
                                 return_code: result.return_code,
                                 exec_time: format!("{:.2}", result.exec_time_minutes),
                                 peak_memory: format_memory(result.peak_memory_bytes),
-                                avg_cpu: format_cpu(result.avg_cpu_percent),
+                                peak_cpu: format_cpu(result.peak_cpu_percent),
                                 completion_time: result.completion_time.clone(),
                                 status: format!("{:?}", result.status),
                             })
@@ -318,6 +318,7 @@ pub fn handle_result_commands(config: &Configuration, command: &ResultCommands, 
                     // Display resource metrics if available
                     if result.peak_memory_bytes.is_some()
                         || result.avg_memory_bytes.is_some()
+                        || result.peak_cpu_percent.is_some()
                         || result.avg_cpu_percent.is_some()
                     {
                         println!("\n  Resource Metrics:");
@@ -326,6 +327,9 @@ pub fn handle_result_commands(config: &Configuration, command: &ResultCommands, 
                         }
                         if let Some(avg_mem) = result.avg_memory_bytes {
                             println!("    Avg Memory:  {}", format_memory(Some(avg_mem)));
+                        }
+                        if let Some(peak_cpu) = result.peak_cpu_percent {
+                            println!("    Peak CPU:    {}", format_cpu(Some(peak_cpu)));
                         }
                         if let Some(avg_cpu) = result.avg_cpu_percent {
                             println!("    Avg CPU:     {}", format_cpu(Some(avg_cpu)));

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -640,6 +640,12 @@ where
                     {
                         app.cycle_results_sort_peak_cpu();
                     }
+                    KeyCode::Char('E')
+                        if app.focus == Focus::Details
+                            && app.detail_view == DetailViewType::Results =>
+                    {
+                        app.cycle_results_sort_runtime();
+                    }
                     // Sort the Jobs table by column index 1=ID, 2=Name, 3=Status.
                     KeyCode::Char('1')
                         if app.focus == Focus::Details

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -277,6 +277,8 @@ pub enum ResultsSort {
     PeakMemoryAsc,
     PeakCpuDesc,
     PeakCpuAsc,
+    RuntimeDesc,
+    RuntimeAsc,
 }
 
 /// Sort state for the Jobs detail table. Number keys 1..3 cycle a single
@@ -356,6 +358,14 @@ impl ResultsSort {
         }
     }
 
+    pub fn cycle_runtime(self) -> Self {
+        match self {
+            Self::RuntimeDesc => Self::RuntimeAsc,
+            Self::RuntimeAsc => Self::None,
+            _ => Self::RuntimeDesc,
+        }
+    }
+
     /// Returns the arrow indicator for the Peak Memory column header.
     pub fn peak_memory_indicator(self) -> &'static str {
         match self {
@@ -369,6 +379,14 @@ impl ResultsSort {
         match self {
             Self::PeakCpuDesc => " ↓",
             Self::PeakCpuAsc => " ↑",
+            _ => "",
+        }
+    }
+
+    pub fn runtime_indicator(self) -> &'static str {
+        match self {
+            Self::RuntimeDesc => " ↓",
+            Self::RuntimeAsc => " ↑",
             _ => "",
         }
     }
@@ -1123,6 +1141,14 @@ impl App {
                         (None, None) => std::cmp::Ordering::Equal,
                     });
             }
+            ResultsSort::RuntimeDesc => {
+                self.results
+                    .sort_by(|a, b| b.exec_time_minutes.total_cmp(&a.exec_time_minutes));
+            }
+            ResultsSort::RuntimeAsc => {
+                self.results
+                    .sort_by(|a, b| a.exec_time_minutes.total_cmp(&b.exec_time_minutes));
+            }
         }
     }
 
@@ -1136,6 +1162,13 @@ impl App {
     pub fn cycle_results_sort_peak_cpu(&mut self) {
         let prev_id = self.selected_result_id();
         self.results_sort = self.results_sort.cycle_peak_cpu();
+        self.apply_results_sort();
+        self.restore_results_selection(prev_id);
+    }
+
+    pub fn cycle_results_sort_runtime(&mut self) {
+        let prev_id = self.selected_result_id();
+        self.results_sort = self.results_sort.cycle_runtime();
         self.apply_results_sort();
         self.restore_results_selection(prev_id);
     }

--- a/src/tui/components.rs
+++ b/src/tui/components.rs
@@ -551,6 +551,10 @@ impl HelpPopup {
             HelpContext::DetailResults => {
                 lines.extend(Self::section("Results Tab"));
                 lines.push(Self::key_line(
+                    "E",
+                    "Sort by Runtime (cycles desc / asc / off)",
+                ));
+                lines.push(Self::key_line(
                     "m",
                     "Sort by Peak Memory (cycles desc / asc / off)",
                 ));

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1024,6 +1024,7 @@ fn draw_results_table(f: &mut Frame, area: Rect, app: &mut App) {
 
     let peak_mem_header = format!("Peak Mem{}", app.results_sort.peak_memory_indicator());
     let peak_cpu_header = format!("Peak CPU %{}", app.results_sort.peak_cpu_indicator());
+    let runtime_header = format!("Runtime (m){}", app.results_sort.runtime_indicator());
     let header = Row::new(vec![
         "ID".to_string(),
         "Job ID".to_string(),
@@ -1031,6 +1032,7 @@ fn draw_results_table(f: &mut Frame, area: Rect, app: &mut App) {
         "Attempt".to_string(),
         "Return".to_string(),
         "Status".to_string(),
+        runtime_header,
         peak_mem_header,
         peak_cpu_header,
     ])
@@ -1044,6 +1046,8 @@ fn draw_results_table(f: &mut Frame, area: Rect, app: &mut App) {
         let attempt_id = result.attempt_id.unwrap_or(1).to_string();
         let return_code = result.return_code;
         let status = format!("{:?}", result.status);
+
+        let runtime = format!("{:.2}", result.exec_time_minutes);
 
         // Format peak memory (bytes to human readable)
         let peak_mem = result
@@ -1073,6 +1077,7 @@ fn draw_results_table(f: &mut Frame, area: Rect, app: &mut App) {
                 Style::default().fg(row_color),
             )),
             Cell::from(Span::styled(status, Style::default().fg(row_color))),
+            Cell::from(runtime),
             Cell::from(peak_mem),
             Cell::from(peak_cpu),
         ])
@@ -1108,6 +1113,7 @@ fn draw_results_table(f: &mut Frame, area: Rect, app: &mut App) {
             Constraint::Length(7),  // Attempt
             Constraint::Length(7),  // Return
             Constraint::Length(12), // Status
+            Constraint::Length(13), // Runtime (m) (+ optional sort indicator)
             Constraint::Length(11), // Peak Mem (+ optional sort indicator)
             Constraint::Length(13), // Peak CPU % (+ optional sort indicator)
         ],


### PR DESCRIPTION
## Summary

Three small, independent fixes bundled together:

- **Fix slurm job runner log path lookup in reports** — `torc results list --include-logs` printed spurious "log file does not exist" warnings on Dane because the runner writes its log filename from `SLURM_NODEID`/`SLURM_TASK_PID` while reports rebuilt it from `compute_node.hostname`/`compute_node.pid`. Stash the real SLURM ids in the scheduler JSON so reports can rebuild the exact filename; fall back to the old behavior for compute nodes created before this change.
- **Show job runtime in TUI Results tab** — adds a `Runtime (m)` column (populated from `exec_time_minutes`, formatted like the CLI's "Exec Time"), with `E` as the sort hotkey (cycles desc/asc/off, matching `m` and `p`).
- **Show Peak CPU (not Avg CPU) in `torc results list`/`get`** — the column was renamed to "Avg CPU %" in #199 when sstat polling was disabled by default, but `peak_cpu_percent` is always populated (sacct backfill copies avg into peak as a fallback). Pairs naturally with Peak Mem and matches the TUI.

## Test plan

- [ ] `torc results list --include-logs` on Dane no longer prints "slurm job runner log file does not exist" warnings for runs created after this change
- [ ] TUI Results tab shows a `Runtime (m)` column and `E` cycles its sort
- [ ] `torc results list` shows `Peak CPU %`; `torc results get <id>` shows both `Peak CPU` and `Avg CPU`
- [ ] Old workflows (no `slurm_node_id`/`slurm_task_pid` in scheduler JSON) still resolve a log path via the hostname/pid fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)