### PR TITLE
Anchor TUI Jobs Elapsed to a snapshot timestamp

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -567,6 +567,11 @@ pub struct App {
     pub jobs_offset: i64,
     /// True when the last Jobs-tab fetch filled a full page.
     pub jobs_has_more: bool,
+    /// Wall-clock time of the most recent `jobs_all` fetch. The Jobs table's
+    /// Elapsed column is computed relative to this snapshot instead of
+    /// `Utc::now()` so it doesn't keep ticking up against stale rows whose
+    /// server-side status has since moved off Running.
+    pub jobs_fetched_at: Option<chrono::DateTime<chrono::Utc>>,
     pub files: Vec<FileModel>,
     pub files_all: Vec<FileModel>,
     pub files_state: TableState,
@@ -695,6 +700,7 @@ impl App {
             jobs_sort: JobsSort::None,
             jobs_offset: 0,
             jobs_has_more: false,
+            jobs_fetched_at: None,
             files: Vec::new(),
             files_all: Vec::new(),
             files_state: TableState::default(),
@@ -1106,6 +1112,7 @@ impl App {
                         if self.jobs_workflow_id != Some(workflow_id) {
                             self.jobs_all = self.client.list_jobs(workflow_id, None, None)?;
                             self.jobs_workflow_id = Some(workflow_id);
+                            self.jobs_fetched_at = Some(chrono::Utc::now());
                         }
                         self.jobs = self.jobs_all.clone();
                         self.apply_jobs_sort();
@@ -1205,6 +1212,7 @@ impl App {
                         if self.jobs_workflow_id != Some(workflow_id) {
                             self.jobs_all = self.client.list_jobs(workflow_id, None, None)?;
                             self.jobs_workflow_id = Some(workflow_id);
+                            self.jobs_fetched_at = Some(chrono::Utc::now());
                             self.jobs = self.jobs_all.clone();
                             self.apply_jobs_sort();
                         }
@@ -1744,6 +1752,7 @@ impl App {
             self.jobs = Vec::new();
             self.jobs_has_more = false;
             self.jobs_state.select(None);
+            self.jobs_fetched_at = None;
             if let Some(msg) = message {
                 self.set_status(StatusMessage::error(&msg));
             }
@@ -1758,6 +1767,7 @@ impl App {
             name.as_deref(),
             command.as_deref(),
         )?;
+        self.jobs_fetched_at = Some(chrono::Utc::now());
         self.jobs = self.jobs_all.clone();
         self.apply_jobs_sort();
         if self.jobs.is_empty() {
@@ -2513,6 +2523,7 @@ impl App {
                 if let Ok(jobs) = self.client.list_jobs(workflow_id, None, None) {
                     self.jobs_all = jobs.clone();
                     self.jobs_workflow_id = Some(workflow_id);
+                    self.jobs_fetched_at = Some(chrono::Utc::now());
                     self.jobs = jobs;
                     self.apply_jobs_sort();
                     if !self.jobs.is_empty() {

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -819,7 +819,7 @@ fn draw_jobs_table(f: &mut Frame, area: Rect, app: &mut App) {
             .map(|n| n.to_string())
             .unwrap_or_default();
         let elapsed = if matches!(job.status, Some(crate::models::JobStatus::Running)) {
-            format_elapsed(job.start_time.as_deref())
+            format_elapsed(job.start_time.as_deref(), app.jobs_fetched_at)
         } else {
             String::new()
         };
@@ -887,15 +887,23 @@ fn draw_jobs_table(f: &mut Frame, area: Rect, app: &mut App) {
     f.render_stateful_widget(table, area, &mut app.jobs_state);
 }
 
-/// Compute elapsed time from an RFC3339 start_time to now, formatted compactly.
-fn format_elapsed(start_time: Option<&str>) -> String {
+/// Compute elapsed time from an RFC3339 start_time to a reference instant,
+/// formatted compactly. The reference is the wall-clock time when the Jobs
+/// list was last fetched from the server (falling back to `Utc::now()`) so the
+/// value freezes between refreshes instead of ticking up against stale rows
+/// whose server-side status has since moved off Running.
+fn format_elapsed(
+    start_time: Option<&str>,
+    as_of: Option<chrono::DateTime<chrono::Utc>>,
+) -> String {
     let Some(s) = start_time else {
         return String::new();
     };
     let Ok(start) = chrono::DateTime::parse_from_rfc3339(s) else {
         return String::new();
     };
-    let elapsed = chrono::Utc::now().signed_duration_since(start.with_timezone(&chrono::Utc));
+    let reference = as_of.unwrap_or_else(chrono::Utc::now);
+    let elapsed = reference.signed_duration_since(start.with_timezone(&chrono::Utc));
     let total_secs = elapsed.num_seconds().max(0);
     let days = total_secs / 86_400;
     let hours = (total_secs % 86_400) / 3_600;


### PR DESCRIPTION
## Summary
- Fixes the Jobs-tab Elapsed value ticking up indefinitely after a job completes.
- Root cause: `format_elapsed` used `Utc::now()` on every redraw (~100 ms), and the column only renders for `status == Running`. `app.jobs` only refreshes on manual `r`, post-popup, or the 30 s auto-refresh (off by default), so the locally-cached row stayed at `Running` and Elapsed kept growing.
- Capture `jobs_fetched_at` whenever `jobs_all` is loaded from the server and compute Elapsed relative to that snapshot. The value reflects "how long the job had been running as of the last refresh" and stops advancing on its own when the data goes stale.

## Test plan
- [ ] Run a workflow with a short-lived job in the TUI; confirm the Jobs tab's Elapsed value stops growing once the job is no longer Running on the server (verified after `r` clears the row, but in the meantime no longer ticks).
- [ ] Confirm Elapsed still updates after pressing `r` (or after auto-refresh fires) while a job is genuinely Running.
- [ ] Verify other Jobs-tab behavior is unchanged: filter, pagination, sort, popup-driven workflow runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)