### PR TITLE
Accept stdin (`-`) as workflow-spec input for CLI commands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -236,6 +236,7 @@ client = [
     "dep:flate2",
     "dep:tar",
     "dep:mime_guess",
+    "dep:tempfile",
     "config",
 ]
 tui = [

--- a/docs/src/core/reference/cli.md
+++ b/docs/src/core/reference/cli.md
@@ -74,13 +74,14 @@ Torc workflow orchestration system
 
 ## `torc run`
 
-Run a workflow locally (create from spec file or run existing workflow by ID)
+Run a workflow locally (create from spec file or stdin, or run existing workflow by ID)
 
 **Usage:** `torc run [OPTIONS] <WORKFLOW_SPEC_OR_ID>`
 
 ###### **Arguments:**
 
-- `<WORKFLOW_SPEC_OR_ID>` — Path to workflow spec file (JSON/JSON5/YAML) or workflow ID
+- `<WORKFLOW_SPEC_OR_ID>` — Path to workflow spec file (JSON/JSON5/YAML/KDL), workflow ID, or `-` to
+  read the spec from stdin
 
 ###### **Options:**
 
@@ -95,7 +96,7 @@ Run a workflow locally (create from spec file or run existing workflow by ID)
 
 ## `torc submit`
 
-Submit a workflow to scheduler (create from spec file or submit existing workflow by ID)
+Submit a workflow to scheduler (create from spec file or stdin, or submit existing workflow by ID)
 
 Requires workflow to have an on_workflow_start action with schedule_nodes. For Slurm workflows
 without pre-configured schedulers, use `slurm generate` + `submit` instead.
@@ -104,7 +105,8 @@ without pre-configured schedulers, use `slurm generate` + `submit` instead.
 
 ###### **Arguments:**
 
-- `<WORKFLOW_SPEC_OR_ID>` — Path to workflow spec file (JSON/JSON5/YAML) or workflow ID
+- `<WORKFLOW_SPEC_OR_ID>` — Path to workflow spec file (JSON/JSON5/YAML/KDL), workflow ID, or `-` to
+  read the spec from stdin
 
 ###### **Options:**
 
@@ -129,7 +131,13 @@ torc slurm generate --account <account> workflow.yaml
 ```
 
 Review the schedulers and actions to ensure they are appropriate for your workflow before
-submitting. You can save the output and submit manually:
+submitting. Then submit in one pipeline (`generate` writes to stdout, `submit -` reads stdin):
+
+```bash
+torc slurm generate --account <account> workflow.yaml | torc submit -
+```
+
+Or save the output to a file and submit that file:
 
 ```bash
 torc slurm generate --account <account> -o workflow_with_schedulers.yaml workflow.yaml
@@ -141,6 +149,8 @@ torc submit workflow_with_schedulers.yaml
 ```bash
 torc slurm generate [OPTIONS] --account <ACCOUNT> <WORKFLOW_FILE>
 torc submit <OUTPUT_FILE>
+# or, in a single pipeline:
+torc slurm generate [OPTIONS] --account <ACCOUNT> <WORKFLOW_FILE> | torc submit -
 ```
 
 See [`torc slurm generate`](#torc-slurm-generate) for full options.
@@ -378,14 +388,15 @@ level. Run `torc --help` to see all commands.
 
 ## `torc create`
 
-Create a workflow from a specification file (supports JSON, JSON5, YAML, and KDL formats)
+Create a workflow from a specification file or stdin (supports JSON, JSON5, YAML, and KDL formats)
 
 **Usage:** `torc create [OPTIONS] --user <USER> <FILE>`
 
 ###### **Arguments:**
 
-- `<FILE>` — Path to specification file containing WorkflowSpec. Supported formats: JSON (.json),
-  JSON5 (.json5), YAML (.yaml, .yml), KDL (.kdl). Format is auto-detected from file extension.
+- `<FILE>` — Path to specification file containing WorkflowSpec, or `-` to read the spec from stdin.
+  Supported formats: JSON (.json), JSON5 (.json5), YAML (.yaml, .yml), KDL (.kdl). Format is
+  auto-detected from file extension, or from the content itself when reading stdin.
 
 ###### **Options:**
 
@@ -1663,7 +1674,8 @@ Generate Slurm schedulers for a workflow based on job resource requirements
 
 ###### **Arguments:**
 
-- `<WORKFLOW_FILE>` — Path to workflow specification file (YAML, JSON, JSON5, or KDL)
+- `<WORKFLOW_FILE>` — Path to workflow specification file (YAML, JSON, JSON5, or KDL), or `-` to
+  read the spec from stdin
 
 ###### **Options:**
 

--- a/docs/src/core/workflows/creating-workflows.md
+++ b/docs/src/core/workflows/creating-workflows.md
@@ -23,6 +23,23 @@ torc create workflow.kdl
 
 Torc detects the format from the file extension.
 
+### Create from stdin
+
+Pass `-` instead of a path to read the spec from stdin. This is handy for shell pipelines and for
+generating a spec on the fly. The format is auto-detected from the piped content (no extension is
+available), so JSON, JSON5, YAML, and KDL all work.
+
+```bash
+# Pipe a file
+cat workflow.yaml | torc create -
+
+# Generate a spec and create in one pipeline
+torc slurm generate --account myproject workflow.yaml | torc submit -
+```
+
+The same `-` convention works for `torc run`, `torc submit`, `torc slurm generate`, and
+`torc slurm plan-allocations`.
+
 ### Create and Run in One Step
 
 For quick iteration, combine creation and execution:

--- a/docs/src/specialized/hpc/slurm-workflows.md
+++ b/docs/src/specialized/hpc/slurm-workflows.md
@@ -69,9 +69,17 @@ jobs:
 
 ### Submitting the Workflow
 
+`torc slurm generate` writes the augmented spec to stdout, so pipe it straight into `torc submit -`:
+
 ```bash
-torc slurm generate --account myproject workflow.yaml
-torc submit workflow.yaml
+torc slurm generate --account myproject workflow.yaml | torc submit -
+```
+
+Or save the generated spec to a file and submit that file:
+
+```bash
+torc slurm generate --account myproject -o workflow_with_slurm.yaml workflow.yaml
+torc submit workflow_with_slurm.yaml
 ```
 
 Torc will:

--- a/docs/src/specialized/hpc/submit-slurm-workflow.md
+++ b/docs/src/specialized/hpc/submit-slurm-workflow.md
@@ -4,14 +4,24 @@ Submit a workflow specification to a Slurm-based HPC system with automatic sched
 
 ## Quick Start
 
-Generate Slurm schedulers and submit in two steps:
+Generate Slurm schedulers and submit in a single pipeline. `torc slurm generate` writes the
+augmented spec to stdout, and `torc submit -` reads it from stdin:
 
 ```bash
-torc slurm generate --account <your-account> workflow.yaml
-torc submit workflow.yaml
+torc slurm generate --account <your-account> workflow.yaml | torc submit -
 ```
 
-Torc will:
+Prefer two explicit steps? Save the generated spec to a file first, then submit that file:
+
+```bash
+torc slurm generate --account <your-account> -o workflow_with_slurm.yaml workflow.yaml
+torc submit workflow_with_slurm.yaml
+```
+
+> Note: `torc slurm generate` does not modify the input file in place — it emits the augmented spec
+> to stdout (or to `-o <file>`). Submit the generated output, not the original `workflow.yaml`.
+
+Either way, torc will:
 
 1. Detect your HPC system (e.g., NLR Kestrel)
 2. Match job requirements to appropriate partitions

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -189,7 +189,7 @@ EXAMPLES:
 "
     )]
     Create {
-        /// Path to specification file containing WorkflowSpec
+        /// Path to specification file containing WorkflowSpec (or "-" to read from stdin)
         ///
         /// Supported formats:
         /// - JSON (.json): Standard JSON format
@@ -197,7 +197,9 @@ EXAMPLES:
         /// - YAML (.yaml, .yml): Human-readable YAML format
         /// - KDL (.kdl): KDL document format
         ///
-        /// Format is auto-detected from file extension, with fallback parsing attempted
+        /// Format is auto-detected from file extension, with fallback parsing attempted.
+        /// Pass "-" to read the spec from stdin (e.g. `torc slurm generate w.yaml | torc create -`);
+        /// the format is detected from the piped content.
         #[arg()]
         file: String,
         /// Disable resource monitoring (default: enabled with summary granularity and 5s sample rate)
@@ -236,7 +238,8 @@ SEE ALSO:
 "
     )]
     Run {
-        /// Path to workflow spec file (JSON/JSON5/YAML) or workflow ID
+        /// Path to workflow spec file (JSON/JSON5/YAML/KDL), workflow ID, or "-" to read the spec
+        /// from stdin
         #[arg()]
         workflow_spec_or_id: String,
         /// Maximum number of parallel jobs to run concurrently
@@ -409,6 +412,9 @@ EXAMPLES:
     # Submit existing workflow
     torc submit 123
 
+    # Generate Slurm schedulers and submit in one pipeline (spec read from stdin)
+    torc slurm generate --account myproj workflow.yaml | torc submit -
+
     # Ignore missing input data
     torc submit -i workflow.yaml
 
@@ -420,7 +426,8 @@ EXAMPLES:
 "
     )]
     Submit {
-        /// Path to workflow spec file (JSON/JSON5/YAML) or workflow ID
+        /// Path to workflow spec file (JSON/JSON5/YAML/KDL), workflow ID, or "-" to read the spec
+        /// from stdin
         #[arg()]
         workflow_spec_or_id: String,
         /// Ignore missing data (defaults to false)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -173,13 +173,16 @@ pub enum Commands {
     // =========================================================================
     // Workflow Execution - Primary commands for running workflows
     // =========================================================================
-    /// Create a workflow from a specification file (supports JSON, JSON5, YAML, and KDL formats)
+    /// Create a workflow from a specification file or stdin (supports JSON, JSON5, YAML, and KDL)
     #[command(
         hide = true,
         after_long_help = "\
 EXAMPLES:
     # Create workflow from YAML
     torc create my_workflow.yaml
+
+    # Read the spec from stdin (format detected from the piped content)
+    cat my_workflow.yaml | torc create -
 
     # Validate spec before creating
     torc create --dry-run my_workflow.yaml
@@ -213,13 +216,16 @@ EXAMPLES:
         #[arg(long)]
         dry_run: bool,
     },
-    /// Run a workflow locally (create from spec file or run existing workflow by ID)
+    /// Run a workflow locally (create from spec file or stdin, or run existing workflow by ID)
     #[command(
         hide = true,
         after_long_help = "\
 EXAMPLES:
     # Run from spec file
     torc run workflow.yaml
+
+    # Read the spec from stdin
+    cat workflow.yaml | torc run -
 
     # Run existing workflow
     torc run 123
@@ -397,7 +403,7 @@ SEE ALSO:
         #[arg(hide = true, trailing_var_arg = true)]
         trailing: Vec<String>,
     },
-    /// Submit a workflow to scheduler (create from spec file or submit existing workflow by ID)
+    /// Submit a workflow to scheduler (create from spec file or stdin, or submit existing by ID)
     ///
     /// Requires workflow to have an on_workflow_start action with schedule_nodes.
     /// For Slurm workflows without pre-configured schedulers, use

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -198,8 +198,8 @@ EXAMPLES:
         /// - KDL (.kdl): KDL document format
         ///
         /// Format is auto-detected from file extension, with fallback parsing attempted.
-        /// Pass "-" to read the spec from stdin (e.g. `torc slurm generate w.yaml | torc create -`);
-        /// the format is detected from the piped content.
+        /// Pass "-" to read the spec from stdin -- e.g. `torc slurm generate w.yaml | torc create -`.
+        /// The format is detected from the piped content.
         #[arg()]
         file: String,
         /// Disable resource monitoring (default: enabled with summary granularity and 5s sample rate)

--- a/src/client/commands/slurm.rs
+++ b/src/client/commands/slurm.rs
@@ -3917,8 +3917,12 @@ fn handle_plan_allocations(
     walltime_multiplier: f64,
     format: &str,
 ) {
+    // Preserve the original CLI argument for user-facing "Suggested" commands
+    // below; for stdin ("-") the staged temp path is not reusable by the user.
+    let workflow_file_arg = workflow_file.to_string_lossy().into_owned();
+
     // Resolve the spec source once (handles `-` reading from stdin).
-    let spec_source = match WorkflowSpec::resolve_spec_source(&workflow_file.to_string_lossy()) {
+    let spec_source = match WorkflowSpec::resolve_spec_source(&workflow_file_arg) {
         Ok(s) => s,
         Err(e) => {
             eprintln!("Error reading workflow spec: {}", e);
@@ -4109,15 +4113,13 @@ fn handle_plan_allocations(
                 "single" if rec.total_nodes > 1 => {
                     println!(
                         "    Suggested: torc slurm generate --account {} --single-allocation {}",
-                        result.account,
-                        workflow_file.display()
+                        result.account, workflow_file_arg
                     );
                 }
                 "many-small" => {
                     println!(
                         "    Suggested: torc slurm generate --account {} {}",
-                        result.account,
-                        workflow_file.display()
+                        result.account, workflow_file_arg
                     );
                 }
                 "chunked" => {

--- a/src/client/commands/slurm.rs
+++ b/src/client/commands/slurm.rs
@@ -529,7 +529,8 @@ EXAMPLES:
 "
     )]
     Generate {
-        /// Path to workflow specification file (YAML, JSON, JSON5, or KDL)
+        /// Path to workflow specification file (YAML, JSON, JSON5, or KDL), or "-" to read the
+        /// spec from stdin
         #[arg()]
         workflow_file: PathBuf,
 
@@ -715,7 +716,8 @@ EXAMPLES:
 "
     )]
     PlanAllocations {
-        /// Path to workflow specification file (YAML, JSON, JSON5, or KDL)
+        /// Path to workflow specification file (YAML, JSON, JSON5, or KDL), or "-" to read the
+        /// spec from stdin
         #[arg()]
         workflow_file: PathBuf,
 
@@ -3904,7 +3906,7 @@ pub fn analyze_plan_allocations(
 /// Handle the plan-allocations command
 #[allow(clippy::too_many_arguments)]
 fn handle_plan_allocations(
-    workflow_file: &PathBuf,
+    workflow_file: &Path,
     account: Option<&str>,
     partition: Option<&str>,
     profile_name: Option<&str>,
@@ -3915,6 +3917,16 @@ fn handle_plan_allocations(
     walltime_multiplier: f64,
     format: &str,
 ) {
+    // Resolve the spec source once (handles `-` reading from stdin).
+    let spec_source = match WorkflowSpec::resolve_spec_source(&workflow_file.to_string_lossy()) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("Error reading workflow spec: {}", e);
+            std::process::exit(1);
+        }
+    };
+    let workflow_file: &Path = spec_source.path();
+
     // Load HPC config and registry
     let torc_config = TorcConfig::load().unwrap_or_default();
     let registry = create_registry_with_config_public(&torc_config.client.hpc);
@@ -4138,7 +4150,7 @@ fn handle_plan_allocations(
 /// Handle the generate command - generates Slurm schedulers for a workflow
 #[allow(clippy::too_many_arguments)]
 fn handle_generate(
-    workflow_file: &PathBuf,
+    workflow_file: &Path,
     account: Option<&str>,
     profile_name: Option<&str>,
     output: Option<&PathBuf>,
@@ -4151,6 +4163,18 @@ fn handle_generate(
     dry_run: bool,
     format: &str,
 ) {
+    // Resolve the spec source once (handles `-` reading from stdin). The staged
+    // temp file carries the detected extension so the output-format heuristic
+    // below still matches the input format.
+    let spec_source = match WorkflowSpec::resolve_spec_source(&workflow_file.to_string_lossy()) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("Error reading workflow spec: {}", e);
+            std::process::exit(1);
+        }
+    };
+    let workflow_file: &Path = spec_source.path();
+
     // Load HPC config and registry
     let torc_config = TorcConfig::load().unwrap_or_default();
     let registry = create_registry_with_config_public(&torc_config.client.hpc);

--- a/src/client/commands/slurm.rs
+++ b/src/client/commands/slurm.rs
@@ -521,6 +521,12 @@ EXAMPLES:
     # Save to new file
     torc slurm generate --account myproject -o workflow_with_slurm.yaml workflow.yaml
 
+    # Generate and submit in one pipeline (output piped straight into submit)
+    torc slurm generate --account myproject workflow.yaml | torc submit -
+
+    # Read the spec from stdin, too
+    cat workflow.yaml | torc slurm generate --account myproject -
+
     # Use specific HPC profile
     torc slurm generate --account myproject --profile kestrel workflow.yaml
 
@@ -713,6 +719,9 @@ EXAMPLES:
 
     # Offline mode (skip sinfo/squeue, only analyze workflow)
     torc slurm plan-allocations --account myproject --offline workflow.yaml
+
+    # Read the spec from stdin
+    cat workflow.yaml | torc slurm plan-allocations --account myproject -
 "
     )]
     PlanAllocations {

--- a/src/client/workflow_spec.rs
+++ b/src/client/workflow_spec.rs
@@ -5,7 +5,7 @@ use crate::client::parameter_expansion::{
 };
 use std::collections::{HashMap, HashSet};
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
 use crate::models;
@@ -1382,6 +1382,25 @@ pub struct WorkflowSpec {
     /// name fails the whole create with a clear error.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub access_groups: Option<Vec<String>>,
+}
+
+/// A workflow-spec source resolved from a CLI argument that may be `-` (stdin).
+///
+/// When the argument is `-`, the stdin contents are staged in a temp file whose
+/// handle is held here; the file is removed when this value is dropped, so it
+/// must outlive any use of [`ResolvedSpecSource::path`].
+#[cfg(feature = "client")]
+pub struct ResolvedSpecSource {
+    _temp: Option<tempfile::NamedTempFile>,
+    path: PathBuf,
+}
+
+#[cfg(feature = "client")]
+impl ResolvedSpecSource {
+    /// Path to the spec file (the original argument, or the staged stdin temp file).
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
 }
 
 impl WorkflowSpec {
@@ -6106,6 +6125,83 @@ impl WorkflowSpec {
         Self::from_json_value(json_value)
     }
 
+    /// Detect the format of workflow-spec content by attempting each parser in
+    /// the same order as `from_spec_file`'s extension-less fallback. Returns a
+    /// canonical file extension ("json", "json5", "yaml", or "kdl"), or `None`
+    /// when the content cannot be parsed by any supported format.
+    pub fn detect_spec_format(content: &str) -> Option<&'static str> {
+        // A workflow spec is always a mapping/object. Requiring an object (rather
+        // than just "parses successfully") avoids false positives -- notably YAML,
+        // which happily parses arbitrary text such as KDL as a bare scalar string.
+        let parses_as_object = |v: Option<serde_json::Value>| v.is_some_and(|v| v.is_object());
+        if parses_as_object(serde_json::from_str(content).ok()) {
+            Some("json")
+        } else if parses_as_object(json5::from_str(content).ok()) {
+            Some("json5")
+        } else if parses_as_object(serde_yaml::from_str(content).ok()) {
+            Some("yaml")
+        } else {
+            #[cfg(feature = "client")]
+            {
+                if Self::kdl_to_json_value(content).is_ok() {
+                    return Some("kdl");
+                }
+            }
+            None
+        }
+    }
+
+    /// Resolve a workflow-spec CLI argument that may be `-` (stdin).
+    ///
+    /// For a normal path, the argument is used as-is. For `-`, the spec is read
+    /// once from stdin, its format is detected, and it is staged in a temp file
+    /// with a matching extension so the existing path-based loaders -- which may
+    /// read the file more than once (prevalidate, then create) -- work unchanged.
+    ///
+    /// The returned [`ResolvedSpecSource`] owns the temp file; keep it alive for
+    /// as long as its `path()` is used.
+    #[cfg(feature = "client")]
+    pub fn resolve_spec_source(
+        arg: &str,
+    ) -> Result<ResolvedSpecSource, Box<dyn std::error::Error>> {
+        use std::io::{IsTerminal, Read, Write};
+
+        if arg != "-" {
+            return Ok(ResolvedSpecSource {
+                _temp: None,
+                path: PathBuf::from(arg),
+            });
+        }
+
+        if std::io::stdin().is_terminal() {
+            return Err("workflow spec '-' requires piped stdin, but stdin is a terminal".into());
+        }
+
+        let mut content = String::new();
+        std::io::stdin().read_to_string(&mut content)?;
+        if content.trim().is_empty() {
+            return Err("workflow spec read from stdin is empty".into());
+        }
+
+        let ext = Self::detect_spec_format(&content).ok_or(
+            "unable to detect the format of the workflow spec read from stdin \
+             (expected JSON, JSON5, YAML, or KDL)",
+        )?;
+
+        let mut tmp = tempfile::Builder::new()
+            .prefix("torc-stdin-spec-")
+            .suffix(&format!(".{}", ext))
+            .tempfile()?;
+        tmp.write_all(content.as_bytes())?;
+        tmp.flush()?;
+        let path = tmp.path().to_path_buf();
+
+        Ok(ResolvedSpecSource {
+            _temp: Some(tmp),
+            path,
+        })
+    }
+
     /// Deserialize a WorkflowSpec from string content with a specified format
     /// Useful for testing or when content is already loaded
     /// All formats are first converted to serde_json::Value, then to WorkflowSpec,
@@ -6339,6 +6435,32 @@ mod tests {
     use super::*;
     use crate::client::resource_monitor::MonitorGranularity;
     use std::path::PathBuf;
+
+    #[test]
+    fn test_detect_spec_format() {
+        // Strict JSON is detected as JSON (and takes precedence over the JSON5/YAML
+        // supersets, since the checks run in that order).
+        assert_eq!(
+            WorkflowSpec::detect_spec_format(r#"{"name": "wf", "jobs": []}"#),
+            Some("json")
+        );
+        // JSON5-only syntax (comments, trailing commas, unquoted keys) is not valid JSON.
+        assert_eq!(
+            WorkflowSpec::detect_spec_format("{ name: 'wf', /* c */ jobs: [], }"),
+            Some("json5")
+        );
+        // Block-style YAML is neither JSON nor JSON5.
+        assert_eq!(
+            WorkflowSpec::detect_spec_format("name: wf\njobs:\n  - name: a\n    command: echo"),
+            Some("yaml")
+        );
+        // KDL is only attempted under the client feature.
+        #[cfg(feature = "client")]
+        assert_eq!(
+            WorkflowSpec::detect_spec_format("name \"wf\"\njobs {\n  job name=\"a\"\n}"),
+            Some("kdl")
+        );
+    }
 
     #[test]
     fn test_legacy_resource_monitor_yaml_controls_jobs() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -829,11 +829,19 @@ fn main() {
                     eprintln!("To submit to Slurm, either:");
                     eprintln!();
                     eprintln!("  1. Use 'torc slurm generate' to auto-generate schedulers:");
-                    eprintln!(
-                        "     torc slurm generate --account <account> -o {} {}",
-                        workflow_spec_or_id, workflow_spec_or_id
-                    );
-                    eprintln!("     torc submit {}", workflow_spec_or_id);
+                    if workflow_spec_or_id == "-" {
+                        // The spec came from stdin; a path-based example would be
+                        // misleading (the staged temp file is gone). Show a pipeline.
+                        eprintln!(
+                            "     ... | torc slurm generate --account <account> - | torc submit -"
+                        );
+                    } else {
+                        eprintln!(
+                            "     torc slurm generate --account <account> -o {} {}",
+                            workflow_spec_or_id, workflow_spec_or_id
+                        );
+                        eprintln!("     torc submit {}", workflow_spec_or_id);
+                    }
                     eprintln!();
                     eprintln!("  2. Add a workflow action manually:");
                     eprintln!("     actions:");
@@ -843,7 +851,11 @@ fn main() {
                     eprintln!("         scheduler: \"my-scheduler\"");
                     eprintln!();
                     eprintln!("Or run locally instead:");
-                    eprintln!("  torc run {}", workflow_spec_or_id);
+                    if workflow_spec_or_id == "-" {
+                        eprintln!("  ... | torc run -");
+                    } else {
+                        eprintln!("  torc run {}", workflow_spec_or_id);
+                    }
                     std::process::exit(1);
                 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -447,7 +447,9 @@ fn start_standalone_server(opts: StandaloneOptions) -> Result<StandaloneServer, 
 
 /// Helper function to determine if a string is a file path or workflow ID
 fn is_spec_file(arg: &str) -> bool {
-    arg.ends_with(".yaml")
+    // "-" reads a spec from stdin (e.g. `torc slurm generate ... | torc submit -`).
+    arg == "-"
+        || arg.ends_with(".yaml")
         || arg.ends_with(".yml")
         || arg.ends_with(".json")
         || arg.ends_with(".json5")
@@ -634,10 +636,19 @@ fn main() {
             skip_checks,
             dry_run,
         } => {
+            // Resolve the spec source once (handles `-` reading from stdin); the
+            // staged path is read multiple times by handle_create.
+            let spec_source = match WorkflowSpec::resolve_spec_source(file) {
+                Ok(s) => s,
+                Err(e) => {
+                    eprintln!("Error reading workflow spec: {}", e);
+                    std::process::exit(1);
+                }
+            };
             let user = torc::get_username();
             torc::client::commands::workflows::handle_create(
                 &config,
-                file,
+                &spec_source.path().to_string_lossy(),
                 &user,
                 *no_resource_monitoring,
                 *skip_checks,
@@ -658,18 +669,24 @@ fn main() {
             skip_checks,
         } => {
             let workflow_id = if is_spec_file(workflow_spec_or_id) {
+                // Resolve the spec source once (handles `-` reading from stdin) so
+                // both prevalidation and creation read the same staged content.
+                let spec_source = match WorkflowSpec::resolve_spec_source(workflow_spec_or_id) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        eprintln!("Error reading workflow spec: {}", e);
+                        std::process::exit(1);
+                    }
+                };
+                let spec_path = spec_source.path();
+
                 if !*skip_checks {
-                    WorkflowSpec::prevalidate_or_exit(workflow_spec_or_id);
+                    WorkflowSpec::prevalidate_or_exit(spec_path);
                 }
 
                 // Create workflow from spec file
                 let user = torc::get_username();
-                match WorkflowSpec::create_workflow_from_spec(
-                    &config,
-                    workflow_spec_or_id,
-                    &user,
-                    true,
-                ) {
+                match WorkflowSpec::create_workflow_from_spec(&config, spec_path, &user, true) {
                     Ok(id) => {
                         print_workflow_message(&format, id, &format!("Created workflow {}", id));
                         id
@@ -781,8 +798,20 @@ fn main() {
             poll_interval,
         } => {
             let workflow_id = if is_spec_file(workflow_spec_or_id) {
+                // Resolve the spec source once (handles `-` reading from stdin) so the
+                // schedule_nodes check, prevalidation, and creation all read the same
+                // staged content -- stdin can only be consumed a single time.
+                let spec_source = match WorkflowSpec::resolve_spec_source(workflow_spec_or_id) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        eprintln!("Error reading workflow spec: {}", e);
+                        std::process::exit(1);
+                    }
+                };
+                let spec_path = spec_source.path();
+
                 // Load and validate spec file
-                let spec = match WorkflowSpec::from_spec_file(workflow_spec_or_id) {
+                let spec = match WorkflowSpec::from_spec_file(spec_path) {
                     Ok(spec) => spec,
                     Err(e) => {
                         eprintln!("Error loading workflow spec: {}", e);
@@ -819,18 +848,13 @@ fn main() {
                 }
 
                 if !*skip_checks {
-                    WorkflowSpec::prevalidate_or_exit(workflow_spec_or_id);
+                    WorkflowSpec::prevalidate_or_exit(spec_path);
                 }
 
                 // Create workflow from spec
                 let user = torc::get_username();
 
-                match WorkflowSpec::create_workflow_from_spec(
-                    &config,
-                    workflow_spec_or_id,
-                    &user,
-                    true,
-                ) {
+                match WorkflowSpec::create_workflow_from_spec(&config, spec_path, &user, true) {
                     Ok(id) => {
                         print_workflow_message(&format, id, &format!("Created workflow {}", id));
                         id


### PR DESCRIPTION
## Summary

Adds stdin support (`-`) to all five workflow-spec-consuming CLI commands, enabling pipelines like:

```bash
torc slurm generate workflow.yaml | torc submit -
```

The argument `-` makes `create`, `run`, `submit`, `slurm generate`, and `slurm plan-allocations` read the spec from stdin instead of a file.

## How it works

Several of these commands read the spec path **more than once** — `submit` reads it three times (schedule-nodes check, prevalidation, creation) — but stdin can only be consumed once. To keep the existing path-based loaders unchanged, a single resolver reads stdin once, detects the format, and stages it in a temp file (carrying a matching extension) that the loaders then read normally. This mirrors the existing `torc exec -C -` stdin pattern.

## Changes

- **`src/client/workflow_spec.rs`** — two new `WorkflowSpec` helpers:
  - `detect_spec_format()` — sniffs JSON → JSON5 → YAML → KDL, requiring the parse to yield an **object** (workflow specs always are), which prevents YAML from greedily swallowing KDL as a bare scalar.
  - `resolve_spec_source()` — returns a `ResolvedSpecSource` (RAII temp-file holder); guards against a terminal/empty stdin.
- **`src/main.rs`** — `is_spec_file("-")` now returns true; `create`/`run`/`submit` resolve the source once and feed the staged path to all downstream reads.
- **`src/client/commands/slurm.rs`** — `generate` and `plan-allocations` resolve `-` at handler entry; `generate`'s output format still matches the piped input via the staged file's sniffed extension.
- **`Cargo.toml`** — add `tempfile` to the `client` feature.
- Help text updated on all five args, plus a pipeline example on `submit`.

## Testing

- `cargo clippy --all --all-targets --all-features -D warnings` and `cargo fmt --check` — clean
- Smoke-tested all four formats (YAML/JSON/JSON5/KDL) piped into `create --dry-run -`
- Verified the canonical pipe `slurm generate <spec> | torc create --dry-run -` produces a submittable workflow
- Confirmed the terminal/empty-stdin guards fire
- New `test_detect_spec_format` unit test; all 111 `workflow_spec` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)