### PR TITLE
Fix dash status badges + Peak CPU column, default TUI workflows to newest-first

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -683,7 +683,9 @@ impl App {
             workflows: Vec::new(),
             workflows_all: Vec::new(),
             workflows_state: TableState::default(),
-            workflows_sort: WorkflowsSort::None,
+            // Default to newest-first to match the dash. Users can cycle
+            // through Asc / unsorted with the ID column shortcut.
+            workflows_sort: WorkflowsSort::IdDesc,
             workflows_offset: 0,
             workflows_has_more: false,
             jobs: Vec::new(),

--- a/torc-dash/static/css/style.css
+++ b/torc-dash/static/css/style.css
@@ -623,6 +623,7 @@ body {
 .status-running { background: #cce5ff; color: #004085; }
 .status-completed { background: #d4edda; color: #155724; }
 .status-failed { background: #f8d7da; color: #721c24; }
+.status-pending_failed { background: #f8d7da; color: #721c24; }
 .status-canceled { background: #e2d9f3; color: #4a235a; }
 .status-terminated { background: #d6d8db; color: #383d41; }
 .status-disabled { background: #fdfdfe; color: #818182; }

--- a/torc-dash/static/js/app-debugging.js
+++ b/torc-dash/static/js/app-debugging.js
@@ -151,8 +151,6 @@ Object.assign(TorcDashboard.prototype, {
             return;
         }
 
-        const statusNames = ['Uninitialized', 'Blocked', 'Ready', 'Pending', 'Running', 'Completed', 'Failed', 'Canceled', 'Terminated', 'Disabled'];
-
         container.innerHTML = `
             <table class="data-table">
                 <thead>
@@ -170,7 +168,7 @@ Object.assign(TorcDashboard.prototype, {
                         return `
                             <tr class="debug-table-row" onclick="app.selectDebugJob(${idx})">
                                 <td>${this.escapeHtml(job.name || '-')}</td>
-                                <td><span class="status-badge status-${statusNames[job.status]?.toLowerCase() || 'unknown'}">${statusNames[job.status] || '-'}</span></td>
+                                <td><span class="status-badge status-${this.jobStatusSlug(job.status)}">${this.formatJobStatus(job.status) || '-'}</span></td>
                                 <td class="${result?.return_code === 0 ? 'return-code-0' : 'return-code-error'}">${result?.return_code ?? '-'}</td>
                                 <td><code>${result?.stdoutPath ? this.escapeHtml(this.truncate(result.stdoutPath, 40)) : '-'}</code></td>
                                 <td><code>${result?.stderrPath ? this.escapeHtml(this.truncate(result.stderrPath, 40)) : '-'}</code></td>

--- a/torc-dash/static/js/app-details.js
+++ b/torc-dash/static/js/app-details.js
@@ -400,15 +400,13 @@ Object.assign(TorcDashboard.prototype, {
     },
 
     renderTableBodyRows(items, tabType, jobNameMap) {
-        const statusNames = ['Uninitialized', 'Blocked', 'Ready', 'Pending', 'Running', 'Completed', 'Failed', 'Canceled', 'Terminated', 'Disabled'];
-
         switch (tabType) {
             case 'jobs':
                 return items.map(job => `
                     <tr>
                         <td><code>${job.id ?? '-'}</code></td>
                         <td>${this.escapeHtml(job.name || '-')}</td>
-                        <td><span class="status-badge status-${statusNames[job.status]?.toLowerCase() || 'unknown'}">${statusNames[job.status] || job.status}</span></td>
+                        <td><span class="status-badge status-${this.jobStatusSlug(job.status)}">${this.formatJobStatus(job.status)}</span></td>
                         <td><code>${this.escapeHtml(this.truncate(job.command || '-', 80))}</code></td>
                         <td><button class="btn-job-details" data-job-id="${job.id}" data-job-name="${this.escapeHtml(job.name || '')}">Details</button></td>
                     </tr>
@@ -422,10 +420,10 @@ Object.assign(TorcDashboard.prototype, {
                         <td>${result.run_id ?? '-'}</td>
                         <td>${result.attempt_id ?? 1}</td>
                         <td class="${result.return_code === 0 ? 'return-code-0' : 'return-code-error'}">${result.return_code ?? '-'}</td>
-                        <td><span class="status-badge status-${statusNames[result.status]?.toLowerCase() || 'unknown'}">${statusNames[result.status] || result.status}</span></td>
+                        <td><span class="status-badge status-${this.jobStatusSlug(result.status)}">${this.formatJobStatus(result.status)}</span></td>
                         <td>${result.exec_time_minutes != null ? result.exec_time_minutes.toFixed(2) : '-'}</td>
                         <td>${this.formatBytes(result.peak_memory_bytes)}</td>
-                        <td>${result.avg_cpu_percent != null ? result.avg_cpu_percent.toFixed(1) : '-'}</td>
+                        <td>${result.peak_cpu_percent != null ? result.peak_cpu_percent.toFixed(1) : '-'}</td>
                     </tr>
                 `).join('');
 
@@ -570,14 +568,10 @@ Object.assign(TorcDashboard.prototype, {
             let itemValue = this.getFieldValue(item, field, tabType, jobNameMap);
 
             if (field === 'status') {
-                const statusNames = ['uninitialized', 'blocked', 'ready', 'pending', 'running', 'completed', 'failed', 'canceled', 'terminated', 'disabled'];
                 const filterStatusName = value.toLowerCase();
-                let itemStatusName;
-                if (typeof item.status === 'number') {
-                    itemStatusName = statusNames[item.status] || '';
-                } else {
-                    itemStatusName = String(item.status).toLowerCase();
-                }
+                const itemStatusName = typeof item.status === 'number'
+                    ? (this.JOB_STATUS_ORDER[item.status] || '')
+                    : String(item.status).toLowerCase();
                 switch (operator) {
                     case '=': return itemStatusName === filterStatusName;
                     case '!=': return itemStatusName !== filterStatusName;
@@ -631,11 +625,10 @@ Object.assign(TorcDashboard.prototype, {
     },
 
     getSearchableText(item, tabType, jobNameMap) {
-        const statusNames = ['Uninitialized', 'Blocked', 'Ready', 'Pending', 'Running', 'Completed', 'Failed', 'Canceled', 'Terminated', 'Disabled'];
         const parts = [];
         if (item.id != null) parts.push(String(item.id));
         if (item.name) parts.push(item.name);
-        if (item.status != null) parts.push(statusNames[item.status] || '');
+        if (item.status != null) parts.push(this.formatJobStatus(item.status));
 
         switch (tabType) {
             case 'jobs':

--- a/torc-dash/static/js/app-job-details.js
+++ b/torc-dash/static/js/app-job-details.js
@@ -144,7 +144,6 @@ Object.assign(TorcDashboard.prototype, {
     },
 
     renderJobDetailsSummary(job) {
-        const statusNames = ['Uninitialized', 'Blocked', 'Ready', 'Pending', 'Running', 'Completed', 'Failed', 'Canceled', 'Terminated', 'Disabled'];
         const summaryEl = document.getElementById('job-details-summary');
 
         summaryEl.innerHTML = `
@@ -159,7 +158,7 @@ Object.assign(TorcDashboard.prototype, {
                 </div>
                 <div class="job-details-summary-item">
                     <span class="label">Status</span>
-                    <span class="value"><span class="status-badge status-${statusNames[job.status]?.toLowerCase() || 'unknown'}">${statusNames[job.status] || job.status}</span></span>
+                    <span class="value"><span class="status-badge status-${this.jobStatusSlug(job.status)}">${this.formatJobStatus(job.status)}</span></span>
                 </div>
                 <div class="job-details-summary-item">
                     <span class="label">Compute Node</span>
@@ -196,7 +195,6 @@ Object.assign(TorcDashboard.prototype, {
         }
 
         const data = this.jobDetailsData;
-        const statusNames = ['Uninitialized', 'Blocked', 'Ready', 'Pending', 'Running', 'Completed', 'Failed', 'Canceled', 'Terminated', 'Disabled'];
 
         switch (tabName) {
             case 'results':
@@ -213,7 +211,7 @@ Object.assign(TorcDashboard.prototype, {
                                     <th>Status</th>
                                     <th>Exec Time (min)</th>
                                     <th>Peak Mem</th>
-                                    <th>Avg CPU %</th>
+                                    <th>Peak CPU %</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -222,10 +220,10 @@ Object.assign(TorcDashboard.prototype, {
                                         <td>${r.run_id ?? '-'}</td>
                                         <td>${r.attempt_id ?? 1}</td>
                                         <td class="${r.return_code === 0 ? 'return-code-0' : 'return-code-error'}">${r.return_code ?? '-'}</td>
-                                        <td><span class="status-badge status-${statusNames[r.status]?.toLowerCase() || 'unknown'}">${statusNames[r.status] || r.status}</span></td>
+                                        <td><span class="status-badge status-${this.jobStatusSlug(r.status)}">${this.formatJobStatus(r.status)}</span></td>
                                         <td>${r.exec_time_minutes != null ? r.exec_time_minutes.toFixed(2) : '-'}</td>
                                         <td>${this.formatBytes(r.peak_memory_bytes)}</td>
-                                        <td>${r.avg_cpu_percent != null ? r.avg_cpu_percent.toFixed(1) : '-'}</td>
+                                        <td>${r.peak_cpu_percent != null ? r.peak_cpu_percent.toFixed(1) : '-'}</td>
                                     </tr>
                                 `).join('')}
                             </tbody>
@@ -306,7 +304,7 @@ Object.assign(TorcDashboard.prototype, {
                                         <tr>
                                             <td><code>${j.id ?? '-'}</code></td>
                                             <td>${this.escapeHtml(j.name || '-')}</td>
-                                            <td><span class="status-badge status-${statusNames[j.status]?.toLowerCase() || 'unknown'}">${statusNames[j.status] || j.status}</span></td>
+                                            <td><span class="status-badge status-${this.jobStatusSlug(j.status)}">${this.formatJobStatus(j.status)}</span></td>
                                         </tr>
                                     `).join('')}
                                 </tbody>
@@ -330,7 +328,7 @@ Object.assign(TorcDashboard.prototype, {
                                         <tr>
                                             <td><code>${j.id ?? '-'}</code></td>
                                             <td>${this.escapeHtml(j.name || '-')}</td>
-                                            <td><span class="status-badge status-${statusNames[j.status]?.toLowerCase() || 'unknown'}">${statusNames[j.status] || j.status}</span></td>
+                                            <td><span class="status-badge status-${this.jobStatusSlug(j.status)}">${this.formatJobStatus(j.status)}</span></td>
                                         </tr>
                                     `).join('')}
                                 </tbody>

--- a/torc-dash/static/js/app-tables.js
+++ b/torc-dash/static/js/app-tables.js
@@ -45,8 +45,6 @@ Object.assign(TorcDashboard.prototype, {
             return `${controls}<div class="placeholder-message">No jobs in this workflow</div>`;
         }
 
-        const statusNames = ['Uninitialized', 'Blocked', 'Ready', 'Pending', 'Running', 'Completed', 'Failed', 'Canceled', 'Terminated', 'Disabled'];
-
         return `
             ${controls}
             ${count}
@@ -64,13 +62,13 @@ Object.assign(TorcDashboard.prototype, {
                 </thead>
                 <tbody>
                     ${jobs.map(job => {
-                        const isRunning = statusNames[job.status] === 'Running';
+                        const isRunning = job.status === 'running';
                         const elapsed = isRunning ? this.formatElapsedSince(job.start_time) : '-';
                         return `
                         <tr>
                             <td><code>${job.id ?? '-'}</code></td>
                             <td>${this.escapeHtml(job.name || '-')}</td>
-                            <td><span class="status-badge status-${statusNames[job.status]?.toLowerCase() || 'unknown'}">${statusNames[job.status] || job.status}</span></td>
+                            <td><span class="status-badge status-${this.jobStatusSlug(job.status)}">${this.formatJobStatus(job.status)}</span></td>
                             <td><code>${job.compute_node_id ?? '-'}</code></td>
                             <td><code>${elapsed}</code></td>
                             <td><code>${this.escapeHtml(this.truncate(job.command || '-', 80))}</code></td>
@@ -167,8 +165,6 @@ Object.assign(TorcDashboard.prototype, {
             });
         }
 
-        const statusNames = ['Uninitialized', 'Blocked', 'Ready', 'Pending', 'Running', 'Completed', 'Failed', 'Canceled', 'Terminated', 'Disabled'];
-
         return `
             ${controls}
             ${count}
@@ -183,7 +179,7 @@ Object.assign(TorcDashboard.prototype, {
                         ${this.renderSortableHeader('Status', 'status')}
                         ${this.renderSortableHeader('Exec Time (min)', 'exec_time_minutes')}
                         ${this.renderSortableHeader('Peak Mem', 'peak_memory_bytes')}
-                        ${this.renderSortableHeader('Avg CPU %', 'avg_cpu_percent')}
+                        ${this.renderSortableHeader('Peak CPU %', 'peak_cpu_percent')}
                     </tr>
                 </thead>
                 <tbody>
@@ -194,10 +190,10 @@ Object.assign(TorcDashboard.prototype, {
                             <td>${result.run_id ?? '-'}</td>
                             <td>${result.attempt_id ?? 1}</td>
                             <td class="${result.return_code === 0 ? 'return-code-0' : 'return-code-error'}">${result.return_code ?? '-'}</td>
-                            <td><span class="status-badge status-${statusNames[result.status]?.toLowerCase() || 'unknown'}">${statusNames[result.status] || result.status}</span></td>
+                            <td><span class="status-badge status-${this.jobStatusSlug(result.status)}">${this.formatJobStatus(result.status)}</span></td>
                             <td>${result.exec_time_minutes != null ? result.exec_time_minutes.toFixed(2) : '-'}</td>
                             <td>${this.formatBytes(result.peak_memory_bytes)}</td>
-                            <td>${result.avg_cpu_percent != null ? result.avg_cpu_percent.toFixed(1) : '-'}</td>
+                            <td>${result.peak_cpu_percent != null ? result.peak_cpu_percent.toFixed(1) : '-'}</td>
                         </tr>
                     `).join('')}
                 </tbody>

--- a/torc-dash/static/js/app-tables.js
+++ b/torc-dash/static/js/app-tables.js
@@ -62,7 +62,9 @@ Object.assign(TorcDashboard.prototype, {
                 </thead>
                 <tbody>
                     ${jobs.map(job => {
-                        const isRunning = job.status === 'running';
+                        // Route through jobStatusSlug so the legacy-integer
+                        // fallback in the helper covers both wire formats.
+                        const isRunning = this.jobStatusSlug(job.status) === 'running';
                         const elapsed = isRunning ? this.formatElapsedSince(job.start_time) : '-';
                         return `
                         <tr>

--- a/torc-dash/static/js/app-utils.js
+++ b/torc-dash/static/js/app-utils.js
@@ -101,6 +101,52 @@ Object.assign(TorcDashboard.prototype, {
         return `${secs}s`;
     },
 
+    // Canonical capitalized display names for JobStatus, keyed by the
+    // snake_case strings the server sends per the OpenAPI enum. Older code
+    // indexed `['Uninitialized', ...]` by an integer status, which silently
+    // returned undefined once the API switched to string status — keep both
+    // shapes working so the dash doesn't quietly fall back to "unknown".
+    JOB_STATUS_NAMES: {
+        uninitialized: 'Uninitialized',
+        blocked: 'Blocked',
+        ready: 'Ready',
+        pending: 'Pending',
+        running: 'Running',
+        completed: 'Completed',
+        failed: 'Failed',
+        canceled: 'Canceled',
+        terminated: 'Terminated',
+        disabled: 'Disabled',
+        pending_failed: 'Pending Failed',
+    },
+
+    JOB_STATUS_ORDER: [
+        'uninitialized', 'blocked', 'ready', 'pending', 'running',
+        'completed', 'failed', 'canceled', 'terminated', 'disabled',
+        'pending_failed',
+    ],
+
+    // Return the capitalized display name for a JobStatus, accepting either
+    // the snake_case string (current API) or the legacy integer index.
+    // Falls back to stringifying unknown values rather than returning ''.
+    formatJobStatus(status) {
+        if (status == null) return '';
+        if (typeof status === 'number') {
+            return this.JOB_STATUS_NAMES[this.JOB_STATUS_ORDER[status]] || String(status);
+        }
+        return this.JOB_STATUS_NAMES[status] || String(status);
+    },
+
+    // CSS-class slug for the status badge ("running", "completed", ...).
+    // Returns 'unknown' for nulls/unrecognized values.
+    jobStatusSlug(status) {
+        if (status == null) return 'unknown';
+        if (typeof status === 'number') {
+            return this.JOB_STATUS_ORDER[status] || 'unknown';
+        }
+        return this.JOB_STATUS_NAMES[status] ? status : 'unknown';
+    },
+
     formatBytes(bytes) {
         if (bytes == null) return '-';
         if (bytes === 0) return '0 B';

--- a/torc-dash/static/js/dag.js
+++ b/torc-dash/static/js/dag.js
@@ -12,30 +12,36 @@ class DAGVisualizer {
     }
 
     // Status to color mapping
+    // Keyed by the snake_case JobStatus string the server sends, per the
+    // OpenAPI enum. (Previously keyed by the legacy integer status, which
+    // made every node fall back to the gray default once the API switched
+    // to string status.)
     static statusColors = {
-        0: '#6c757d', // uninitialized
-        1: '#ffc107', // blocked
-        2: '#17a2b8', // ready
-        3: '#fd7e14', // pending
-        4: '#007bff', // running
-        5: '#28a745', // completed
-        6: '#dc3545', // failed
-        7: '#6f42c1', // canceled
-        8: '#adb5bd', // terminated
-        9: '#e9ecef', // disabled
+        uninitialized: '#6c757d',
+        blocked: '#ffc107',
+        ready: '#17a2b8',
+        pending: '#fd7e14',
+        running: '#007bff',
+        completed: '#28a745',
+        failed: '#dc3545',
+        canceled: '#6f42c1',
+        terminated: '#adb5bd',
+        disabled: '#e9ecef',
+        pending_failed: '#dc3545',
     };
 
     static statusNames = {
-        0: 'Uninitialized',
-        1: 'Blocked',
-        2: 'Ready',
-        3: 'Pending',
-        4: 'Running',
-        5: 'Completed',
-        6: 'Failed',
-        7: 'Canceled',
-        8: 'Terminated',
-        9: 'Disabled',
+        uninitialized: 'Uninitialized',
+        blocked: 'Blocked',
+        ready: 'Ready',
+        pending: 'Pending',
+        running: 'Running',
+        completed: 'Completed',
+        failed: 'Failed',
+        canceled: 'Canceled',
+        terminated: 'Terminated',
+        disabled: 'Disabled',
+        pending_failed: 'Pending Failed',
     };
 
     initialize() {


### PR DESCRIPTION
## Summary

Two small bug fixes that came up after PR #351 landed.

### Dash status indexing was broken everywhere

The dash assumed `job.status` / `result.status` was an integer index into local `['Uninitialized', 'Blocked', ...]` arrays, but the API serves it as a snake_case string per the OpenAPI `JobStatus` enum (`#[serde(rename_all = \"snake_case\")]`). Symptoms:

- **Jobs table "Elapsed" column always rendered `-`** because the \`isRunning\` check (`statusNames[job.status] === 'Running'`) was comparing `undefined` to `'Running'`.
- **Status badges quietly fell back to `status-unknown`** and displayed the raw lowercase string (e.g. `running`) instead of the capitalized "Running" with the right colors.
- **DAG visualizer rendered every node gray** because its integer-keyed `statusColors` / `statusNames` maps missed on every string status.

Added `JOB_STATUS_NAMES` + `formatJobStatus()` + `jobStatusSlug()` helpers to `app-utils.js` (string-keyed, with a defensive integer fallback) and routed all 8 badge call sites in `app-tables.js`, `app-details.js`, `app-job-details.js`, and `app-debugging.js` through them. Rekeyed `DAGVisualizer.statusColors` and `statusNames` to snake_case strings.

### Results tab showed Avg CPU instead of Peak CPU

The CLI's `torc results list` shows **Peak CPU %**, but the dash results tab was showing the `avg_cpu_percent` field under an "Avg CPU %" header. Switched both the column header and the value to `peak_cpu_percent` in the main results table (`app-tables.js`) and the per-job results sub-tab (`app-job-details.js`).

### TUI workflows list now defaults to newest-first

The dash already sorts workflows by id descending so users see the most recent runs without scrolling; the TUI was inheriting whatever order the API returned (ascending by id). Switched the default `workflows_sort` to `IdDesc` in `src/tui/app.rs` so the two surfaces agree.

Sort is still user-controllable — the existing ID column shortcut cycles Desc → Asc → unsorted as before, just from a different starting point.

## Test plan

- [x] \`cargo build --bin torc --features \"client,tui,plot_resources\"\` — clean
- [x] \`cargo nextest run --lib\` — passes
- [ ] Manual: open dash, confirm jobs table "Elapsed" shows time for running jobs (was always \`-\`)
- [ ] Manual: confirm status badges show capitalized names with proper colors (Running blue, Completed green, etc.)
- [ ] Manual: open the DAG view; nodes should be colored by status, not all gray
- [ ] Manual: open results tab; header should say "Peak CPU %" and values should match \`torc results list\`
- [ ] Manual: launch TUI; workflows list should show newest IDs at the top

🤖 Generated with [Claude Code](https://claude.com/claude-code)