### PR TITLE
TUI pagination/sorting + server-side jobs filtering, plus CLI fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -347,6 +347,15 @@ cascade-delete the entire database contents.
 - Generated Rust surfaces should not be hand-edited. Keep deterministic post-processing under the
   Rust-owned OpenAPI workflow under `api/sync_openapi.sh`.
 - Implement business logic in non-generated modules (e.g., `server/src/bin/server/api/*.rs`)
+- Client regeneration (`sync_openapi.sh clients`, `regenerate_clients.sh`,
+  `regenerate_rust_client.sh`, `check_client_codegen_parity.sh`) runs the `openapi-generator-cli`
+  container. The scripts honor `CONTAINER_EXEC` (default `docker`). **If Docker is unavailable, use
+  Podman:** prefix the command with `CONTAINER_EXEC=podman`, e.g.
+  `cd api && CONTAINER_EXEC=podman bash sync_openapi.sh clients`. Podman is CLI-compatible with the
+  scripts' `run -v … <image> generate …` invocation and pulls the right arch from the pinned
+  multi-arch digest. On macOS a Linux VM must be running first
+  (`podman machine init && podman machine start`); host paths under `$HOME` are shared by default.
+  The `emit`/`check`/`promote` subcommands are pure `cargo` and need no container.
 
 ### Documentation Build
 

--- a/api/openapi.codegen.yaml
+++ b/api/openapi.codegen.yaml
@@ -1385,7 +1385,9 @@ paths:
           - 'null'
       - name: name
         in: query
-        description: Case-sensitive substring filter on the job name (SQL `LIKE %value%`).
+        description: |-
+          Substring filter on the job name (SQL `LIKE %value%`, case-insensitive
+          for ASCII).
         required: false
         schema:
           type:
@@ -1393,7 +1395,9 @@ paths:
           - 'null'
       - name: command
         in: query
-        description: Case-sensitive substring filter on the job command (SQL `LIKE %value%`).
+        description: |-
+          Substring filter on the job command (SQL `LIKE %value%`, case-insensitive
+          for ASCII).
         required: false
         schema:
           type:

--- a/api/openapi.codegen.yaml
+++ b/api/openapi.codegen.yaml
@@ -1383,6 +1383,22 @@ paths:
           type:
           - boolean
           - 'null'
+      - name: name
+        in: query
+        description: Case-sensitive substring filter on the job name (SQL `LIKE %value%`).
+        required: false
+        schema:
+          type:
+          - string
+          - 'null'
+      - name: command
+        in: query
+        description: Case-sensitive substring filter on the job command (SQL `LIKE %value%`).
+        required: false
+        schema:
+          type:
+          - string
+          - 'null'
       responses:
         '200':
           description: Successful response

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1385,7 +1385,9 @@ paths:
           - 'null'
       - name: name
         in: query
-        description: Case-sensitive substring filter on the job name (SQL `LIKE %value%`).
+        description: |-
+          Substring filter on the job name (SQL `LIKE %value%`, case-insensitive
+          for ASCII).
         required: false
         schema:
           type:
@@ -1393,7 +1395,9 @@ paths:
           - 'null'
       - name: command
         in: query
-        description: Case-sensitive substring filter on the job command (SQL `LIKE %value%`).
+        description: |-
+          Substring filter on the job command (SQL `LIKE %value%`, case-insensitive
+          for ASCII).
         required: false
         schema:
           type:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1383,6 +1383,22 @@ paths:
           type:
           - boolean
           - 'null'
+      - name: name
+        in: query
+        description: Case-sensitive substring filter on the job name (SQL `LIKE %value%`).
+        required: false
+        schema:
+          type:
+          - string
+          - 'null'
+      - name: command
+        in: query
+        description: Case-sensitive substring filter on the job command (SQL `LIKE %value%`).
+        required: false
+        schema:
+          type:
+          - string
+          - 'null'
       responses:
         '200':
           description: Successful response

--- a/julia_client/Torc/src/api/apis/api_JobsApi.jl
+++ b/julia_client/Torc/src/api/apis/api_JobsApi.jl
@@ -203,7 +203,7 @@ const _returntypes_list_jobs_JobsApi = Dict{Regex,Type}(
     Regex("^" * replace("500", "x"=>".") * "\$") => ErrorResponse,
 )
 
-function _oacinternal_list_jobs(_api::JobsApi, workflow_id::Int64; status=nothing, needs_file_id=nothing, upstream_job_id=nothing, offset=nothing, limit=nothing, sort_by=nothing, reverse_sort=nothing, include_relationships=nothing, active_compute_node_id=nothing, origin_is_set=nothing, _mediaType=nothing)
+function _oacinternal_list_jobs(_api::JobsApi, workflow_id::Int64; status=nothing, needs_file_id=nothing, upstream_job_id=nothing, offset=nothing, limit=nothing, sort_by=nothing, reverse_sort=nothing, include_relationships=nothing, active_compute_node_id=nothing, origin_is_set=nothing, name=nothing, command=nothing, _mediaType=nothing)
     _ctx = OpenAPI.Clients.Ctx(_api.client, "GET", _returntypes_list_jobs_JobsApi, "/jobs", [])
     OpenAPI.Clients.set_param(_ctx.query, "workflow_id", workflow_id; style="form", is_explode=true)  # type Int64
     OpenAPI.Clients.set_param(_ctx.query, "status", status; style="form", is_explode=true)  # type JobStatus
@@ -216,6 +216,8 @@ function _oacinternal_list_jobs(_api::JobsApi, workflow_id::Int64; status=nothin
     OpenAPI.Clients.set_param(_ctx.query, "include_relationships", include_relationships; style="form", is_explode=true)  # type Bool
     OpenAPI.Clients.set_param(_ctx.query, "active_compute_node_id", active_compute_node_id; style="form", is_explode=true)  # type Int64
     OpenAPI.Clients.set_param(_ctx.query, "origin_is_set", origin_is_set; style="form", is_explode=true)  # type Bool
+    OpenAPI.Clients.set_param(_ctx.query, "name", name; style="form", is_explode=true)  # type String
+    OpenAPI.Clients.set_param(_ctx.query, "command", command; style="form", is_explode=true)  # type String
     OpenAPI.Clients.set_header_accept(_ctx, ["application/json", ])
     OpenAPI.Clients.set_header_content_type(_ctx, (_mediaType === nothing) ? [] : [_mediaType])
     return _ctx
@@ -233,16 +235,18 @@ end
 - include_relationships::Bool
 - active_compute_node_id::Int64
 - origin_is_set::Bool
+- name::String
+- command::String
 
 Return: ListJobsResponse, OpenAPI.Clients.ApiResponse
 """
-function list_jobs(_api::JobsApi, workflow_id::Int64; status=nothing, needs_file_id=nothing, upstream_job_id=nothing, offset=nothing, limit=nothing, sort_by=nothing, reverse_sort=nothing, include_relationships=nothing, active_compute_node_id=nothing, origin_is_set=nothing, _mediaType=nothing)
-    _ctx = _oacinternal_list_jobs(_api, workflow_id; status=status, needs_file_id=needs_file_id, upstream_job_id=upstream_job_id, offset=offset, limit=limit, sort_by=sort_by, reverse_sort=reverse_sort, include_relationships=include_relationships, active_compute_node_id=active_compute_node_id, origin_is_set=origin_is_set, _mediaType=_mediaType)
+function list_jobs(_api::JobsApi, workflow_id::Int64; status=nothing, needs_file_id=nothing, upstream_job_id=nothing, offset=nothing, limit=nothing, sort_by=nothing, reverse_sort=nothing, include_relationships=nothing, active_compute_node_id=nothing, origin_is_set=nothing, name=nothing, command=nothing, _mediaType=nothing)
+    _ctx = _oacinternal_list_jobs(_api, workflow_id; status=status, needs_file_id=needs_file_id, upstream_job_id=upstream_job_id, offset=offset, limit=limit, sort_by=sort_by, reverse_sort=reverse_sort, include_relationships=include_relationships, active_compute_node_id=active_compute_node_id, origin_is_set=origin_is_set, name=name, command=command, _mediaType=_mediaType)
     return OpenAPI.Clients.exec(_ctx)
 end
 
-function list_jobs(_api::JobsApi, response_stream::Channel, workflow_id::Int64; status=nothing, needs_file_id=nothing, upstream_job_id=nothing, offset=nothing, limit=nothing, sort_by=nothing, reverse_sort=nothing, include_relationships=nothing, active_compute_node_id=nothing, origin_is_set=nothing, _mediaType=nothing)
-    _ctx = _oacinternal_list_jobs(_api, workflow_id; status=status, needs_file_id=needs_file_id, upstream_job_id=upstream_job_id, offset=offset, limit=limit, sort_by=sort_by, reverse_sort=reverse_sort, include_relationships=include_relationships, active_compute_node_id=active_compute_node_id, origin_is_set=origin_is_set, _mediaType=_mediaType)
+function list_jobs(_api::JobsApi, response_stream::Channel, workflow_id::Int64; status=nothing, needs_file_id=nothing, upstream_job_id=nothing, offset=nothing, limit=nothing, sort_by=nothing, reverse_sort=nothing, include_relationships=nothing, active_compute_node_id=nothing, origin_is_set=nothing, name=nothing, command=nothing, _mediaType=nothing)
+    _ctx = _oacinternal_list_jobs(_api, workflow_id; status=status, needs_file_id=needs_file_id, upstream_job_id=upstream_job_id, offset=offset, limit=limit, sort_by=sort_by, reverse_sort=reverse_sort, include_relationships=include_relationships, active_compute_node_id=active_compute_node_id, origin_is_set=origin_is_set, name=name, command=command, _mediaType=_mediaType)
     return OpenAPI.Clients.exec(_ctx, response_stream)
 end
 

--- a/julia_client/julia_client/docs/JobsApi.md
+++ b/julia_client/julia_client/docs/JobsApi.md
@@ -190,8 +190,8 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **list_jobs**
-> list_jobs(_api::JobsApi, workflow_id::Int64; status=nothing, needs_file_id=nothing, upstream_job_id=nothing, offset=nothing, limit=nothing, sort_by=nothing, reverse_sort=nothing, include_relationships=nothing, active_compute_node_id=nothing, origin_is_set=nothing, _mediaType=nothing) -> ListJobsResponse, OpenAPI.Clients.ApiResponse <br/>
-> list_jobs(_api::JobsApi, response_stream::Channel, workflow_id::Int64; status=nothing, needs_file_id=nothing, upstream_job_id=nothing, offset=nothing, limit=nothing, sort_by=nothing, reverse_sort=nothing, include_relationships=nothing, active_compute_node_id=nothing, origin_is_set=nothing, _mediaType=nothing) -> Channel{ ListJobsResponse }, OpenAPI.Clients.ApiResponse
+> list_jobs(_api::JobsApi, workflow_id::Int64; status=nothing, needs_file_id=nothing, upstream_job_id=nothing, offset=nothing, limit=nothing, sort_by=nothing, reverse_sort=nothing, include_relationships=nothing, active_compute_node_id=nothing, origin_is_set=nothing, name=nothing, command=nothing, _mediaType=nothing) -> ListJobsResponse, OpenAPI.Clients.ApiResponse <br/>
+> list_jobs(_api::JobsApi, response_stream::Channel, workflow_id::Int64; status=nothing, needs_file_id=nothing, upstream_job_id=nothing, offset=nothing, limit=nothing, sort_by=nothing, reverse_sort=nothing, include_relationships=nothing, active_compute_node_id=nothing, origin_is_set=nothing, name=nothing, command=nothing, _mediaType=nothing) -> Channel{ ListJobsResponse }, OpenAPI.Clients.ApiResponse
 
 
 
@@ -216,6 +216,8 @@ Name | Type | Description  | Notes
  **include_relationships** | **Bool** |  | [default to nothing]
  **active_compute_node_id** | **Int64** |  | [default to nothing]
  **origin_is_set** | **Bool** | When set, filters by job provenance: &#x60;true&#x60; returns only jobs with &#x60;origin IS NOT NULL&#x60; (failure-handler retries and &#x60;spawn_jobs&#x60; children); &#x60;false&#x60; returns only originally-declared jobs. Used by &#x60;torc watch --auto-schedule&#x60; to count jobs needing unplanned Slurm allocations with &#x60;limit&#x3D;1&#x60; (the response&#39;s &#x60;total_count&#x60; suffices — no rows downloaded). | [default to nothing]
+ **name** | **String** | Case-sensitive substring filter on the job name (SQL &#x60;LIKE %value%&#x60;). | [default to nothing]
+ **command** | **String** | Case-sensitive substring filter on the job command (SQL &#x60;LIKE %value%&#x60;). | [default to nothing]
 
 ### Return type
 

--- a/julia_client/julia_client/docs/JobsApi.md
+++ b/julia_client/julia_client/docs/JobsApi.md
@@ -216,8 +216,8 @@ Name | Type | Description  | Notes
  **include_relationships** | **Bool** |  | [default to nothing]
  **active_compute_node_id** | **Int64** |  | [default to nothing]
  **origin_is_set** | **Bool** | When set, filters by job provenance: &#x60;true&#x60; returns only jobs with &#x60;origin IS NOT NULL&#x60; (failure-handler retries and &#x60;spawn_jobs&#x60; children); &#x60;false&#x60; returns only originally-declared jobs. Used by &#x60;torc watch --auto-schedule&#x60; to count jobs needing unplanned Slurm allocations with &#x60;limit&#x3D;1&#x60; (the response&#39;s &#x60;total_count&#x60; suffices — no rows downloaded). | [default to nothing]
- **name** | **String** | Case-sensitive substring filter on the job name (SQL &#x60;LIKE %value%&#x60;). | [default to nothing]
- **command** | **String** | Case-sensitive substring filter on the job command (SQL &#x60;LIKE %value%&#x60;). | [default to nothing]
+ **name** | **String** | Substring filter on the job name (SQL &#x60;LIKE %value%&#x60;, case-insensitive for ASCII). | [default to nothing]
+ **command** | **String** | Substring filter on the job command (SQL &#x60;LIKE %value%&#x60;, case-insensitive for ASCII). | [default to nothing]
 
 ### Return type
 

--- a/python_client/src/torc/openapi_client/api/jobs_api.py
+++ b/python_client/src/torc/openapi_client/api/jobs_api.py
@@ -1749,6 +1749,8 @@ class JobsApi:
         include_relationships: Optional[StrictBool] = None,
         active_compute_node_id: Optional[StrictInt] = None,
         origin_is_set: Annotated[Optional[StrictBool], Field(description="When set, filters by job provenance: `true` returns only jobs with `origin IS NOT NULL` (failure-handler retries and `spawn_jobs` children); `false` returns only originally-declared jobs. Used by `torc watch --auto-schedule` to count jobs needing unplanned Slurm allocations with `limit=1` (the response's `total_count` suffices — no rows downloaded).")] = None,
+        name: Annotated[Optional[StrictStr], Field(description="Case-sensitive substring filter on the job name (SQL `LIKE %value%`).")] = None,
+        command: Annotated[Optional[StrictStr], Field(description="Case-sensitive substring filter on the job command (SQL `LIKE %value%`).")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1787,6 +1789,10 @@ class JobsApi:
         :type active_compute_node_id: int
         :param origin_is_set: When set, filters by job provenance: `true` returns only jobs with `origin IS NOT NULL` (failure-handler retries and `spawn_jobs` children); `false` returns only originally-declared jobs. Used by `torc watch --auto-schedule` to count jobs needing unplanned Slurm allocations with `limit=1` (the response's `total_count` suffices — no rows downloaded).
         :type origin_is_set: bool
+        :param name: Case-sensitive substring filter on the job name (SQL `LIKE %value%`).
+        :type name: str
+        :param command: Case-sensitive substring filter on the job command (SQL `LIKE %value%`).
+        :type command: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1821,6 +1827,8 @@ class JobsApi:
             include_relationships=include_relationships,
             active_compute_node_id=active_compute_node_id,
             origin_is_set=origin_is_set,
+            name=name,
+            command=command,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1858,6 +1866,8 @@ class JobsApi:
         include_relationships: Optional[StrictBool] = None,
         active_compute_node_id: Optional[StrictInt] = None,
         origin_is_set: Annotated[Optional[StrictBool], Field(description="When set, filters by job provenance: `true` returns only jobs with `origin IS NOT NULL` (failure-handler retries and `spawn_jobs` children); `false` returns only originally-declared jobs. Used by `torc watch --auto-schedule` to count jobs needing unplanned Slurm allocations with `limit=1` (the response's `total_count` suffices — no rows downloaded).")] = None,
+        name: Annotated[Optional[StrictStr], Field(description="Case-sensitive substring filter on the job name (SQL `LIKE %value%`).")] = None,
+        command: Annotated[Optional[StrictStr], Field(description="Case-sensitive substring filter on the job command (SQL `LIKE %value%`).")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1896,6 +1906,10 @@ class JobsApi:
         :type active_compute_node_id: int
         :param origin_is_set: When set, filters by job provenance: `true` returns only jobs with `origin IS NOT NULL` (failure-handler retries and `spawn_jobs` children); `false` returns only originally-declared jobs. Used by `torc watch --auto-schedule` to count jobs needing unplanned Slurm allocations with `limit=1` (the response's `total_count` suffices — no rows downloaded).
         :type origin_is_set: bool
+        :param name: Case-sensitive substring filter on the job name (SQL `LIKE %value%`).
+        :type name: str
+        :param command: Case-sensitive substring filter on the job command (SQL `LIKE %value%`).
+        :type command: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1930,6 +1944,8 @@ class JobsApi:
             include_relationships=include_relationships,
             active_compute_node_id=active_compute_node_id,
             origin_is_set=origin_is_set,
+            name=name,
+            command=command,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1967,6 +1983,8 @@ class JobsApi:
         include_relationships: Optional[StrictBool] = None,
         active_compute_node_id: Optional[StrictInt] = None,
         origin_is_set: Annotated[Optional[StrictBool], Field(description="When set, filters by job provenance: `true` returns only jobs with `origin IS NOT NULL` (failure-handler retries and `spawn_jobs` children); `false` returns only originally-declared jobs. Used by `torc watch --auto-schedule` to count jobs needing unplanned Slurm allocations with `limit=1` (the response's `total_count` suffices — no rows downloaded).")] = None,
+        name: Annotated[Optional[StrictStr], Field(description="Case-sensitive substring filter on the job name (SQL `LIKE %value%`).")] = None,
+        command: Annotated[Optional[StrictStr], Field(description="Case-sensitive substring filter on the job command (SQL `LIKE %value%`).")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -2005,6 +2023,10 @@ class JobsApi:
         :type active_compute_node_id: int
         :param origin_is_set: When set, filters by job provenance: `true` returns only jobs with `origin IS NOT NULL` (failure-handler retries and `spawn_jobs` children); `false` returns only originally-declared jobs. Used by `torc watch --auto-schedule` to count jobs needing unplanned Slurm allocations with `limit=1` (the response's `total_count` suffices — no rows downloaded).
         :type origin_is_set: bool
+        :param name: Case-sensitive substring filter on the job name (SQL `LIKE %value%`).
+        :type name: str
+        :param command: Case-sensitive substring filter on the job command (SQL `LIKE %value%`).
+        :type command: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -2039,6 +2061,8 @@ class JobsApi:
             include_relationships=include_relationships,
             active_compute_node_id=active_compute_node_id,
             origin_is_set=origin_is_set,
+            name=name,
+            command=command,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -2071,6 +2095,8 @@ class JobsApi:
         include_relationships,
         active_compute_node_id,
         origin_is_set,
+        name,
+        command,
         _request_auth,
         _content_type,
         _headers,
@@ -2136,6 +2162,14 @@ class JobsApi:
         if origin_is_set is not None:
             
             _query_params.append(('origin_is_set', origin_is_set))
+            
+        if name is not None:
+            
+            _query_params.append(('name', name))
+            
+        if command is not None:
+            
+            _query_params.append(('command', command))
             
         # process the header parameters
         # process the form parameters

--- a/python_client/src/torc/openapi_client/api/jobs_api.py
+++ b/python_client/src/torc/openapi_client/api/jobs_api.py
@@ -1749,8 +1749,8 @@ class JobsApi:
         include_relationships: Optional[StrictBool] = None,
         active_compute_node_id: Optional[StrictInt] = None,
         origin_is_set: Annotated[Optional[StrictBool], Field(description="When set, filters by job provenance: `true` returns only jobs with `origin IS NOT NULL` (failure-handler retries and `spawn_jobs` children); `false` returns only originally-declared jobs. Used by `torc watch --auto-schedule` to count jobs needing unplanned Slurm allocations with `limit=1` (the response's `total_count` suffices — no rows downloaded).")] = None,
-        name: Annotated[Optional[StrictStr], Field(description="Case-sensitive substring filter on the job name (SQL `LIKE %value%`).")] = None,
-        command: Annotated[Optional[StrictStr], Field(description="Case-sensitive substring filter on the job command (SQL `LIKE %value%`).")] = None,
+        name: Annotated[Optional[StrictStr], Field(description="Substring filter on the job name (SQL `LIKE %value%`, case-insensitive for ASCII).")] = None,
+        command: Annotated[Optional[StrictStr], Field(description="Substring filter on the job command (SQL `LIKE %value%`, case-insensitive for ASCII).")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1789,9 +1789,9 @@ class JobsApi:
         :type active_compute_node_id: int
         :param origin_is_set: When set, filters by job provenance: `true` returns only jobs with `origin IS NOT NULL` (failure-handler retries and `spawn_jobs` children); `false` returns only originally-declared jobs. Used by `torc watch --auto-schedule` to count jobs needing unplanned Slurm allocations with `limit=1` (the response's `total_count` suffices — no rows downloaded).
         :type origin_is_set: bool
-        :param name: Case-sensitive substring filter on the job name (SQL `LIKE %value%`).
+        :param name: Substring filter on the job name (SQL `LIKE %value%`, case-insensitive for ASCII).
         :type name: str
-        :param command: Case-sensitive substring filter on the job command (SQL `LIKE %value%`).
+        :param command: Substring filter on the job command (SQL `LIKE %value%`, case-insensitive for ASCII).
         :type command: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
@@ -1866,8 +1866,8 @@ class JobsApi:
         include_relationships: Optional[StrictBool] = None,
         active_compute_node_id: Optional[StrictInt] = None,
         origin_is_set: Annotated[Optional[StrictBool], Field(description="When set, filters by job provenance: `true` returns only jobs with `origin IS NOT NULL` (failure-handler retries and `spawn_jobs` children); `false` returns only originally-declared jobs. Used by `torc watch --auto-schedule` to count jobs needing unplanned Slurm allocations with `limit=1` (the response's `total_count` suffices — no rows downloaded).")] = None,
-        name: Annotated[Optional[StrictStr], Field(description="Case-sensitive substring filter on the job name (SQL `LIKE %value%`).")] = None,
-        command: Annotated[Optional[StrictStr], Field(description="Case-sensitive substring filter on the job command (SQL `LIKE %value%`).")] = None,
+        name: Annotated[Optional[StrictStr], Field(description="Substring filter on the job name (SQL `LIKE %value%`, case-insensitive for ASCII).")] = None,
+        command: Annotated[Optional[StrictStr], Field(description="Substring filter on the job command (SQL `LIKE %value%`, case-insensitive for ASCII).")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1906,9 +1906,9 @@ class JobsApi:
         :type active_compute_node_id: int
         :param origin_is_set: When set, filters by job provenance: `true` returns only jobs with `origin IS NOT NULL` (failure-handler retries and `spawn_jobs` children); `false` returns only originally-declared jobs. Used by `torc watch --auto-schedule` to count jobs needing unplanned Slurm allocations with `limit=1` (the response's `total_count` suffices — no rows downloaded).
         :type origin_is_set: bool
-        :param name: Case-sensitive substring filter on the job name (SQL `LIKE %value%`).
+        :param name: Substring filter on the job name (SQL `LIKE %value%`, case-insensitive for ASCII).
         :type name: str
-        :param command: Case-sensitive substring filter on the job command (SQL `LIKE %value%`).
+        :param command: Substring filter on the job command (SQL `LIKE %value%`, case-insensitive for ASCII).
         :type command: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
@@ -1983,8 +1983,8 @@ class JobsApi:
         include_relationships: Optional[StrictBool] = None,
         active_compute_node_id: Optional[StrictInt] = None,
         origin_is_set: Annotated[Optional[StrictBool], Field(description="When set, filters by job provenance: `true` returns only jobs with `origin IS NOT NULL` (failure-handler retries and `spawn_jobs` children); `false` returns only originally-declared jobs. Used by `torc watch --auto-schedule` to count jobs needing unplanned Slurm allocations with `limit=1` (the response's `total_count` suffices — no rows downloaded).")] = None,
-        name: Annotated[Optional[StrictStr], Field(description="Case-sensitive substring filter on the job name (SQL `LIKE %value%`).")] = None,
-        command: Annotated[Optional[StrictStr], Field(description="Case-sensitive substring filter on the job command (SQL `LIKE %value%`).")] = None,
+        name: Annotated[Optional[StrictStr], Field(description="Substring filter on the job name (SQL `LIKE %value%`, case-insensitive for ASCII).")] = None,
+        command: Annotated[Optional[StrictStr], Field(description="Substring filter on the job command (SQL `LIKE %value%`, case-insensitive for ASCII).")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -2023,9 +2023,9 @@ class JobsApi:
         :type active_compute_node_id: int
         :param origin_is_set: When set, filters by job provenance: `true` returns only jobs with `origin IS NOT NULL` (failure-handler retries and `spawn_jobs` children); `false` returns only originally-declared jobs. Used by `torc watch --auto-schedule` to count jobs needing unplanned Slurm allocations with `limit=1` (the response's `total_count` suffices — no rows downloaded).
         :type origin_is_set: bool
-        :param name: Case-sensitive substring filter on the job name (SQL `LIKE %value%`).
+        :param name: Substring filter on the job name (SQL `LIKE %value%`, case-insensitive for ASCII).
         :type name: str
-        :param command: Case-sensitive substring filter on the job command (SQL `LIKE %value%`).
+        :param command: Substring filter on the job command (SQL `LIKE %value%`, case-insensitive for ASCII).
         :type command: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request

--- a/src/client/apis/jobs_api.rs
+++ b/src/client/apis/jobs_api.rs
@@ -489,6 +489,8 @@ pub fn list_jobs(
     include_relationships: Option<bool>,
     active_compute_node_id: Option<i64>,
     origin_is_set: Option<bool>,
+    name: Option<&str>,
+    command: Option<&str>,
 ) -> Result<models::ListJobsResponse, Error<ListJobsError>> {
     // add a prefix to parameters to efficiently prevent name collisions
     let p_query_workflow_id = workflow_id;
@@ -502,6 +504,8 @@ pub fn list_jobs(
     let p_query_include_relationships = include_relationships;
     let p_query_active_compute_node_id = active_compute_node_id;
     let p_query_origin_is_set = origin_is_set;
+    let p_query_name = name;
+    let p_query_command = command;
 
     let uri_str = format!("{}/jobs", configuration.base_path);
     let mut req_builder = configuration.client.request(reqwest::Method::GET, &uri_str);
@@ -536,6 +540,12 @@ pub fn list_jobs(
     }
     if let Some(ref param_value) = p_query_origin_is_set {
         req_builder = req_builder.query(&[("origin_is_set", &param_value.to_string())]);
+    }
+    if let Some(ref param_value) = p_query_name {
+        req_builder = req_builder.query(&[("name", &param_value.to_string())]);
+    }
+    if let Some(ref param_value) = p_query_command {
+        req_builder = req_builder.query(&[("command", &param_value.to_string())]);
     }
     if let Some(ref user_agent) = configuration.user_agent {
         req_builder = req_builder.header(reqwest::header::USER_AGENT, user_agent.clone());

--- a/src/client/commands/jobs.rs
+++ b/src/client/commands/jobs.rs
@@ -543,6 +543,7 @@ pub fn handle_job_commands(config: &Configuration, command: &JobCommands, format
                     println!("  Command: {}", job.command);
                     println!("  Workflow ID: {}", job.workflow_id);
                     println!("  Status: {}", status);
+                    println!("  Priority: {}", job.priority.unwrap_or(0));
                     println!(
                         "  Blocking job IDs: {}",
                         job.depends_on_job_ids
@@ -792,6 +793,8 @@ pub fn handle_job_commands(config: &Configuration, command: &JobCommands, format
                 None,    // include_relationships
                 None,    // active_compute_node_id
                 None,    // origin_is_set
+                None,    // name
+                None,    // command
             ) {
                 Ok(response) => {
                     let job_count = response.total_count;
@@ -1243,6 +1246,8 @@ pub fn get_current_job_count(
         None,    // include_relationships
         None,    // active_compute_node_id
         None,    // origin_is_set
+        None,    // name
+        None,    // command
     )
     .map_err(|e| format!("Failed to get job count: {:?}", e))?;
 
@@ -1272,6 +1277,8 @@ pub fn get_existing_job_names(
             None, // include_relationships
             None, // active_compute_node_id
             None, // origin_is_set
+            None, // name
+            None, // command
         )
         .map_err(|e| format!("Failed to get existing job names: {:?}", e))?;
 

--- a/src/client/commands/pagination/jobs.rs
+++ b/src/client/commands/pagination/jobs.rs
@@ -138,6 +138,8 @@ impl Paginatable for JobModel {
             params.include_relationships,
             params.active_compute_node_id,
             params.origin_is_set,
+            None, // name
+            None, // command
         )?;
 
         Ok(PaginatedResponse {

--- a/src/client/commands/recover.rs
+++ b/src/client/commands/recover.rs
@@ -486,6 +486,8 @@ fn check_recovery_preconditions(config: &Configuration, workflow_id: i64) -> Res
         None,                                   // include_relationships
         None,                                   // active_compute_node_id
         None,                                   // origin_is_set
+        None,                                   // name
+        None,                                   // command
     )
     .map_err(|e| format!("Failed to list failed jobs: {}", e))?;
 
@@ -502,6 +504,8 @@ fn check_recovery_preconditions(config: &Configuration, workflow_id: i64) -> Res
         None,                                       // include_relationships
         None,                                       // active_compute_node_id
         None,                                       // origin_is_set
+        None,                                       // name
+        None,                                       // command
     )
     .map_err(|e| format!("Failed to list terminated jobs: {}", e))?;
 
@@ -658,6 +662,8 @@ fn count_pending_failed_jobs(config: &Configuration, workflow_id: i64) -> Result
         None,    // include_relationships
         None,    // active_compute_node_id
         None,    // origin_is_set
+        None,    // name
+        None,    // command
     )
     .map_err(|e| format!("Failed to list pending_failed jobs: {}", e))?;
 

--- a/src/client/commands/watch.rs
+++ b/src/client/commands/watch.rs
@@ -164,6 +164,8 @@ fn count_ready_unplanned_jobs(
         None,
         None,
         None,
+        None, // name
+        None, // command
     )
     .map_err(|e| format!("Failed to count ready jobs: {}", e))?
     .total_count;
@@ -181,6 +183,8 @@ fn count_ready_unplanned_jobs(
         None,
         None,
         Some(true),
+        None, // name
+        None, // command
     )
     .map_err(|e| format!("Failed to count unplanned ready jobs: {}", e))?
     .total_count;

--- a/src/client/commands/workflows.rs
+++ b/src/client/commands/workflows.rs
@@ -2546,8 +2546,8 @@ fn handle_get(config: &Configuration, id: &Option<i64>, user: &str, format: &str
                         println!("    {}: {}", key, value_str);
                     }
                 }
-                if let Some(config) = &workflow.execution_config
-                    && let Ok(serde_json::Value::Object(obj)) = serde_json::to_value(config)
+                if let Some(exec_config) = &workflow.execution_config
+                    && let Ok(serde_json::Value::Object(obj)) = serde_json::to_value(exec_config)
                 {
                     println!("  Execution Config:");
                     for (key, value) in &obj {

--- a/src/client/commands/workflows.rs
+++ b/src/client/commands/workflows.rs
@@ -74,12 +74,27 @@ use crate::models::JobStatus;
 use serde_json;
 use tabled::Tabled;
 
+/// Render an optional boolean status flag as a compact "yes"/"no" string.
+fn yes_no(value: Option<bool>) -> String {
+    if value.unwrap_or(false) {
+        "yes".to_string()
+    } else {
+        "no".to_string()
+    }
+}
+
 #[derive(Tabled)]
 struct WorkflowTableRowNoUser {
     #[tabled(rename = "ID")]
     id: i64,
     #[tabled(rename = "Name")]
     name: String,
+    #[tabled(rename = "Run")]
+    run_id: String,
+    #[tabled(rename = "Canceled")]
+    canceled: String,
+    #[tabled(rename = "Archived")]
+    archived: String,
     #[tabled(rename = "Description")]
     description: String,
     #[tabled(rename = "Project")]
@@ -98,6 +113,12 @@ struct WorkflowTableRow {
     user: String,
     #[tabled(rename = "Name")]
     name: String,
+    #[tabled(rename = "Run")]
+    run_id: String,
+    #[tabled(rename = "Canceled")]
+    canceled: String,
+    #[tabled(rename = "Archived")]
+    archived: String,
     #[tabled(rename = "Description")]
     description: String,
     #[tabled(rename = "Project")]
@@ -2280,6 +2301,8 @@ pub fn handle_delete(config: &Configuration, ids: &[i64], no_prompts: bool, form
             None,    // include_relationships
             None,    // active_compute_node_id
             None,    // origin_is_set
+            None,    // name
+            None,    // command
         ) {
             Ok(response) => response.total_count,
             Err(e) => {
@@ -2494,6 +2517,11 @@ fn handle_get(config: &Configuration, id: &Option<i64>, user: &str, format: &str
                 if let Some(timestamp) = &workflow.timestamp {
                     println!("  Timestamp: {}", timestamp);
                 }
+                if let Some(run_id) = workflow.run_id {
+                    println!("  Run ID: {}", run_id);
+                }
+                println!("  Canceled: {}", workflow.is_canceled.unwrap_or(false));
+                println!("  Archived: {}", workflow.is_archived.unwrap_or(false));
                 if let Some(defaults_map) = &workflow.slurm_defaults {
                     println!("  Slurm Defaults:");
                     for (key, value) in defaults_map {
@@ -2508,6 +2536,20 @@ fn handle_get(config: &Configuration, id: &Option<i64>, user: &str, format: &str
                     && let Ok(serde_json::Value::Object(obj)) = serde_json::to_value(config)
                 {
                     println!("  Resource Monitor:");
+                    for (key, value) in &obj {
+                        let value_str = match value {
+                            serde_json::Value::String(s) => s.clone(),
+                            serde_json::Value::Bool(b) => b.to_string(),
+                            serde_json::Value::Number(n) => n.to_string(),
+                            _ => value.to_string(),
+                        };
+                        println!("    {}: {}", key, value_str);
+                    }
+                }
+                if let Some(config) = &workflow.execution_config
+                    && let Ok(serde_json::Value::Object(obj)) = serde_json::to_value(config)
+                {
+                    println!("  Execution Config:");
                     for (key, value) in &obj {
                         let value_str = match value {
                             serde_json::Value::String(s) => s.clone(),
@@ -2593,6 +2635,12 @@ fn handle_list(
                         id: workflow.id.unwrap_or(-1),
                         user: workflow.user.clone(),
                         name: workflow.name.clone(),
+                        run_id: workflow
+                            .run_id
+                            .map(|r| r.to_string())
+                            .unwrap_or_else(|| "-".to_string()),
+                        canceled: yes_no(workflow.is_canceled),
+                        archived: yes_no(workflow.is_archived),
                         description: workflow.description.as_deref().unwrap_or("").to_string(),
                         project: workflow.project.as_deref().unwrap_or("").to_string(),
                         metadata: workflow
@@ -2611,6 +2659,12 @@ fn handle_list(
                     .map(|workflow| WorkflowTableRowNoUser {
                         id: workflow.id.unwrap_or(-1),
                         name: workflow.name.clone(),
+                        run_id: workflow
+                            .run_id
+                            .map(|r| r.to_string())
+                            .unwrap_or_else(|| "-".to_string()),
+                        canceled: yes_no(workflow.is_canceled),
+                        archived: yes_no(workflow.is_archived),
                         description: workflow.description.as_deref().unwrap_or("").to_string(),
                         project: workflow.project.as_deref().unwrap_or("").to_string(),
                         metadata: workflow

--- a/src/server/api/jobs.rs
+++ b/src/server/api/jobs.rs
@@ -23,8 +23,9 @@ use crate::models::{self as models, JobStatus};
 
 use super::{
     ApiContext, MAX_RECORD_TRANSFER_COUNT, SqlQueryBuilder, begin_immediate,
-    database_error_with_msg, deserialize_env_map, message_error_response, normalize_env_map,
-    parse_job_status, resource_not_found_response, serialize_env_map, validate_env_map,
+    database_error_with_msg, deserialize_env_map, escape_like_pattern, message_error_response,
+    normalize_env_map, parse_job_status, resource_not_found_response, serialize_env_map,
+    validate_env_map,
 };
 
 /// Per-job values prepared during the first pass of bulk `create_jobs` so the
@@ -152,6 +153,8 @@ pub trait JobsApi<C> {
         include_relationships: Option<bool>,
         active_compute_node_id: Option<i64>,
         origin_is_set: Option<bool>,
+        name: Option<String>,
+        command: Option<String>,
         context: &C,
     ) -> Result<ListJobsResponse, ApiError>;
 
@@ -1855,10 +1858,12 @@ where
         include_relationships: Option<bool>,
         active_compute_node_id: Option<i64>,
         origin_is_set: Option<bool>,
+        name: Option<String>,
+        command: Option<String>,
         context: &C,
     ) -> Result<ListJobsResponse, ApiError> {
         debug!(
-            "list_jobs({}, {:?}, {:?}, {:?}, {}, {}, {:?}, {:?}, {:?}, {:?}, {:?}) - X-Span-ID: {:?}",
+            "list_jobs({}, {:?}, {:?}, {:?}, {}, {}, {:?}, {:?}, {:?}, {:?}, {:?}, {:?}, {:?}) - X-Span-ID: {:?}",
             workflow_id,
             status,
             needs_file_id,
@@ -1870,6 +1875,8 @@ where
             include_relationships,
             active_compute_node_id,
             origin_is_set,
+            name,
+            command,
             context.get().0.clone()
         );
 
@@ -1916,6 +1923,16 @@ where
             where_conditions.push("origin IS NULL".to_string());
         }
 
+        // Substring filters on name/command (LIKE '%value%'), matching the
+        // pattern used by the workflows `description` filter. Bound last so the
+        // `?` placeholders line up with the manual binds below.
+        if name.is_some() {
+            where_conditions.push("name LIKE ? ESCAPE '\\'".to_string());
+        }
+        if command.is_some() {
+            where_conditions.push("command LIKE ? ESCAPE '\\'".to_string());
+        }
+
         let where_clause = where_conditions.join(" AND ");
         let sort_by = if let Some(ref col) = sort_by {
             if JOB_COLUMNS.contains(&col.as_str()) {
@@ -1954,6 +1971,12 @@ where
         }
         if let Some(cn_id) = active_compute_node_id {
             sqlx_query = sqlx_query.bind(cn_id);
+        }
+        if let Some(ref n) = name {
+            sqlx_query = sqlx_query.bind(format!("%{}%", escape_like_pattern(n)));
+        }
+        if let Some(ref c) = command {
+            sqlx_query = sqlx_query.bind(format!("%{}%", escape_like_pattern(c)));
         }
 
         let records = match sqlx_query.fetch_all(self.context.pool.as_ref()).await {
@@ -2034,6 +2057,12 @@ where
         }
         if let Some(cn_id) = active_compute_node_id {
             count_sqlx_query = count_sqlx_query.bind(cn_id);
+        }
+        if let Some(ref n) = name {
+            count_sqlx_query = count_sqlx_query.bind(format!("%{}%", escape_like_pattern(n)));
+        }
+        if let Some(ref c) = command {
+            count_sqlx_query = count_sqlx_query.bind(format!("%{}%", escape_like_pattern(c)));
         }
 
         let total_count = match count_sqlx_query.fetch_one(self.context.pool.as_ref()).await {

--- a/src/server/api_contract.rs
+++ b/src/server/api_contract.rs
@@ -503,6 +503,8 @@ pub trait TransportApiCore<C: Send + Sync> {
         include_relationships: Option<bool>,
         active_compute_node_id: Option<i64>,
         origin_is_set: Option<bool>,
+        name: Option<String>,
+        command: Option<String>,
         context: &C,
     ) -> Result<ListJobsResponse, ApiError>;
 

--- a/src/server/http_server.rs
+++ b/src/server/http_server.rs
@@ -1572,6 +1572,8 @@ where
         include_relationships: Option<bool>,
         active_compute_node_id: Option<i64>,
         origin_is_set: Option<bool>,
+        name: Option<String>,
+        command: Option<String>,
         context: &C,
     ) -> Result<ListJobsResponse, ApiError> {
         self.transport_list_jobs(
@@ -1586,6 +1588,8 @@ where
             include_relationships,
             active_compute_node_id,
             origin_is_set,
+            name,
+            command,
             context,
         )
         .await

--- a/src/server/http_server/jobs_transport.rs
+++ b/src/server/http_server/jobs_transport.rs
@@ -1066,6 +1066,8 @@ where
         include_relationships: Option<bool>,
         active_compute_node_id: Option<i64>,
         origin_is_set: Option<bool>,
+        name: Option<String>,
+        command: Option<String>,
         context: &C,
     ) -> Result<ListJobsResponse, ApiError> {
         let (offset, limit) = authorize_workflow_and_paginate!(
@@ -1089,6 +1091,8 @@ where
                 include_relationships,
                 active_compute_node_id,
                 origin_is_set,
+                name,
+                command,
                 context,
             )
             .await

--- a/src/server/live_router.rs
+++ b/src/server/live_router.rs
@@ -2220,10 +2220,12 @@ pub struct JobsListQuery {
     /// suffices — no rows downloaded).
     #[param(nullable = true)]
     pub origin_is_set: Option<bool>,
-    /// Case-sensitive substring filter on the job name (SQL `LIKE %value%`).
+    /// Substring filter on the job name (SQL `LIKE %value%`, case-insensitive
+    /// for ASCII).
     #[param(nullable = true)]
     pub name: Option<String>,
-    /// Case-sensitive substring filter on the job command (SQL `LIKE %value%`).
+    /// Substring filter on the job command (SQL `LIKE %value%`, case-insensitive
+    /// for ASCII).
     #[param(nullable = true)]
     pub command: Option<String>,
 }

--- a/src/server/live_router.rs
+++ b/src/server/live_router.rs
@@ -2220,6 +2220,12 @@ pub struct JobsListQuery {
     /// suffices — no rows downloaded).
     #[param(nullable = true)]
     pub origin_is_set: Option<bool>,
+    /// Case-sensitive substring filter on the job name (SQL `LIKE %value%`).
+    #[param(nullable = true)]
+    pub name: Option<String>,
+    /// Case-sensitive substring filter on the job command (SQL `LIKE %value%`).
+    #[param(nullable = true)]
+    pub command: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, IntoParams)]
@@ -2264,6 +2270,8 @@ pub async fn list_jobs(
             query.include_relationships,
             query.active_compute_node_id,
             query.origin_is_set,
+            query.name,
+            query.command,
             &context,
         )
         .await

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -516,7 +516,7 @@ where
                     KeyCode::Tab => app.next_detail_view(),
                     KeyCode::BackTab => app.previous_detail_view(),
                     // Page through the active list (Workflows / Jobs / Results /
-                    // Compute Nodes), 1000 records at a time, on demand.
+                    // Compute Nodes) one TUI_PAGE_SIZE page at a time, on demand.
                     KeyCode::Char(']') => {
                         if let Err(err) = app.next_page() {
                             app.set_status(components::StatusMessage::error(&format!(

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -515,6 +515,24 @@ where
                     }
                     KeyCode::Tab => app.next_detail_view(),
                     KeyCode::BackTab => app.previous_detail_view(),
+                    // Page through the active list (Workflows / Jobs / Results /
+                    // Compute Nodes), 1000 records at a time, on demand.
+                    KeyCode::Char(']') => {
+                        if let Err(err) = app.next_page() {
+                            app.set_status(components::StatusMessage::error(&format!(
+                                "Failed to load next page: {}",
+                                err
+                            )));
+                        }
+                    }
+                    KeyCode::Char('[') => {
+                        if let Err(err) = app.prev_page() {
+                            app.set_status(components::StatusMessage::error(&format!(
+                                "Failed to load previous page: {}",
+                                err
+                            )));
+                        }
+                    }
                     KeyCode::Char('r') => {
                         app.refresh_workflows()?;
                         if app.selected_workflow_id.is_some() {
@@ -639,6 +657,42 @@ where
                             && app.detail_view == DetailViewType::Results =>
                     {
                         app.cycle_results_sort_peak_cpu();
+                    }
+                    // Sort the Compute Nodes table: 1=ID, 2=Hostname, m=Peak
+                    // Memory, p=Peak CPU. Each press cycles None → Desc → Asc.
+                    KeyCode::Char('1')
+                        if app.focus == Focus::Details
+                            && app.detail_view == DetailViewType::ComputeNodes =>
+                    {
+                        app.cycle_compute_nodes_sort_id();
+                    }
+                    KeyCode::Char('2')
+                        if app.focus == Focus::Details
+                            && app.detail_view == DetailViewType::ComputeNodes =>
+                    {
+                        app.cycle_compute_nodes_sort_hostname();
+                    }
+                    KeyCode::Char('m')
+                        if app.focus == Focus::Details
+                            && app.detail_view == DetailViewType::ComputeNodes =>
+                    {
+                        app.cycle_compute_nodes_sort_peak_memory();
+                    }
+                    KeyCode::Char('p')
+                        if app.focus == Focus::Details
+                            && app.detail_view == DetailViewType::ComputeNodes =>
+                    {
+                        app.cycle_compute_nodes_sort_peak_cpu();
+                    }
+                    // Sort the Workflows list: 1=ID, 2=Name, 3=User.
+                    KeyCode::Char('1') if app.focus == Focus::Workflows => {
+                        app.cycle_workflows_sort_id();
+                    }
+                    KeyCode::Char('2') if app.focus == Focus::Workflows => {
+                        app.cycle_workflows_sort_name();
+                    }
+                    KeyCode::Char('3') if app.focus == Focus::Workflows => {
+                        app.cycle_workflows_sort_user();
                     }
                     KeyCode::Char('E')
                         if app.focus == Focus::Details

--- a/src/tui/api.rs
+++ b/src/tui/api.rs
@@ -70,30 +70,39 @@ impl TorcClient {
         self.config.base_path = base_url.to_string();
     }
 
-    pub fn list_workflows(&self) -> Result<Vec<WorkflowModel>> {
+    pub fn list_workflows(
+        &self,
+        offset: Option<i64>,
+        limit: Option<i64>,
+    ) -> Result<Vec<WorkflowModel>> {
         let response = apis::workflows_api::list_workflows(
             &self.config,
-            None, // offset
-            None, // sort_by
-            None, // reverse_sort
-            None, // limit
-            None, // name
-            None, // user
-            None, // description
-            None, // is_archived
+            offset, // offset
+            limit,  // limit
+            None,   // sort_by
+            None,   // reverse_sort
+            None,   // name
+            None,   // user
+            None,   // description
+            None,   // is_archived
         )
         .context("Failed to list workflows")?;
 
         Ok(response.items)
     }
 
-    pub fn list_workflows_for_user(&self, user: &str) -> Result<Vec<WorkflowModel>> {
+    pub fn list_workflows_for_user(
+        &self,
+        user: &str,
+        offset: Option<i64>,
+        limit: Option<i64>,
+    ) -> Result<Vec<WorkflowModel>> {
         let response = apis::workflows_api::list_workflows(
             &self.config,
-            None,       // offset
+            offset,     // offset
+            limit,      // limit
             None,       // sort_by
             None,       // reverse_sort
-            None,       // limit
             None,       // name
             Some(user), // user filter
             None,       // description
@@ -114,20 +123,43 @@ impl TorcClient {
             .context("Failed to check workflow completion")
     }
 
-    pub fn list_jobs(&self, workflow_id: i64) -> Result<Vec<JobModel>> {
+    pub fn list_jobs(
+        &self,
+        workflow_id: i64,
+        offset: Option<i64>,
+        limit: Option<i64>,
+    ) -> Result<Vec<JobModel>> {
+        self.list_jobs_filtered(workflow_id, offset, limit, None, None, None)
+    }
+
+    /// List jobs with server-side filters applied. `status` is an exact match;
+    /// `name` and `command` are substring (`LIKE %value%`) matches. Used by the
+    /// TUI Jobs pane so filtering spans the whole workflow, not just the loaded
+    /// page.
+    pub fn list_jobs_filtered(
+        &self,
+        workflow_id: i64,
+        offset: Option<i64>,
+        limit: Option<i64>,
+        status: Option<JobStatus>,
+        name: Option<&str>,
+        command: Option<&str>,
+    ) -> Result<Vec<JobModel>> {
         let response = apis::jobs_api::list_jobs(
             &self.config,
             workflow_id,
-            None, // status
-            None, // needs_file_id
-            None, // upstream_job_id
-            None, // offset
-            None, // limit
-            None, // sort_by
-            None, // reverse_sort
-            None, // include_relationships
-            None, // active_compute_node_id
-            None, // origin_is_set
+            status,  // status
+            None,    // needs_file_id
+            None,    // upstream_job_id
+            offset,  // offset
+            limit,   // limit
+            None,    // sort_by
+            None,    // reverse_sort
+            None,    // include_relationships
+            None,    // active_compute_node_id
+            None,    // origin_is_set
+            name,    // name
+            command, // command
         )
         .context("Failed to list jobs")?;
 
@@ -152,20 +184,25 @@ impl TorcClient {
         Ok(response.items)
     }
 
-    pub fn list_results(&self, workflow_id: i64) -> Result<Vec<ResultModel>> {
+    pub fn list_results(
+        &self,
+        workflow_id: i64,
+        offset: Option<i64>,
+        limit: Option<i64>,
+    ) -> Result<Vec<ResultModel>> {
         let response = apis::results_api::list_results(
             &self.config,
             workflow_id,
-            None, // job_id
-            None, // run_id
-            None, // return_code
-            None, // status
-            None, // compute_node_id
-            None, // offset
-            None, // limit
-            None, // sort_by
-            None, // reverse_sort
-            None, // all_runs
+            None,   // job_id
+            None,   // run_id
+            None,   // return_code
+            None,   // status
+            None,   // compute_node_id
+            offset, // offset
+            limit,  // limit
+            None,   // sort_by
+            None,   // reverse_sort
+            None,   // all_runs
         )
         .context("Failed to list results")?;
 
@@ -221,17 +258,22 @@ impl TorcClient {
         Ok(response.items)
     }
 
-    pub fn list_compute_nodes(&self, workflow_id: i64) -> Result<Vec<ComputeNodeModel>> {
+    pub fn list_compute_nodes(
+        &self,
+        workflow_id: i64,
+        offset: Option<i64>,
+        limit: Option<i64>,
+    ) -> Result<Vec<ComputeNodeModel>> {
         let response = apis::compute_nodes_api::list_compute_nodes(
             &self.config,
             workflow_id,
-            None, // offset
-            None, // limit
-            None, // sort_by
-            None, // reverse_sort
-            None, // hostname
-            None, // is_active
-            None, // scheduled_compute_node_id
+            offset, // offset
+            limit,  // limit
+            None,   // sort_by
+            None,   // reverse_sort
+            None,   // hostname
+            None,   // is_active
+            None,   // scheduled_compute_node_id
         )
         .context("Failed to list compute nodes")?;
 

--- a/src/tui/api.rs
+++ b/src/tui/api.rs
@@ -74,7 +74,7 @@ impl TorcClient {
         &self,
         offset: Option<i64>,
         limit: Option<i64>,
-    ) -> Result<Vec<WorkflowModel>> {
+    ) -> Result<(Vec<WorkflowModel>, bool)> {
         let response = apis::workflows_api::list_workflows(
             &self.config,
             offset, // offset
@@ -88,7 +88,7 @@ impl TorcClient {
         )
         .context("Failed to list workflows")?;
 
-        Ok(response.items)
+        Ok((response.items, response.has_more))
     }
 
     pub fn list_workflows_for_user(
@@ -96,7 +96,7 @@ impl TorcClient {
         user: &str,
         offset: Option<i64>,
         limit: Option<i64>,
-    ) -> Result<Vec<WorkflowModel>> {
+    ) -> Result<(Vec<WorkflowModel>, bool)> {
         let response = apis::workflows_api::list_workflows(
             &self.config,
             offset,     // offset
@@ -110,7 +110,7 @@ impl TorcClient {
         )
         .context("Failed to list workflows")?;
 
-        Ok(response.items)
+        Ok((response.items, response.has_more))
     }
 
     pub fn get_workflow(&self, workflow_id: i64) -> Result<WorkflowModel> {
@@ -129,13 +129,17 @@ impl TorcClient {
         offset: Option<i64>,
         limit: Option<i64>,
     ) -> Result<Vec<JobModel>> {
-        self.list_jobs_filtered(workflow_id, offset, limit, None, None, None)
+        // Callers of this unfiltered variant load the full list (no paging), so
+        // the server's has_more is not needed here.
+        Ok(self
+            .list_jobs_filtered(workflow_id, offset, limit, None, None, None)?
+            .0)
     }
 
     /// List jobs with server-side filters applied. `status` is an exact match;
     /// `name` and `command` are substring (`LIKE %value%`) matches. Used by the
     /// TUI Jobs pane so filtering spans the whole workflow, not just the loaded
-    /// page.
+    /// page. Returns the page items plus the server's `has_more` flag.
     pub fn list_jobs_filtered(
         &self,
         workflow_id: i64,
@@ -144,7 +148,7 @@ impl TorcClient {
         status: Option<JobStatus>,
         name: Option<&str>,
         command: Option<&str>,
-    ) -> Result<Vec<JobModel>> {
+    ) -> Result<(Vec<JobModel>, bool)> {
         let response = apis::jobs_api::list_jobs(
             &self.config,
             workflow_id,
@@ -163,7 +167,7 @@ impl TorcClient {
         )
         .context("Failed to list jobs")?;
 
-        Ok(response.items)
+        Ok((response.items, response.has_more))
     }
 
     pub fn list_files(&self, workflow_id: i64) -> Result<Vec<FileModel>> {
@@ -184,12 +188,14 @@ impl TorcClient {
         Ok(response.items)
     }
 
+    /// Returns the page items plus the server's `has_more` flag. Callers that
+    /// load the full list (offset/limit `None`) can ignore the flag.
     pub fn list_results(
         &self,
         workflow_id: i64,
         offset: Option<i64>,
         limit: Option<i64>,
-    ) -> Result<Vec<ResultModel>> {
+    ) -> Result<(Vec<ResultModel>, bool)> {
         let response = apis::results_api::list_results(
             &self.config,
             workflow_id,
@@ -206,7 +212,7 @@ impl TorcClient {
         )
         .context("Failed to list results")?;
 
-        Ok(response.items)
+        Ok((response.items, response.has_more))
     }
 
     pub fn list_job_dependencies(&self, workflow_id: i64) -> Result<Vec<JobDependencyModel>> {
@@ -263,7 +269,7 @@ impl TorcClient {
         workflow_id: i64,
         offset: Option<i64>,
         limit: Option<i64>,
-    ) -> Result<Vec<ComputeNodeModel>> {
+    ) -> Result<(Vec<ComputeNodeModel>, bool)> {
         let response = apis::compute_nodes_api::list_compute_nodes(
             &self.config,
             workflow_id,
@@ -277,7 +283,7 @@ impl TorcClient {
         )
         .context("Failed to list compute nodes")?;
 
-        Ok(response.items)
+        Ok((response.items, response.has_more))
     }
 
     // === Workflow Actions ===

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -13,7 +13,7 @@ use crate::client::log_paths::{
 };
 use crate::client::sse_client::SseEvent;
 use crate::models::{
-    ComputeNodeModel, FileModel, JobModel, ResultModel, ScheduledComputeNodesModel,
+    ComputeNodeModel, FileModel, JobModel, JobStatus, ResultModel, ScheduledComputeNodesModel,
     SlurmStatsModel, WorkflowModel,
 };
 
@@ -269,6 +269,11 @@ pub enum FilterTarget {
 /// Number of rows to advance/retreat for PageDown/PageUp.
 pub const PAGE_STEP: usize = 10;
 
+/// Number of records the TUI fetches per page for the paginated list views
+/// (Workflows, Jobs, Results, Compute Nodes). Lists are loaded on demand one
+/// page at a time; `]` / `[` move to the next / previous page.
+pub const TUI_PAGE_SIZE: i64 = 250;
+
 /// Sort state for the Results detail table.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ResultsSort {
@@ -392,6 +397,138 @@ impl ResultsSort {
     }
 }
 
+/// Sort state for the Workflows list. Number keys 1..3 cycle a single column
+/// at a time (None → Desc → Asc → None), mirroring [`JobsSort`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkflowsSort {
+    None,
+    IdDesc,
+    IdAsc,
+    NameDesc,
+    NameAsc,
+    UserDesc,
+    UserAsc,
+}
+
+impl WorkflowsSort {
+    pub fn cycle_id(self) -> Self {
+        match self {
+            Self::IdDesc => Self::IdAsc,
+            Self::IdAsc => Self::None,
+            _ => Self::IdDesc,
+        }
+    }
+    pub fn cycle_name(self) -> Self {
+        match self {
+            Self::NameDesc => Self::NameAsc,
+            Self::NameAsc => Self::None,
+            _ => Self::NameDesc,
+        }
+    }
+    pub fn cycle_user(self) -> Self {
+        match self {
+            Self::UserDesc => Self::UserAsc,
+            Self::UserAsc => Self::None,
+            _ => Self::UserDesc,
+        }
+    }
+    pub fn id_indicator(self) -> &'static str {
+        match self {
+            Self::IdDesc => " ↓",
+            Self::IdAsc => " ↑",
+            _ => "",
+        }
+    }
+    pub fn name_indicator(self) -> &'static str {
+        match self {
+            Self::NameDesc => " ↓",
+            Self::NameAsc => " ↑",
+            _ => "",
+        }
+    }
+    pub fn user_indicator(self) -> &'static str {
+        match self {
+            Self::UserDesc => " ↓",
+            Self::UserAsc => " ↑",
+            _ => "",
+        }
+    }
+}
+
+/// Sort state for the Compute Nodes detail table. Keys 1=ID, 2=Hostname cycle
+/// like [`JobsSort`]; `m`/`p` cycle Peak Memory / Peak CPU like [`ResultsSort`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ComputeNodesSort {
+    None,
+    IdDesc,
+    IdAsc,
+    HostnameDesc,
+    HostnameAsc,
+    PeakCpuDesc,
+    PeakCpuAsc,
+    PeakMemoryDesc,
+    PeakMemoryAsc,
+}
+
+impl ComputeNodesSort {
+    pub fn cycle_id(self) -> Self {
+        match self {
+            Self::IdDesc => Self::IdAsc,
+            Self::IdAsc => Self::None,
+            _ => Self::IdDesc,
+        }
+    }
+    pub fn cycle_hostname(self) -> Self {
+        match self {
+            Self::HostnameDesc => Self::HostnameAsc,
+            Self::HostnameAsc => Self::None,
+            _ => Self::HostnameDesc,
+        }
+    }
+    pub fn cycle_peak_cpu(self) -> Self {
+        match self {
+            Self::PeakCpuDesc => Self::PeakCpuAsc,
+            Self::PeakCpuAsc => Self::None,
+            _ => Self::PeakCpuDesc,
+        }
+    }
+    pub fn cycle_peak_memory(self) -> Self {
+        match self {
+            Self::PeakMemoryDesc => Self::PeakMemoryAsc,
+            Self::PeakMemoryAsc => Self::None,
+            _ => Self::PeakMemoryDesc,
+        }
+    }
+    pub fn id_indicator(self) -> &'static str {
+        match self {
+            Self::IdDesc => " ↓",
+            Self::IdAsc => " ↑",
+            _ => "",
+        }
+    }
+    pub fn hostname_indicator(self) -> &'static str {
+        match self {
+            Self::HostnameDesc => " ↓",
+            Self::HostnameAsc => " ↑",
+            _ => "",
+        }
+    }
+    pub fn peak_cpu_indicator(self) -> &'static str {
+        match self {
+            Self::PeakCpuDesc => " ↓",
+            Self::PeakCpuAsc => " ↑",
+            _ => "",
+        }
+    }
+    pub fn peak_memory_indicator(self) -> &'static str {
+        match self {
+            Self::PeakMemoryDesc => " ↓",
+            Self::PeakMemoryAsc => " ↑",
+            _ => "",
+        }
+    }
+}
+
 /// Aggregated high-level information about a single workflow, computed from
 /// list_jobs + get_workflow + is_workflow_complete and rendered by the
 /// Summary detail view.
@@ -416,11 +553,20 @@ pub struct App {
     pub workflows: Vec<WorkflowModel>,
     pub workflows_all: Vec<WorkflowModel>,
     pub workflows_state: TableState,
+    pub workflows_sort: WorkflowsSort,
+    /// Offset of the currently-loaded Workflows page (multiple of TUI_PAGE_SIZE).
+    pub workflows_offset: i64,
+    /// True when the last Workflows fetch filled a full page (a next page may exist).
+    pub workflows_has_more: bool,
     pub jobs: Vec<JobModel>,
     pub jobs_all: Vec<JobModel>,
     pub jobs_workflow_id: Option<i64>,
     pub jobs_state: TableState,
     pub jobs_sort: JobsSort,
+    /// Offset of the currently-loaded Jobs page on the Jobs detail tab.
+    pub jobs_offset: i64,
+    /// True when the last Jobs-tab fetch filled a full page.
+    pub jobs_has_more: bool,
     pub files: Vec<FileModel>,
     pub files_all: Vec<FileModel>,
     pub files_state: TableState,
@@ -432,10 +578,19 @@ pub struct App {
     pub results_state: TableState,
     pub results_workflow_id: Option<i64>,
     pub results_sort: ResultsSort,
+    /// Offset of the currently-loaded Results page on the Results detail tab.
+    pub results_offset: i64,
+    /// True when the last Results-tab fetch filled a full page.
+    pub results_has_more: bool,
     pub exec_time_map: std::collections::HashMap<(i64, i64, i64), f64>,
     pub compute_nodes: Vec<ComputeNodeModel>,
     pub compute_nodes_all: Vec<ComputeNodeModel>,
     pub compute_nodes_state: TableState,
+    pub compute_nodes_sort: ComputeNodesSort,
+    /// Offset of the currently-loaded Compute Nodes page.
+    pub compute_nodes_offset: i64,
+    /// True when the last Compute Nodes fetch filled a full page.
+    pub compute_nodes_has_more: bool,
     pub scheduled_nodes: Vec<ScheduledComputeNodesModel>,
     pub scheduled_nodes_all: Vec<ScheduledComputeNodesModel>,
     pub scheduled_nodes_state: TableState,
@@ -528,11 +683,16 @@ impl App {
             workflows: Vec::new(),
             workflows_all: Vec::new(),
             workflows_state: TableState::default(),
+            workflows_sort: WorkflowsSort::None,
+            workflows_offset: 0,
+            workflows_has_more: false,
             jobs: Vec::new(),
             jobs_all: Vec::new(),
             jobs_workflow_id: None,
             jobs_state: TableState::default(),
             jobs_sort: JobsSort::None,
+            jobs_offset: 0,
+            jobs_has_more: false,
             files: Vec::new(),
             files_all: Vec::new(),
             files_state: TableState::default(),
@@ -544,10 +704,15 @@ impl App {
             results_state: TableState::default(),
             results_workflow_id: None,
             results_sort: ResultsSort::None,
+            results_offset: 0,
+            results_has_more: false,
             exec_time_map: std::collections::HashMap::new(),
             compute_nodes: Vec::new(),
             compute_nodes_all: Vec::new(),
             compute_nodes_state: TableState::default(),
+            compute_nodes_sort: ComputeNodesSort::None,
+            compute_nodes_offset: 0,
+            compute_nodes_has_more: false,
             scheduled_nodes: Vec::new(),
             scheduled_nodes_all: Vec::new(),
             scheduled_nodes_state: TableState::default(),
@@ -607,11 +772,14 @@ impl App {
             .and_then(|i| self.workflows.get(i))
             .and_then(|w| w.id);
 
+        let offset = Some(self.workflows_offset);
+        let limit = Some(TUI_PAGE_SIZE);
         self.workflows_all = if let Some(ref user) = self.user_filter {
-            self.client.list_workflows_for_user(user)?
+            self.client.list_workflows_for_user(user, offset, limit)?
         } else {
-            self.client.list_workflows()?
+            self.client.list_workflows(offset, limit)?
         };
+        self.workflows_has_more = self.workflows_all.len() as i64 == TUI_PAGE_SIZE;
 
         // Re-apply any active workflow filter against the freshly loaded data.
         if self.filter_target == FilterTarget::Workflows
@@ -622,6 +790,7 @@ impl App {
         } else {
             self.workflows = self.workflows_all.clone();
         }
+        self.apply_workflows_sort();
 
         if let Some(id) = prev_id
             && let Some(idx) = self.workflows.iter().position(|w| w.id == Some(id))
@@ -916,17 +1085,23 @@ impl App {
 
     pub fn load_detail_data(&mut self) -> Result<()> {
         if let Some(idx) = self.workflows_state.selected()
-            && let Some(workflow) = self.workflows.get(idx)
+            && let Some(workflow_id_opt) = self.workflows.get(idx).map(|w| w.id)
         {
-            self.selected_workflow_id = workflow.id;
-            if let Some(workflow_id) = workflow.id {
+            // When the selected workflow changes, restart every detail list at
+            // its first page so we don't carry a stale offset into a workflow
+            // that may have far fewer records.
+            if self.selected_workflow_id != workflow_id_opt {
+                self.reset_detail_pagination();
+            }
+            self.selected_workflow_id = workflow_id_opt;
+            if let Some(workflow_id) = workflow_id_opt {
                 // Clear any existing filter when loading new data
                 self.filter = None;
 
                 match self.detail_view {
                     DetailViewType::Summary => {
                         if self.jobs_workflow_id != Some(workflow_id) {
-                            self.jobs_all = self.client.list_jobs(workflow_id)?;
+                            self.jobs_all = self.client.list_jobs(workflow_id, None, None)?;
                             self.jobs_workflow_id = Some(workflow_id);
                         }
                         self.jobs = self.jobs_all.clone();
@@ -952,13 +1127,10 @@ impl App {
                         });
                     }
                     DetailViewType::Jobs => {
-                        self.jobs_all = self.client.list_jobs(workflow_id)?;
-                        self.jobs_workflow_id = Some(workflow_id);
-                        self.jobs = self.jobs_all.clone();
-                        self.apply_jobs_sort();
-                        if !self.jobs.is_empty() {
-                            self.jobs_state.select(Some(0));
-                        }
+                        // self.filter was just cleared above, so this loads an
+                        // unfiltered first page. Server-side filtering is driven
+                        // through reload_jobs_page from apply_filter/paging.
+                        self.reload_jobs_page()?;
                     }
                     DetailViewType::Files => {
                         self.files_all = self.client.list_files(workflow_id)?;
@@ -972,10 +1144,16 @@ impl App {
                         self.start_sse_connection(workflow_id);
                     }
                     DetailViewType::Results => {
-                        if self.results_workflow_id != Some(workflow_id) {
-                            self.results_all = self.client.list_results(workflow_id)?;
-                            self.results_workflow_id = Some(workflow_id);
-                        }
+                        self.results_all = self.client.list_results(
+                            workflow_id,
+                            Some(self.results_offset),
+                            Some(TUI_PAGE_SIZE),
+                        )?;
+                        self.results_has_more = self.results_all.len() as i64 == TUI_PAGE_SIZE;
+                        // results_all now holds only one page; invalidate the
+                        // full-list cache so the Slurm Stats tab refetches the
+                        // complete set for its CPU%/runtime computations.
+                        self.results_workflow_id = None;
                         self.results = self.results_all.clone();
                         self.apply_results_sort();
                         if !self.results.is_empty() {
@@ -983,8 +1161,15 @@ impl App {
                         }
                     }
                     DetailViewType::ComputeNodes => {
-                        self.compute_nodes_all = self.client.list_compute_nodes(workflow_id)?;
+                        self.compute_nodes_all = self.client.list_compute_nodes(
+                            workflow_id,
+                            Some(self.compute_nodes_offset),
+                            Some(TUI_PAGE_SIZE),
+                        )?;
+                        self.compute_nodes_has_more =
+                            self.compute_nodes_all.len() as i64 == TUI_PAGE_SIZE;
                         self.compute_nodes = self.compute_nodes_all.clone();
+                        self.apply_compute_nodes_sort();
                         if !self.compute_nodes.is_empty() {
                             self.compute_nodes_state.select(Some(0));
                         }
@@ -1006,7 +1191,7 @@ impl App {
                         // Load results for CPU% computation if not already loaded
                         // for this workflow
                         if self.results_workflow_id != Some(workflow_id)
-                            && let Ok(r) = self.client.list_results(workflow_id)
+                            && let Ok(r) = self.client.list_results(workflow_id, None, None)
                         {
                             self.results_all = r;
                             self.results = self.results_all.clone();
@@ -1017,7 +1202,7 @@ impl App {
                     }
                     DetailViewType::Dag => {
                         if self.jobs_workflow_id != Some(workflow_id) {
-                            self.jobs_all = self.client.list_jobs(workflow_id)?;
+                            self.jobs_all = self.client.list_jobs(workflow_id, None, None)?;
                             self.jobs_workflow_id = Some(workflow_id);
                             self.jobs = self.jobs_all.clone();
                             self.apply_jobs_sort();
@@ -1068,7 +1253,14 @@ impl App {
         // only its Details counterpart needs re-narrowing here.
         if let Some(filter) = prev_filter {
             if filter_target == FilterTarget::Details {
-                self.filter_active_view(FilterTarget::Details, &filter.column, &filter.value);
+                if self.detail_view == DetailViewType::Jobs {
+                    // Jobs filters server-side; re-fetch the current page with
+                    // the filter rather than narrowing the loaded page.
+                    self.filter = Some(filter.clone());
+                    self.reload_jobs_page()?;
+                } else {
+                    self.filter_active_view(FilterTarget::Details, &filter.column, &filter.value);
+                }
             }
             self.filter = Some(filter);
         }
@@ -1247,6 +1439,324 @@ impl App {
         self.jobs_sort = self.jobs_sort.cycle_status();
         self.apply_jobs_sort();
         self.restore_jobs_selection(prev_id);
+    }
+
+    /// Sort `self.workflows` in-place based on `self.workflows_sort`. Rows with
+    /// missing IDs sort last in both directions.
+    pub fn apply_workflows_sort(&mut self) {
+        match self.workflows_sort {
+            WorkflowsSort::None => {}
+            WorkflowsSort::IdDesc => self
+                .workflows
+                .sort_by_key(|w| (w.id.is_none(), std::cmp::Reverse(w.id.unwrap_or(i64::MIN)))),
+            WorkflowsSort::IdAsc => self
+                .workflows
+                .sort_by_key(|w| (w.id.is_none(), w.id.unwrap_or(i64::MAX))),
+            WorkflowsSort::NameDesc => self
+                .workflows
+                .sort_by_cached_key(|w| std::cmp::Reverse(w.name.to_lowercase())),
+            WorkflowsSort::NameAsc => self.workflows.sort_by_cached_key(|w| w.name.to_lowercase()),
+            WorkflowsSort::UserDesc => self
+                .workflows
+                .sort_by_cached_key(|w| std::cmp::Reverse(w.user.to_lowercase())),
+            WorkflowsSort::UserAsc => self.workflows.sort_by_cached_key(|w| w.user.to_lowercase()),
+        }
+    }
+
+    fn selected_workflow_row_id(&self) -> Option<i64> {
+        self.workflows_state
+            .selected()
+            .and_then(|i| self.workflows.get(i))
+            .and_then(|w| w.id)
+    }
+
+    fn restore_workflows_selection(&mut self, prev_id: Option<i64>) {
+        if self.workflows.is_empty() {
+            self.workflows_state.select(None);
+            return;
+        }
+        let idx = prev_id
+            .and_then(|id| self.workflows.iter().position(|w| w.id == Some(id)))
+            .unwrap_or(0);
+        self.workflows_state.select(Some(idx));
+    }
+
+    pub fn cycle_workflows_sort_id(&mut self) {
+        let prev_id = self.selected_workflow_row_id();
+        self.workflows_sort = self.workflows_sort.cycle_id();
+        self.apply_workflows_sort();
+        self.restore_workflows_selection(prev_id);
+    }
+
+    pub fn cycle_workflows_sort_name(&mut self) {
+        let prev_id = self.selected_workflow_row_id();
+        self.workflows_sort = self.workflows_sort.cycle_name();
+        self.apply_workflows_sort();
+        self.restore_workflows_selection(prev_id);
+    }
+
+    pub fn cycle_workflows_sort_user(&mut self) {
+        let prev_id = self.selected_workflow_row_id();
+        self.workflows_sort = self.workflows_sort.cycle_user();
+        self.apply_workflows_sort();
+        self.restore_workflows_selection(prev_id);
+    }
+
+    /// Sort `self.compute_nodes` in-place based on `self.compute_nodes_sort`.
+    /// Rows with missing values sort last in both directions.
+    pub fn apply_compute_nodes_sort(&mut self) {
+        match self.compute_nodes_sort {
+            ComputeNodesSort::None => {}
+            ComputeNodesSort::IdDesc => self
+                .compute_nodes
+                .sort_by_key(|n| (n.id.is_none(), std::cmp::Reverse(n.id.unwrap_or(i64::MIN)))),
+            ComputeNodesSort::IdAsc => self
+                .compute_nodes
+                .sort_by_key(|n| (n.id.is_none(), n.id.unwrap_or(i64::MAX))),
+            ComputeNodesSort::HostnameDesc => self
+                .compute_nodes
+                .sort_by_cached_key(|n| std::cmp::Reverse(n.hostname.to_lowercase())),
+            ComputeNodesSort::HostnameAsc => self
+                .compute_nodes
+                .sort_by_cached_key(|n| n.hostname.to_lowercase()),
+            ComputeNodesSort::PeakCpuDesc => {
+                self.compute_nodes
+                    .sort_by(|a, b| match (a.peak_cpu_percent, b.peak_cpu_percent) {
+                        (Some(x), Some(y)) => y.total_cmp(&x),
+                        (Some(_), None) => std::cmp::Ordering::Less,
+                        (None, Some(_)) => std::cmp::Ordering::Greater,
+                        (None, None) => std::cmp::Ordering::Equal,
+                    })
+            }
+            ComputeNodesSort::PeakCpuAsc => {
+                self.compute_nodes
+                    .sort_by(|a, b| match (a.peak_cpu_percent, b.peak_cpu_percent) {
+                        (Some(x), Some(y)) => x.total_cmp(&y),
+                        (Some(_), None) => std::cmp::Ordering::Less,
+                        (None, Some(_)) => std::cmp::Ordering::Greater,
+                        (None, None) => std::cmp::Ordering::Equal,
+                    })
+            }
+            ComputeNodesSort::PeakMemoryDesc => self.compute_nodes.sort_by_key(|n| {
+                (
+                    n.peak_memory_bytes.is_none(),
+                    std::cmp::Reverse(n.peak_memory_bytes.unwrap_or(i64::MIN)),
+                )
+            }),
+            ComputeNodesSort::PeakMemoryAsc => self.compute_nodes.sort_by_key(|n| {
+                (
+                    n.peak_memory_bytes.is_none(),
+                    n.peak_memory_bytes.unwrap_or(i64::MAX),
+                )
+            }),
+        }
+    }
+
+    fn selected_compute_node_id(&self) -> Option<i64> {
+        self.compute_nodes_state
+            .selected()
+            .and_then(|i| self.compute_nodes.get(i))
+            .and_then(|n| n.id)
+    }
+
+    /// Reset every detail-list page offset back to the first page. Called when
+    /// the selected workflow changes so a stale offset isn't carried over.
+    fn reset_detail_pagination(&mut self) {
+        self.jobs_offset = 0;
+        self.jobs_has_more = false;
+        self.results_offset = 0;
+        self.results_has_more = false;
+        self.compute_nodes_offset = 0;
+        self.compute_nodes_has_more = false;
+    }
+
+    /// True when a next page may exist for the active paginated view.
+    pub fn active_page_has_more(&self) -> bool {
+        match self.focus {
+            Focus::Workflows => self.workflows_has_more,
+            Focus::Details => match self.detail_view {
+                DetailViewType::Jobs => self.jobs_has_more,
+                DetailViewType::Results => self.results_has_more,
+                DetailViewType::ComputeNodes => self.compute_nodes_has_more,
+                _ => false,
+            },
+            _ => false,
+        }
+    }
+
+    /// Load the next page of the active paginated view, if one may exist.
+    pub fn next_page(&mut self) -> Result<()> {
+        if !self.active_page_has_more() {
+            return Ok(());
+        }
+        match self.focus {
+            Focus::Workflows => {
+                self.workflows_offset += TUI_PAGE_SIZE;
+                self.refresh_workflows()?;
+                self.select_first_workflow_row();
+            }
+            Focus::Details => match self.detail_view {
+                DetailViewType::Jobs => {
+                    // reload_jobs_page (not load_detail_data) so the active
+                    // server-side filter is preserved across pages.
+                    self.jobs_offset += TUI_PAGE_SIZE;
+                    self.reload_jobs_page()?;
+                }
+                DetailViewType::Results => {
+                    self.results_offset += TUI_PAGE_SIZE;
+                    self.load_detail_data()?;
+                }
+                DetailViewType::ComputeNodes => {
+                    self.compute_nodes_offset += TUI_PAGE_SIZE;
+                    self.load_detail_data()?;
+                }
+                _ => {}
+            },
+            _ => {}
+        }
+        Ok(())
+    }
+
+    /// Load the previous page of the active paginated view, if not already on
+    /// the first page.
+    pub fn prev_page(&mut self) -> Result<()> {
+        match self.focus {
+            Focus::Workflows => {
+                if self.workflows_offset == 0 {
+                    return Ok(());
+                }
+                self.workflows_offset = (self.workflows_offset - TUI_PAGE_SIZE).max(0);
+                self.refresh_workflows()?;
+                self.select_first_workflow_row();
+            }
+            Focus::Details => match self.detail_view {
+                DetailViewType::Jobs if self.jobs_offset > 0 => {
+                    self.jobs_offset = (self.jobs_offset - TUI_PAGE_SIZE).max(0);
+                    self.reload_jobs_page()?;
+                }
+                DetailViewType::Results if self.results_offset > 0 => {
+                    self.results_offset = (self.results_offset - TUI_PAGE_SIZE).max(0);
+                    self.load_detail_data()?;
+                }
+                DetailViewType::ComputeNodes if self.compute_nodes_offset > 0 => {
+                    self.compute_nodes_offset = (self.compute_nodes_offset - TUI_PAGE_SIZE).max(0);
+                    self.load_detail_data()?;
+                }
+                _ => {}
+            },
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn select_first_workflow_row(&mut self) {
+        if self.workflows.is_empty() {
+            self.workflows_state.select(None);
+        } else {
+            self.workflows_state.select(Some(0));
+        }
+    }
+
+    /// Resolve the Jobs-pane filter (`self.filter`) into server-side query
+    /// arguments. Returns `(status, name, command, impossible)`. `impossible`
+    /// is true when a Status filter value matches no known status, in which
+    /// case the caller should show zero rows without hitting the server.
+    /// Returns all-`None` when no Jobs filter is active.
+    fn jobs_server_filter(&self) -> (Option<JobStatus>, Option<String>, Option<String>, bool) {
+        if self.filter_target != FilterTarget::Details {
+            return (None, None, None, false);
+        }
+        let Some(filter) = self.filter.as_ref() else {
+            return (None, None, None, false);
+        };
+        match filter.column.as_str() {
+            "Status" => match resolve_job_status_filter(&filter.value) {
+                Some(s) => (Some(s), None, None, false),
+                None => (None, None, None, true),
+            },
+            "Name" => (None, Some(filter.value.clone()), None, false),
+            "Command" => (None, None, Some(filter.value.clone()), false),
+            _ => (None, None, None, false),
+        }
+    }
+
+    /// Fetch the current page of the Jobs detail table from the server,
+    /// applying the active Jobs filter server-side so it spans the whole
+    /// workflow rather than just the loaded page. Does not modify `self.filter`.
+    pub fn reload_jobs_page(&mut self) -> Result<()> {
+        let Some(workflow_id) = self.selected_workflow_id else {
+            return Ok(());
+        };
+        let (status, name, command, impossible) = self.jobs_server_filter();
+
+        // jobs_all now holds at most one (possibly filtered) page; invalidate
+        // the full-list cache so Summary/Dag refetch the complete set.
+        self.jobs_workflow_id = None;
+
+        if impossible {
+            self.jobs_all = Vec::new();
+            self.jobs = Vec::new();
+            self.jobs_has_more = false;
+            self.jobs_state.select(None);
+            return Ok(());
+        }
+
+        self.jobs_all = self.client.list_jobs_filtered(
+            workflow_id,
+            Some(self.jobs_offset),
+            Some(TUI_PAGE_SIZE),
+            status,
+            name.as_deref(),
+            command.as_deref(),
+        )?;
+        self.jobs_has_more = self.jobs_all.len() as i64 == TUI_PAGE_SIZE;
+        self.jobs = self.jobs_all.clone();
+        self.apply_jobs_sort();
+        if self.jobs.is_empty() {
+            self.jobs_state.select(None);
+        } else {
+            self.jobs_state.select(Some(0));
+        }
+        Ok(())
+    }
+
+    fn restore_compute_nodes_selection(&mut self, prev_id: Option<i64>) {
+        if self.compute_nodes.is_empty() {
+            self.compute_nodes_state.select(None);
+            return;
+        }
+        let idx = prev_id
+            .and_then(|id| self.compute_nodes.iter().position(|n| n.id == Some(id)))
+            .unwrap_or(0);
+        self.compute_nodes_state.select(Some(idx));
+    }
+
+    pub fn cycle_compute_nodes_sort_id(&mut self) {
+        let prev_id = self.selected_compute_node_id();
+        self.compute_nodes_sort = self.compute_nodes_sort.cycle_id();
+        self.apply_compute_nodes_sort();
+        self.restore_compute_nodes_selection(prev_id);
+    }
+
+    pub fn cycle_compute_nodes_sort_hostname(&mut self) {
+        let prev_id = self.selected_compute_node_id();
+        self.compute_nodes_sort = self.compute_nodes_sort.cycle_hostname();
+        self.apply_compute_nodes_sort();
+        self.restore_compute_nodes_selection(prev_id);
+    }
+
+    pub fn cycle_compute_nodes_sort_peak_cpu(&mut self) {
+        let prev_id = self.selected_compute_node_id();
+        self.compute_nodes_sort = self.compute_nodes_sort.cycle_peak_cpu();
+        self.apply_compute_nodes_sort();
+        self.restore_compute_nodes_selection(prev_id);
+    }
+
+    pub fn cycle_compute_nodes_sort_peak_memory(&mut self) {
+        let prev_id = self.selected_compute_node_id();
+        self.compute_nodes_sort = self.compute_nodes_sort.cycle_peak_memory();
+        self.apply_compute_nodes_sort();
+        self.restore_compute_nodes_selection(prev_id);
     }
 
     fn selected_job_id(&self) -> Option<i64> {
@@ -1499,7 +2009,19 @@ impl App {
             column: column.clone(),
             value: value.clone(),
         });
-        self.filter_active_view(target, &column, &value);
+        // The Jobs pane filters server-side (across the whole workflow); other
+        // views filter the loaded page client-side.
+        if target == FilterTarget::Details && self.detail_view == DetailViewType::Jobs {
+            self.jobs_offset = 0;
+            if let Err(err) = self.reload_jobs_page() {
+                self.set_status(StatusMessage::error(&format!(
+                    "Failed to filter jobs: {}",
+                    err
+                )));
+            }
+        } else {
+            self.filter_active_view(target, &column, &value);
+        }
         self.focus = return_focus;
     }
 
@@ -1517,6 +2039,7 @@ impl App {
 
         if target == FilterTarget::Workflows {
             self.workflows = filter_workflow_list(&self.workflows_all, &column, &value);
+            self.apply_workflows_sort();
             if !self.workflows.is_empty() {
                 self.workflows_state.select(Some(0));
             } else {
@@ -1617,6 +2140,7 @@ impl App {
                     })
                     .cloned()
                     .collect();
+                self.apply_compute_nodes_sort();
                 if !self.compute_nodes.is_empty() {
                     self.compute_nodes_state.select(Some(0));
                 } else {
@@ -1687,6 +2211,7 @@ impl App {
         }
         if target == FilterTarget::Workflows {
             self.workflows = self.workflows_all.clone();
+            self.apply_workflows_sort();
             if !self.workflows.is_empty() {
                 self.workflows_state.select(Some(0));
             } else {
@@ -1696,10 +2221,15 @@ impl App {
         }
         match self.detail_view {
             DetailViewType::Jobs => {
-                self.jobs = self.jobs_all.clone();
-                self.apply_jobs_sort();
-                if !self.jobs.is_empty() {
-                    self.jobs_state.select(Some(0));
+                // Re-fetch an unfiltered first page from the server (the Jobs
+                // filter is server-side, so the loaded page may be a strict
+                // subset that can't be widened client-side).
+                self.jobs_offset = 0;
+                if let Err(err) = self.reload_jobs_page() {
+                    self.set_status(StatusMessage::error(&format!(
+                        "Failed to reload jobs: {}",
+                        err
+                    )));
                 }
             }
             DetailViewType::Files => {
@@ -1723,6 +2253,7 @@ impl App {
             }
             DetailViewType::ComputeNodes => {
                 self.compute_nodes = self.compute_nodes_all.clone();
+                self.apply_compute_nodes_sort();
                 if !self.compute_nodes.is_empty() {
                     self.compute_nodes_state.select(Some(0));
                 }
@@ -1838,6 +2369,8 @@ impl App {
 
     pub fn toggle_show_all_users(&mut self) -> Result<()> {
         self.show_all_users = !self.show_all_users;
+        // The set of workflows changes, so restart at the first page.
+        self.workflows_offset = 0;
         if self.show_all_users {
             self.user_filter = None;
             self.set_status(StatusMessage::info("Showing all users"));
@@ -1917,7 +2450,7 @@ impl App {
         if should_refresh {
             if let Some(workflow_id) = self.selected_workflow_id {
                 // Refresh jobs for the current workflow
-                if let Ok(jobs) = self.client.list_jobs(workflow_id) {
+                if let Ok(jobs) = self.client.list_jobs(workflow_id, None, None) {
                     self.jobs_all = jobs.clone();
                     self.jobs_workflow_id = Some(workflow_id);
                     self.jobs = jobs;
@@ -1929,7 +2462,7 @@ impl App {
                     self.filter = None;
                 }
                 // Also refresh results
-                if let Ok(results) = self.client.list_results(workflow_id) {
+                if let Ok(results) = self.client.list_results(workflow_id, None, None) {
                     self.results_all = results.clone();
                     self.results = results;
                     self.apply_results_sort();
@@ -2824,7 +3357,7 @@ impl App {
     fn load_job_logs(&self, viewer: &mut LogViewer) -> Result<()> {
         // Try to find log files based on job results
         if let Some(workflow_id) = self.selected_workflow_id {
-            let results = self.client.list_results(workflow_id)?;
+            let results = self.client.list_results(workflow_id, None, None)?;
 
             // Find the most recent result for this job
             // Sort by (run_id, attempt_id) to get the latest attempt of the latest run
@@ -3391,6 +3924,38 @@ fn restore_selection(state: &mut TableState, prev: Option<usize>, len: usize) {
         Some(idx) if len > 0 => state.select(Some(idx.min(len - 1))),
         _ => state.select(None),
     }
+}
+
+/// Resolve a user-typed Jobs status filter to a single [`JobStatus`] for
+/// server-side filtering. Matches the status name the user sees in the table
+/// (the `{:?}` debug form, e.g. "Completed"), case-insensitively: an exact
+/// match wins, otherwise the first status whose name contains the value.
+/// Returns `None` when the value is non-empty but matches no status, so the
+/// caller can show zero rows rather than silently dropping the filter.
+fn resolve_job_status_filter(value: &str) -> Option<JobStatus> {
+    let v = value.trim().to_lowercase();
+    if v.is_empty() {
+        return None;
+    }
+    const ALL: [JobStatus; 11] = [
+        JobStatus::Uninitialized,
+        JobStatus::Blocked,
+        JobStatus::Ready,
+        JobStatus::Pending,
+        JobStatus::Running,
+        JobStatus::Completed,
+        JobStatus::Failed,
+        JobStatus::Canceled,
+        JobStatus::Terminated,
+        JobStatus::Disabled,
+        JobStatus::PendingFailed,
+    ];
+    if let Some(s) = ALL.iter().find(|s| format!("{:?}", s).to_lowercase() == v) {
+        return Some(*s);
+    }
+    ALL.iter()
+        .find(|s| format!("{:?}", s).to_lowercase().contains(&v))
+        .copied()
 }
 
 /// Apply a case-insensitive substring filter on the given column to a list of

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1604,11 +1604,11 @@ impl App {
                 }
                 DetailViewType::Results => {
                     self.results_offset += TUI_PAGE_SIZE;
-                    self.load_detail_data()?;
+                    self.reload_detail_page_preserving_filter()?;
                 }
                 DetailViewType::ComputeNodes => {
                     self.compute_nodes_offset += TUI_PAGE_SIZE;
-                    self.load_detail_data()?;
+                    self.reload_detail_page_preserving_filter()?;
                 }
                 _ => {}
             },
@@ -1636,11 +1636,11 @@ impl App {
                 }
                 DetailViewType::Results if self.results_offset > 0 => {
                     self.results_offset = (self.results_offset - TUI_PAGE_SIZE).max(0);
-                    self.load_detail_data()?;
+                    self.reload_detail_page_preserving_filter()?;
                 }
                 DetailViewType::ComputeNodes if self.compute_nodes_offset > 0 => {
                     self.compute_nodes_offset = (self.compute_nodes_offset - TUI_PAGE_SIZE).max(0);
-                    self.load_detail_data()?;
+                    self.reload_detail_page_preserving_filter()?;
                 }
                 _ => {}
             },
@@ -1655,6 +1655,24 @@ impl App {
         } else {
             self.workflows_state.select(Some(0));
         }
+    }
+
+    /// Reload the active detail view's current page, preserving any active
+    /// client-side Details filter. `load_detail_data` clears `self.filter`, so
+    /// we capture it and re-narrow the freshly loaded page afterward. Used by
+    /// paging on the client-side-filtered views (Results, Compute Nodes); the
+    /// Jobs pane filters server-side via `reload_jobs_page` instead.
+    fn reload_detail_page_preserving_filter(&mut self) -> Result<()> {
+        let saved = self.filter.clone();
+        let saved_target = self.filter_target;
+        self.load_detail_data()?;
+        if saved_target == FilterTarget::Details
+            && let Some(f) = saved
+        {
+            self.filter = Some(f.clone());
+            self.filter_active_view(FilterTarget::Details, &f.column, &f.value);
+        }
+        Ok(())
     }
 
     /// Resolve the Jobs-pane filter (`self.filter`) into server-side query

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -774,12 +774,13 @@ impl App {
 
         let offset = Some(self.workflows_offset);
         let limit = Some(TUI_PAGE_SIZE);
-        self.workflows_all = if let Some(ref user) = self.user_filter {
+        let has_more;
+        (self.workflows_all, has_more) = if let Some(ref user) = self.user_filter {
             self.client.list_workflows_for_user(user, offset, limit)?
         } else {
             self.client.list_workflows(offset, limit)?
         };
-        self.workflows_has_more = self.workflows_all.len() as i64 == TUI_PAGE_SIZE;
+        self.workflows_has_more = has_more;
 
         // Re-apply any active workflow filter against the freshly loaded data.
         if self.filter_target == FilterTarget::Workflows
@@ -1144,12 +1145,11 @@ impl App {
                         self.start_sse_connection(workflow_id);
                     }
                     DetailViewType::Results => {
-                        self.results_all = self.client.list_results(
+                        (self.results_all, self.results_has_more) = self.client.list_results(
                             workflow_id,
                             Some(self.results_offset),
                             Some(TUI_PAGE_SIZE),
                         )?;
-                        self.results_has_more = self.results_all.len() as i64 == TUI_PAGE_SIZE;
                         // results_all now holds only one page; invalidate the
                         // full-list cache so the Slurm Stats tab refetches the
                         // complete set for its CPU%/runtime computations.
@@ -1161,13 +1161,12 @@ impl App {
                         }
                     }
                     DetailViewType::ComputeNodes => {
-                        self.compute_nodes_all = self.client.list_compute_nodes(
-                            workflow_id,
-                            Some(self.compute_nodes_offset),
-                            Some(TUI_PAGE_SIZE),
-                        )?;
-                        self.compute_nodes_has_more =
-                            self.compute_nodes_all.len() as i64 == TUI_PAGE_SIZE;
+                        (self.compute_nodes_all, self.compute_nodes_has_more) =
+                            self.client.list_compute_nodes(
+                                workflow_id,
+                                Some(self.compute_nodes_offset),
+                                Some(TUI_PAGE_SIZE),
+                            )?;
                         self.compute_nodes = self.compute_nodes_all.clone();
                         self.apply_compute_nodes_sort();
                         if !self.compute_nodes.is_empty() {
@@ -1191,7 +1190,7 @@ impl App {
                         // Load results for CPU% computation if not already loaded
                         // for this workflow
                         if self.results_workflow_id != Some(workflow_id)
-                            && let Ok(r) = self.client.list_results(workflow_id, None, None)
+                            && let Ok((r, _)) = self.client.list_results(workflow_id, None, None)
                         {
                             self.results_all = r;
                             self.results = self.results_all.clone();
@@ -1676,25 +1675,52 @@ impl App {
     }
 
     /// Resolve the Jobs-pane filter (`self.filter`) into server-side query
-    /// arguments. Returns `(status, name, command, impossible)`. `impossible`
-    /// is true when a Status filter value matches no known status, in which
-    /// case the caller should show zero rows without hitting the server.
-    /// Returns all-`None` when no Jobs filter is active.
-    fn jobs_server_filter(&self) -> (Option<JobStatus>, Option<String>, Option<String>, bool) {
+    /// arguments. Returns `(status, name, command, impossible, message)`.
+    /// `impossible` is true when a Status filter value cannot be resolved to a
+    /// single status (unknown or ambiguous), in which case the caller should
+    /// show zero rows without hitting the server; `message`, when present,
+    /// explains why so the caller can surface it. Returns all-`None`/empty when
+    /// no Jobs filter is active.
+    fn jobs_server_filter(
+        &self,
+    ) -> (
+        Option<JobStatus>,
+        Option<String>,
+        Option<String>,
+        bool,
+        Option<String>,
+    ) {
         if self.filter_target != FilterTarget::Details {
-            return (None, None, None, false);
+            return (None, None, None, false, None);
         }
         let Some(filter) = self.filter.as_ref() else {
-            return (None, None, None, false);
+            return (None, None, None, false, None);
         };
         match filter.column.as_str() {
             "Status" => match resolve_job_status_filter(&filter.value) {
-                Some(s) => (Some(s), None, None, false),
-                None => (None, None, None, true),
+                StatusFilterResolution::Matched(s) => (Some(s), None, None, false, None),
+                StatusFilterResolution::Unknown => (
+                    None,
+                    None,
+                    None,
+                    true,
+                    Some(format!("No job status matches \"{}\"", filter.value)),
+                ),
+                StatusFilterResolution::Ambiguous(names) => (
+                    None,
+                    None,
+                    None,
+                    true,
+                    Some(format!(
+                        "\"{}\" is ambiguous; matches {}. Type a full status name.",
+                        filter.value,
+                        names.join(", ")
+                    )),
+                ),
             },
-            "Name" => (None, Some(filter.value.clone()), None, false),
-            "Command" => (None, None, Some(filter.value.clone()), false),
-            _ => (None, None, None, false),
+            "Name" => (None, Some(filter.value.clone()), None, false, None),
+            "Command" => (None, None, Some(filter.value.clone()), false, None),
+            _ => (None, None, None, false, None),
         }
     }
 
@@ -1705,7 +1731,7 @@ impl App {
         let Some(workflow_id) = self.selected_workflow_id else {
             return Ok(());
         };
-        let (status, name, command, impossible) = self.jobs_server_filter();
+        let (status, name, command, impossible, message) = self.jobs_server_filter();
 
         // jobs_all now holds at most one (possibly filtered) page; invalidate
         // the full-list cache so Summary/Dag refetch the complete set.
@@ -1716,10 +1742,13 @@ impl App {
             self.jobs = Vec::new();
             self.jobs_has_more = false;
             self.jobs_state.select(None);
+            if let Some(msg) = message {
+                self.set_status(StatusMessage::error(&msg));
+            }
             return Ok(());
         }
 
-        self.jobs_all = self.client.list_jobs_filtered(
+        (self.jobs_all, self.jobs_has_more) = self.client.list_jobs_filtered(
             workflow_id,
             Some(self.jobs_offset),
             Some(TUI_PAGE_SIZE),
@@ -1727,7 +1756,6 @@ impl App {
             name.as_deref(),
             command.as_deref(),
         )?;
-        self.jobs_has_more = self.jobs_all.len() as i64 == TUI_PAGE_SIZE;
         self.jobs = self.jobs_all.clone();
         self.apply_jobs_sort();
         if self.jobs.is_empty() {
@@ -2034,6 +2062,18 @@ impl App {
             if let Err(err) = self.reload_jobs_page() {
                 self.set_status(StatusMessage::error(&format!(
                     "Failed to filter jobs: {}",
+                    err
+                )));
+            }
+        } else if target == FilterTarget::Workflows {
+            // Workflows filtering narrows the loaded page client-side, so
+            // restart from page 1 first; otherwise filtering while on, say,
+            // page 3 would search only that page. refresh_workflows re-applies
+            // the active filter (now set above) to the freshly loaded page.
+            self.workflows_offset = 0;
+            if let Err(err) = self.refresh_workflows() {
+                self.set_status(StatusMessage::error(&format!(
+                    "Failed to filter workflows: {}",
                     err
                 )));
             }
@@ -2480,7 +2520,7 @@ impl App {
                     self.filter = None;
                 }
                 // Also refresh results
-                if let Ok(results) = self.client.list_results(workflow_id, None, None) {
+                if let Ok((results, _)) = self.client.list_results(workflow_id, None, None) {
                     self.results_all = results.clone();
                     self.results = results;
                     self.apply_results_sort();
@@ -3375,7 +3415,7 @@ impl App {
     fn load_job_logs(&self, viewer: &mut LogViewer) -> Result<()> {
         // Try to find log files based on job results
         if let Some(workflow_id) = self.selected_workflow_id {
-            let results = self.client.list_results(workflow_id, None, None)?;
+            let (results, _) = self.client.list_results(workflow_id, None, None)?;
 
             // Find the most recent result for this job
             // Sort by (run_id, attempt_id) to get the latest attempt of the latest run
@@ -3944,16 +3984,30 @@ fn restore_selection(state: &mut TableState, prev: Option<usize>, len: usize) {
     }
 }
 
+/// Outcome of resolving a user-typed Jobs status filter against the known
+/// statuses.
+enum StatusFilterResolution {
+    /// The value resolved to exactly one status (exact match or unique
+    /// substring).
+    Matched(JobStatus),
+    /// The value matched no status name.
+    Unknown,
+    /// The value is a substring of more than one status name; we refuse to
+    /// guess. Holds the matching status names for a helpful message.
+    Ambiguous(Vec<String>),
+}
+
 /// Resolve a user-typed Jobs status filter to a single [`JobStatus`] for
 /// server-side filtering. Matches the status name the user sees in the table
 /// (the `{:?}` debug form, e.g. "Completed"), case-insensitively: an exact
-/// match wins, otherwise the first status whose name contains the value.
-/// Returns `None` when the value is non-empty but matches no status, so the
-/// caller can show zero rows rather than silently dropping the filter.
-fn resolve_job_status_filter(value: &str) -> Option<JobStatus> {
+/// match wins; otherwise a substring is accepted only when it matches exactly
+/// one status. An empty value is treated as `Unknown`. Substrings that match
+/// several statuses (e.g. "ed" → Completed/Failed/…) return `Ambiguous` so the
+/// caller can surface the ambiguity instead of silently picking one.
+fn resolve_job_status_filter(value: &str) -> StatusFilterResolution {
     let v = value.trim().to_lowercase();
     if v.is_empty() {
-        return None;
+        return StatusFilterResolution::Unknown;
     }
     const ALL: [JobStatus; 11] = [
         JobStatus::Uninitialized,
@@ -3969,11 +4023,20 @@ fn resolve_job_status_filter(value: &str) -> Option<JobStatus> {
         JobStatus::PendingFailed,
     ];
     if let Some(s) = ALL.iter().find(|s| format!("{:?}", s).to_lowercase() == v) {
-        return Some(*s);
+        return StatusFilterResolution::Matched(*s);
     }
-    ALL.iter()
-        .find(|s| format!("{:?}", s).to_lowercase().contains(&v))
+    let matches: Vec<JobStatus> = ALL
+        .iter()
+        .filter(|s| format!("{:?}", s).to_lowercase().contains(&v))
         .copied()
+        .collect();
+    match matches.as_slice() {
+        [] => StatusFilterResolution::Unknown,
+        [s] => StatusFilterResolution::Matched(*s),
+        many => {
+            StatusFilterResolution::Ambiguous(many.iter().map(|s| format!("{:?}", s)).collect())
+        }
+    }
 }
 
 /// Apply a case-insensitive substring filter on the given column to a list of

--- a/src/tui/components.rs
+++ b/src/tui/components.rs
@@ -512,6 +512,10 @@ impl HelpPopup {
             Self::key_line(left_right_arrows(), "Switch focus between panes"),
             Self::key_line(up_down_arrows(), "Navigate rows in tables"),
             Self::key_line("PgUp/PgDn", "Page through rows (10 at a time)"),
+            Self::key_line(
+                "] / [",
+                "Load next / previous page (1000 records, on demand)",
+            ),
             Self::key_line("g / G", "Jump to top / bottom of table"),
             Self::key_line("Enter", "Load details / Confirm action"),
             Self::key_line("f", "Filter current pane (Workflows or Details)"),
@@ -538,9 +542,14 @@ impl HelpPopup {
                     "C",
                     "Cancel workflow (Jobs tab: cancel job)",
                 ));
+                lines.push(Self::key_line("1 / 2 / 3", "Sort by ID / Name / User"));
             }
             HelpContext::DetailJobs => {
                 lines.extend(Self::section("Jobs Tab"));
+                lines.push(Self::key_line(
+                    "f",
+                    "Filter by Status/Name/Command (server-side, whole workflow)",
+                ));
                 lines.push(Self::key_line("Enter", "View job details"));
                 lines.push(Self::key_line("l", "View logs"));
                 lines.push(Self::key_line("C", "Cancel job"));
@@ -563,6 +572,18 @@ impl HelpPopup {
                     "Sort by Peak CPU % (cycles desc / asc / off)",
                 ));
             }
+            HelpContext::DetailComputeNodes => {
+                lines.extend(Self::section("Compute Nodes Tab"));
+                lines.push(Self::key_line("1 / 2", "Sort by ID / Hostname"));
+                lines.push(Self::key_line(
+                    "m",
+                    "Sort by Peak Memory (cycles desc / asc / off)",
+                ));
+                lines.push(Self::key_line(
+                    "p",
+                    "Sort by Peak CPU % (cycles desc / asc / off)",
+                ));
+            }
             HelpContext::DetailScheduledNodes => {
                 lines.extend(Self::section("Scheduled Nodes Tab"));
                 lines.push(Self::key_line("l", "View Slurm stdout/stderr logs"));
@@ -576,7 +597,6 @@ impl HelpPopup {
             HelpContext::DetailSummary
             | HelpContext::DetailFiles
             | HelpContext::DetailEvents
-            | HelpContext::DetailComputeNodes
             | HelpContext::DetailSlurmStats
             | HelpContext::DetailDag
             | HelpContext::Other => {

--- a/src/tui/components.rs
+++ b/src/tui/components.rs
@@ -512,10 +512,7 @@ impl HelpPopup {
             Self::key_line(left_right_arrows(), "Switch focus between panes"),
             Self::key_line(up_down_arrows(), "Navigate rows in tables"),
             Self::key_line("PgUp/PgDn", "Page through rows (10 at a time)"),
-            Self::key_line(
-                "] / [",
-                "Load next / previous page (1000 records, on demand)",
-            ),
+            Self::key_line("] / [", "Load next / previous page (on demand)"),
             Self::key_line("g / G", "Jump to top / bottom of table"),
             Self::key_line("Enter", "Load details / Confirm action"),
             Self::key_line("f", "Filter current pane (Workflows or Details)"),

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -62,6 +62,19 @@ fn filter_suffix(app: &App, target: FilterTarget) -> String {
     }
 }
 
+/// Title suffix showing the current page for a paginated list. `offset` is the
+/// loaded page's record offset and `has_more` indicates a possible next page.
+/// Empty for the first page when no further pages exist.
+fn page_suffix(offset: i64, has_more: bool) -> String {
+    if offset == 0 && !has_more {
+        return String::new();
+    }
+    let page = offset / super::app::TUI_PAGE_SIZE + 1;
+    let next = if has_more { " ]:next" } else { "" };
+    let prev = if offset > 0 { " [:prev" } else { "" };
+    format!(" │ pg {}{}{}", page, prev, next)
+}
+
 fn format_timestamp_ms(timestamp_ms: i64) -> String {
     DateTime::from_timestamp_millis(timestamp_ms)
         .map(|dt: DateTime<Utc>| {
@@ -414,9 +427,17 @@ fn draw_workflows_table(f: &mut Frame, area: Rect, app: &mut App) {
         .fg(Color::Yellow)
         .add_modifier(Modifier::BOLD);
 
-    let header = Row::new(vec!["ID", "Name", "User", "Description"])
-        .style(header_style)
-        .bottom_margin(1);
+    let id_header = format!("ID{}", app.workflows_sort.id_indicator());
+    let name_header = format!("Name{}", app.workflows_sort.name_indicator());
+    let user_header = format!("User{}", app.workflows_sort.user_indicator());
+    let header = Row::new(vec![
+        id_header,
+        name_header,
+        user_header,
+        "Description".to_string(),
+    ])
+    .style(header_style)
+    .bottom_margin(1);
 
     let rows = app.workflows.iter().map(|workflow| {
         let id = workflow.id.map(|i| i.to_string()).unwrap_or_default();
@@ -436,12 +457,14 @@ fn draw_workflows_table(f: &mut Frame, area: Rect, app: &mut App) {
     });
 
     let filter = filter_suffix(app, FilterTarget::Workflows);
+    let page = page_suffix(app.workflows_offset, app.workflows_has_more);
     let (title, border_style) = if app.focus == Focus::Workflows {
         (
             Line::from(vec![
                 Span::styled("◆ ", Style::default().fg(Color::Green)),
                 Span::styled("Workflows", Style::default().fg(Color::White)),
                 Span::styled(filter, Style::default().fg(Color::Magenta)),
+                Span::styled(page, Style::default().fg(Color::DarkGray)),
                 Span::styled(
                     " │ Enter: load details",
                     Style::default().fg(Color::DarkGray),
@@ -455,6 +478,7 @@ fn draw_workflows_table(f: &mut Frame, area: Rect, app: &mut App) {
                 Span::styled("◇ ", Style::default().fg(Color::Cyan)),
                 Span::styled("Workflows", Style::default().fg(Color::White)),
                 Span::styled(filter, Style::default().fg(Color::Magenta)),
+                Span::styled(page, Style::default().fg(Color::DarkGray)),
             ]),
             Style::default().fg(Color::DarkGray),
         )
@@ -798,12 +822,14 @@ fn draw_jobs_table(f: &mut Frame, area: Rect, app: &mut App) {
     });
 
     let filter = filter_suffix(app, FilterTarget::Details);
+    let page = page_suffix(app.jobs_offset, app.jobs_has_more);
     let (title, border_style) = if app.focus == Focus::Details {
         (
             Line::from(vec![
                 Span::styled("▶ ", Style::default().fg(Color::Green)),
                 Span::styled("Jobs", Style::default().fg(Color::White)),
                 Span::styled(filter, Style::default().fg(Color::Magenta)),
+                Span::styled(page, Style::default().fg(Color::DarkGray)),
                 Span::styled(
                     " │ Enter: details  l: logs  C: cancel  t: terminate  y: retry",
                     Style::default().fg(Color::DarkGray),
@@ -817,6 +843,7 @@ fn draw_jobs_table(f: &mut Frame, area: Rect, app: &mut App) {
                 Span::styled("▶ ", Style::default().fg(Color::Cyan)),
                 Span::styled("Jobs", Style::default().fg(Color::White)),
                 Span::styled(filter, Style::default().fg(Color::Magenta)),
+                Span::styled(page, Style::default().fg(Color::DarkGray)),
             ]),
             Style::default().fg(Color::DarkGray),
         )
@@ -1084,12 +1111,14 @@ fn draw_results_table(f: &mut Frame, area: Rect, app: &mut App) {
     });
 
     let filter = filter_suffix(app, FilterTarget::Details);
+    let page = page_suffix(app.results_offset, app.results_has_more);
     let (title, border_style) = if is_focused {
         (
             Line::from(vec![
                 Span::styled("✓ ", Style::default().fg(Color::Green)),
                 Span::styled("Results", Style::default().fg(Color::White)),
                 Span::styled(filter, Style::default().fg(Color::Magenta)),
+                Span::styled(page, Style::default().fg(Color::DarkGray)),
             ]),
             Style::default().fg(Color::Green),
         )
@@ -1099,6 +1128,7 @@ fn draw_results_table(f: &mut Frame, area: Rect, app: &mut App) {
                 Span::styled("✓ ", Style::default().fg(Color::Cyan)),
                 Span::styled("Results", Style::default().fg(Color::White)),
                 Span::styled(filter, Style::default().fg(Color::Magenta)),
+                Span::styled(page, Style::default().fg(Color::DarkGray)),
             ]),
             Style::default().fg(Color::DarkGray),
         )
@@ -1140,15 +1170,25 @@ fn draw_compute_nodes_table(f: &mut Frame, area: Rect, app: &mut App) {
         .fg(Color::Yellow)
         .add_modifier(Modifier::BOLD);
 
+    let id_header = format!("ID{}", app.compute_nodes_sort.id_indicator());
+    let hostname_header = format!("Hostname{}", app.compute_nodes_sort.hostname_indicator());
+    let cpu_header = format!(
+        "CPU peak/avg{}",
+        app.compute_nodes_sort.peak_cpu_indicator()
+    );
+    let mem_header = format!(
+        "Mem peak/avg{}",
+        app.compute_nodes_sort.peak_memory_indicator()
+    );
     let header = Row::new(vec![
-        "ID",
-        "Hostname",
-        "CPUs",
-        "Memory",
-        "GPUs",
-        "Active",
-        "CPU peak/avg",
-        "Mem peak/avg",
+        id_header,
+        hostname_header,
+        "CPUs".to_string(),
+        "Memory".to_string(),
+        "GPUs".to_string(),
+        "Active".to_string(),
+        cpu_header,
+        mem_header,
     ])
     .style(header_style)
     .bottom_margin(1);
@@ -1182,12 +1222,14 @@ fn draw_compute_nodes_table(f: &mut Frame, area: Rect, app: &mut App) {
     });
 
     let filter = filter_suffix(app, FilterTarget::Details);
+    let page = page_suffix(app.compute_nodes_offset, app.compute_nodes_has_more);
     let (title, border_style) = if is_focused {
         (
             Line::from(vec![
                 Span::styled("▣ ", Style::default().fg(Color::Green)),
                 Span::styled("Compute Nodes", Style::default().fg(Color::White)),
                 Span::styled(filter, Style::default().fg(Color::Magenta)),
+                Span::styled(page, Style::default().fg(Color::DarkGray)),
             ]),
             Style::default().fg(Color::Green),
         )
@@ -1197,6 +1239,7 @@ fn draw_compute_nodes_table(f: &mut Frame, area: Rect, app: &mut App) {
                 Span::styled("▣ ", Style::default().fg(Color::Cyan)),
                 Span::styled("Compute Nodes", Style::default().fg(Color::White)),
                 Span::styled(filter, Style::default().fg(Color::Magenta)),
+                Span::styled(page, Style::default().fg(Color::DarkGray)),
             ]),
             Style::default().fg(Color::DarkGray),
         )

--- a/tests/test_access_groups.rs
+++ b/tests/test_access_groups.rs
@@ -1492,6 +1492,8 @@ fn test_comprehensive_access_control_workflow_execution(
         None,
         None,
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list jobs");
 

--- a/tests/test_ai_assisted_recovery.rs
+++ b/tests/test_ai_assisted_recovery.rs
@@ -174,6 +174,8 @@ fn test_list_pending_failed_jobs(start_server: &ServerProcess) {
         None,
         None,
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list pending_failed jobs");
 

--- a/tests/test_auto_ro_crate.rs
+++ b/tests/test_auto_ro_crate.rs
@@ -715,6 +715,8 @@ fn test_auto_ro_crate_diamond_workflow(start_server: &ServerProcess) {
         None,
         None,
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list jobs");
 

--- a/tests/test_auto_schedule.rs
+++ b/tests/test_auto_schedule.rs
@@ -139,6 +139,8 @@ fn test_no_schedulers_with_ready_jobs_scenario(start_server: &ServerProcess) {
         None,
         None,
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list jobs");
 
@@ -194,6 +196,8 @@ fn test_count_jobs_by_attempt_id(start_server: &ServerProcess) {
         None,
         None,
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list jobs");
 

--- a/tests/test_correct_resources.rs
+++ b/tests/test_correct_resources.rs
@@ -880,6 +880,8 @@ fn fetch_jobs(config: &torc::client::Configuration, workflow_id: i64) -> Vec<mod
         None,
         None,
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list jobs")
     .items

--- a/tests/test_direct_mode_e2e.rs
+++ b/tests/test_direct_mode_e2e.rs
@@ -52,6 +52,8 @@ fn verify_all_jobs_completed(server: &ServerProcess, workflow_id: i64) {
         None,
         None,
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list jobs");
 
@@ -106,6 +108,8 @@ fn get_job_return_code(server: &ServerProcess, workflow_id: i64, job_name: &str)
         None,
         None,
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list jobs");
 
@@ -1246,6 +1250,8 @@ execution_config:
         None,
         None,
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list jobs");
 
@@ -1347,6 +1353,8 @@ execution_config:
         None,
         None,
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list jobs");
 
@@ -1447,6 +1455,8 @@ execution_config:
         None,
         None,
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list jobs");
 

--- a/tests/test_dynamic_jobs.rs
+++ b/tests/test_dynamic_jobs.rs
@@ -380,6 +380,8 @@ fn test_env_merge_includes_workflow_env(start_server: &ServerProcess) {
         None,
         None,
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .unwrap()
     .items
@@ -439,6 +441,8 @@ fn test_spawned_jobs_have_origin_spawn(start_server: &ServerProcess) {
         None,
         None,
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .unwrap()
     .items
@@ -651,6 +655,8 @@ fn test_runner_flow_continuation_and_convergence(start_server: &ServerProcess) {
             None,
             None,
             None, // origin_is_set
+            None, // name
+            None, // command
         )
         .expect("list_jobs")
         .items
@@ -805,6 +811,8 @@ fn test_append_only_history(start_server: &ServerProcess) {
         None,
         None,
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .unwrap()
     .items
@@ -824,6 +832,8 @@ fn test_append_only_history(start_server: &ServerProcess) {
         None,
         None,
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .unwrap()
     .items
@@ -896,6 +906,8 @@ fn test_idempotent_replay(start_server: &ServerProcess) {
             None,
             None,
             None, // origin_is_set
+            None, // name
+            None, // command
         )
         .unwrap()
         .items
@@ -985,6 +997,8 @@ fn test_max_iterations_cap(start_server: &ServerProcess) {
         None,
         None,
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .unwrap()
     .items
@@ -1004,6 +1018,8 @@ fn test_max_iterations_cap(start_server: &ServerProcess) {
         None,
         None,
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .unwrap()
     .items

--- a/tests/test_full_workflows.rs
+++ b/tests/test_full_workflows.rs
@@ -93,6 +93,8 @@ fn verify_diamond_workflow_completion(
         None, // include_relationships
         None, // active_compute_node_id
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list jobs");
 
@@ -414,6 +416,8 @@ fn verify_many_jobs_completion(
         None, // include_relationships
         None, // active_compute_node_id
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list jobs");
 
@@ -600,6 +604,8 @@ resource_requirements:
         None,
         None, // active_compute_node_id
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list jobs");
 
@@ -713,6 +719,8 @@ resource_requirements:
         None,
         None, // active_compute_node_id
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list jobs after reset");
 
@@ -787,6 +795,8 @@ resource_requirements:
         None,
         None, // active_compute_node_id
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list jobs after second run");
 
@@ -980,6 +990,8 @@ resource_requirements:
         None,
         None, // active_compute_node_id
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list jobs");
 
@@ -1051,6 +1063,8 @@ resource_requirements:
         None,
         None, // active_compute_node_id
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list jobs after reinitialize");
 
@@ -1121,6 +1135,8 @@ resource_requirements:
         None,
         None, // active_compute_node_id
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list jobs after second run");
 

--- a/tests/test_jobs.rs
+++ b/tests/test_jobs.rs
@@ -268,6 +268,68 @@ fn test_jobs_list_sorting(start_server: &ServerProcess) {
 }
 
 #[rstest]
+fn test_jobs_list_name_command_filter(start_server: &ServerProcess) {
+    let config = &start_server.config;
+
+    let workflow = create_test_workflow(config, "test_name_filter_workflow");
+    let workflow_id = workflow.id.unwrap();
+
+    // create_test_job sets command = "echo 'Running <name>'".
+    let _ = create_test_job(config, workflow_id, "alpha_job");
+    let _ = create_test_job(config, workflow_id, "beta_job");
+    let _ = create_test_job(config, workflow_id, "gamma_job");
+
+    let list = |name: Option<&str>, command: Option<&str>| {
+        apis::jobs_api::list_jobs(
+            config,
+            workflow_id,
+            None, // status
+            None, // needs_file_id
+            None, // upstream_job_id
+            None, // offset
+            None, // limit
+            None, // sort_by
+            None, // reverse_sort
+            None, // include_relationships
+            None, // active_compute_node_id
+            None, // origin_is_set
+            name,
+            command,
+        )
+        .expect("list_jobs failed")
+    };
+
+    // Name substring matches a single job.
+    let alpha = list(Some("alpha"), None);
+    assert_eq!(alpha.total_count, 1);
+    assert_eq!(alpha.items.len(), 1);
+    assert_eq!(alpha.items[0].name, "alpha_job");
+
+    // Name substring shared by all jobs matches every job.
+    let all = list(Some("job"), None);
+    assert_eq!(all.total_count, 3);
+
+    // Command substring filter (command embeds the job name).
+    let beta = list(None, Some("Running beta"));
+    assert_eq!(beta.total_count, 1);
+    assert_eq!(beta.items[0].name, "beta_job");
+
+    // Case-insensitive for ASCII (SQLite LIKE default).
+    let upper = list(Some("GAMMA"), None);
+    assert_eq!(upper.total_count, 1);
+    assert_eq!(upper.items[0].name, "gamma_job");
+
+    // No match yields zero rows and zero total_count.
+    let none = list(Some("does_not_exist"), None);
+    assert_eq!(none.total_count, 0);
+    assert!(none.items.is_empty());
+
+    // Name and command together are ANDed.
+    let both = list(Some("alpha"), Some("Running beta"));
+    assert_eq!(both.total_count, 0);
+}
+
+#[rstest]
 fn test_jobs_get_command_json(start_server: &ServerProcess) {
     let config = &start_server.config;
 
@@ -1017,6 +1079,8 @@ fn test_jobs_delete_all(start_server: &ServerProcess) {
         None, // include_relationships
         None, // active_compute_node_id
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list jobs before deletion");
     assert_eq!(
@@ -1049,6 +1113,8 @@ fn test_jobs_delete_all(start_server: &ServerProcess) {
         None, // include_relationships
         None, // active_compute_node_id
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list jobs after deletion");
     assert_eq!(

--- a/tests/test_jobs_create_from_file.rs
+++ b/tests/test_jobs_create_from_file.rs
@@ -55,6 +55,8 @@ fn test_create_jobs_from_file_basic(start_server: &ServerProcess) {
         None, // include_relationships
         None, // active_compute_node_id
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list jobs");
 
@@ -126,6 +128,8 @@ echo 'job 3'
         None, // include_relationships
         None, // active_compute_node_id
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list jobs");
 
@@ -214,6 +218,8 @@ fn test_create_jobs_from_file_with_existing_jobs(start_server: &ServerProcess) {
         None, // include_relationships
         None, // active_compute_node_id
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list jobs");
 
@@ -289,6 +295,8 @@ fn test_create_jobs_from_file_name_conflicts(start_server: &ServerProcess) {
         None, // include_relationships
         None, // active_compute_node_id
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list jobs");
 
@@ -465,6 +473,8 @@ ffmpeg -i input.mp4 -vcodec libx264 output.mp4"#;
         None, // include_relationships
         None, // active_compute_node_id
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list jobs");
 

--- a/tests/test_multi_node_slurm.rs
+++ b/tests/test_multi_node_slurm.rs
@@ -307,6 +307,8 @@ fn test_two_node_allocation_one_worker_per_node_parallel_jobs(start_server: &Ser
         None, // include_relationships
         None, // active_compute_node_id
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list jobs")
     .items;

--- a/tests/test_orphaned_jobs.rs
+++ b/tests/test_orphaned_jobs.rs
@@ -122,6 +122,8 @@ fn test_start_job_sets_active_compute_node_id(start_server: &ServerProcess) {
         None,
         Some(compute_node_id), // active_compute_node_id filter
         None,                  // origin_is_set
+        None,                  // name
+        None,                  // command
     )
     .expect("Failed to list jobs");
 
@@ -197,6 +199,8 @@ fn test_complete_job_clears_active_compute_node_id(start_server: &ServerProcess)
         None,
         Some(compute_node_id),
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list jobs before completion");
     assert_eq!(jobs_before.items.len(), 1);
@@ -230,6 +234,8 @@ fn test_complete_job_clears_active_compute_node_id(start_server: &ServerProcess)
         None,
         Some(compute_node_id),
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list jobs after completion");
     assert_eq!(jobs_after.items.len(), 0);
@@ -324,6 +330,8 @@ fn test_orphaned_job_simulation(start_server: &ServerProcess) {
         None,
         Some(compute_node_id),
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list orphaned jobs");
 
@@ -364,6 +372,8 @@ fn test_orphaned_job_simulation(start_server: &ServerProcess) {
         None,
         None,
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list failed jobs");
     assert_eq!(failed_jobs.items.len(), 2);
@@ -382,6 +392,8 @@ fn test_orphaned_job_simulation(start_server: &ServerProcess) {
         None,
         Some(compute_node_id),
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list active jobs");
     assert_eq!(active_jobs.items.len(), 0);
@@ -450,6 +462,8 @@ fn test_list_jobs_no_active_compute_node(start_server: &ServerProcess) {
         None,
         Some(99999), // Non-existent compute_node_id
         None,        // origin_is_set
+        None,        // name
+        None,        // command
     )
     .expect("Failed to list jobs");
 
@@ -551,6 +565,8 @@ fn test_multiple_compute_nodes_job_tracking(start_server: &ServerProcess) {
         None,
         Some(cn1_id),
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list cn1 jobs");
     let cn1_items = cn1_jobs.items;
@@ -573,6 +589,8 @@ fn test_multiple_compute_nodes_job_tracking(start_server: &ServerProcess) {
         None,
         Some(cn2_id),
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list cn2 jobs");
     let cn2_items = cn2_jobs.items;
@@ -613,6 +631,8 @@ fn test_multiple_compute_nodes_job_tracking(start_server: &ServerProcess) {
         None,
         Some(cn1_id),
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list cn1 jobs after");
     assert_eq!(cn1_after.items.len(), 0);
@@ -631,6 +651,8 @@ fn test_multiple_compute_nodes_job_tracking(start_server: &ServerProcess) {
         None,
         Some(cn2_id),
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list cn2 jobs after");
     assert_eq!(cn2_after.items.len(), 2);
@@ -701,6 +723,8 @@ fn test_reset_job_clears_active_compute_node_id(start_server: &ServerProcess) {
         None,
         Some(compute_node_id),
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list before reset");
     assert_eq!(before_reset.items.len(), 1);
@@ -723,6 +747,8 @@ fn test_reset_job_clears_active_compute_node_id(start_server: &ServerProcess) {
         None,
         Some(compute_node_id),
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list after reset");
     assert_eq!(after_reset.items.len(), 0);

--- a/tests/test_slurm_commands.rs
+++ b/tests/test_slurm_commands.rs
@@ -1651,6 +1651,8 @@ fn test_slurm_run_jobs(start_server: &ServerProcess) {
         None, // include_relationships
         None, // active_compute_node_id
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list jobs");
 
@@ -1957,6 +1959,8 @@ fn test_cancel_workflow_with_slurm_scheduler(start_server: &ServerProcess) {
         None,      // include_relationships
         None,      // active_compute_node_id
         None,      // origin_is_set
+        None,      // name
+        None,      // command
     )
     .expect("Failed to list jobs");
 

--- a/tests/test_workflow_export.rs
+++ b/tests/test_workflow_export.rs
@@ -187,6 +187,8 @@ fn test_export_import_basic(start_server: &ServerProcess) {
         Some(true),
         None,
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list imported jobs");
     let imported_jobs = jobs_response.items;
@@ -621,6 +623,8 @@ fn test_import_id_remapping(start_server: &ServerProcess) {
         None,
         None,
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list jobs 1")
     .items;
@@ -638,6 +642,8 @@ fn test_import_id_remapping(start_server: &ServerProcess) {
         None,
         None,
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list jobs 2")
     .items;
@@ -789,6 +795,8 @@ fn test_export_import_ro_crate_job_id_remapping(start_server: &ServerProcess) {
         None,
         None,
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list imported jobs");
     let imported_jobs = jobs_response.items;

--- a/tests/test_workflow_manager.rs
+++ b/tests/test_workflow_manager.rs
@@ -377,6 +377,8 @@ fn test_start_workflow_basic(start_server: &ServerProcess) {
         None, // include_relationships
         None, // active_compute_node_id
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list jobs");
     let job_items = &jobs.items;
@@ -1247,6 +1249,8 @@ fn test_workflow_manager_end_to_end(start_server: &ServerProcess) {
         None, // include_relationships
         None, // active_compute_node_id
         None, // origin_is_set
+        None, // name
+        None, // command
     )
     .expect("Failed to list jobs");
     let job_items = &jobs.items;

--- a/tests/test_workflow_spec.rs
+++ b/tests/test_workflow_spec.rs
@@ -1563,6 +1563,8 @@ fn test_create_workflow_with_regex_job_dependencies(start_server: &ServerProcess
         Some(true), // include_relationships - needed for tests that check dependencies/files
         None,       // active_compute_node_id
         None,       // origin_is_set
+        None,       // name
+        None,       // command
     )
     .expect("Failed to list jobs");
 
@@ -1657,6 +1659,8 @@ fn test_create_workflow_with_regex_file_dependencies(start_server: &ServerProces
         Some(true), // include_relationships - needed for tests that check dependencies/files
         None,       // active_compute_node_id
         None,       // origin_is_set
+        None,       // name
+        None,       // command
     )
     .expect("Failed to list jobs");
 
@@ -1744,6 +1748,8 @@ fn test_create_workflow_with_regex_user_data_dependencies(start_server: &ServerP
         Some(true), // include_relationships - needed for tests that check dependencies/files
         None,       // active_compute_node_id
         None,       // origin_is_set
+        None,       // name
+        None,       // command
     )
     .expect("Failed to list jobs");
 
@@ -1834,6 +1840,8 @@ fn test_create_workflow_with_mixed_exact_and_regex_dependencies(start_server: &S
         Some(true), // include_relationships - needed for tests that check dependencies/files
         None,       // active_compute_node_id
         None,       // origin_is_set
+        None,       // name
+        None,       // command
     )
     .expect("Failed to list jobs");
 
@@ -3914,6 +3922,8 @@ fn test_create_subgraph_workflows_from_examples(start_server: &ServerProcess) {
             None,
             None, // active_compute_node_id
             None, // origin_is_set
+            None, // name
+            None, // command
         )
         .expect("Failed to list jobs");
 
@@ -4081,6 +4091,8 @@ fn test_subgraph_workflow_execution_plan_from_database() {
         Some(true), // include_relationships - this is key!
         None,       // active_compute_node_id
         None,       // origin_is_set
+        None,       // name
+        None,       // command
     )
     .expect("Failed to list jobs")
     .items;
@@ -4249,6 +4261,8 @@ fn test_subgraph_workflow_execution_plan_spec_vs_database() {
         Some(true), // include_relationships
         None,       // active_compute_node_id
         None,       // origin_is_set
+        None,       // name
+        None,       // command
     )
     .expect("Failed to list jobs")
     .items;


### PR DESCRIPTION
## Summary

Audited the CLI and TUI list/get surfaces for **jobs, workflows, results, and compute nodes** and closed the gaps found. The headline fix: on a workflow with 100k+ jobs, the TUI now pages on demand and filters jobs server-side instead of loading everything and substring-matching one page.

## TUI
- **On-demand pagination** — list views load 250 records per page; `]` / `[` page through Workflows, Jobs, Results, and Compute Nodes. Titles show the current page. (Previously every view loaded the entire list.)
- **Sorting** added to the Workflows and Compute Nodes tabs (parity with Jobs/Results), with header sort indicators.
- **Server-side Jobs filter** — `f` now filters across the whole workflow, not just the loaded page. Status resolves to a `JobStatus`; name/command are substring (`LIKE %value%`) matches. Paging preserves the active filter.

## CLI
- `torc workflows get` prints `execution_config` (text mode; JSON already included it).
- `torc jobs get` shows job priority.
- `torc workflows list` / `get` surface `run_id`, `is_canceled`, `is_archived`.

## Server
- New `name` and `command` substring query params on `GET /jobs`, following the workflows `description` filter pattern. Plumbed through the contract trait, `http_server`, the transport layer, and the SQL impl (applied to both the page query and the count query).

## Codegen
- Re-emitted/promoted the OpenAPI spec and regenerated the **Rust, Python, and Julia** clients.
- Added a `CLAUDE.md` note to use `CONTAINER_EXEC=podman` when Docker is unavailable.

## Tests
- New `test_jobs_list_name_command_filter` covering single/multi/zero matches, AND-combination, and ASCII case-insensitivity.

## Verification
- `cargo fmt --check`, `cargo clippy --all --all-targets --all-features -D warnings`, `dprint check` — all clean (enforced by pre-commit hook).
- 455 lib tests + jobs/workflow-manager/correct-resources integration tests pass.
- OpenAPI spec parity and client codegen parity (Rust/Python/Julia) both green.

## Notes for reviewers
- TUI page size is `TUI_PAGE_SIZE` (250) in `src/tui/app.rs`.
- Jobs status filtering changed from substring to resolved-exact (server takes one `JobStatus`); name/command remain substring and stay case-insensitive for ASCII via SQLite `LIKE`.
- Results/Compute Nodes filtering remains client-side within the loaded page; only Jobs got server-side filtering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)