### PR TITLE
Expose claim_backoff_max_secs as a CLI option

### DIFF
--- a/docs/src/core/reference/configuration.md
+++ b/docs/src/core/reference/configuration.md
@@ -42,14 +42,15 @@ Settings for the `torc` CLI.
 
 Settings for `torc run` command.
 
-| Option              | Type  | Default       | Description                                         |
-| ------------------- | ----- | ------------- | --------------------------------------------------- |
-| `poll_interval`     | float | `5.0`         | Job completion poll interval (seconds)              |
-| `output_dir`        | path  | `torc_output` | Output directory for job logs                       |
-| `max_parallel_jobs` | int   | (none)        | Maximum parallel jobs (overrides resource-based)    |
-| `num_cpus`          | int   | (none)        | Available CPUs for resource-based scheduling        |
-| `memory_gb`         | float | (none)        | Available memory (GB) for resource-based scheduling |
-| `num_gpus`          | int   | (none)        | Available GPUs for resource-based scheduling        |
+| Option                   | Type  | Default       | Description                                                            |
+| ------------------------ | ----- | ------------- | ---------------------------------------------------------------------- |
+| `poll_interval`          | float | `5.0`         | Job completion poll interval (seconds)                                 |
+| `claim_backoff_max_secs` | float | `300.0`       | Upper bound (seconds) for the adaptive idle backoff (see job-runners). |
+| `output_dir`             | path  | `torc_output` | Output directory for job logs                                          |
+| `max_parallel_jobs`      | int   | (none)        | Maximum parallel jobs (overrides resource-based)                       |
+| `num_cpus`               | int   | (none)        | Available CPUs for resource-based scheduling                           |
+| `memory_gb`              | float | (none)        | Available memory (GB) for resource-based scheduling                    |
+| `num_gpus`               | int   | (none)        | Available GPUs for resource-based scheduling                           |
 
 ### `[client.offline]` Section
 
@@ -264,20 +265,21 @@ Environment variables use double underscore (`__`) to separate nested keys.
 
 ### Client Variables
 
-| Variable                              | Maps To                        |
-| ------------------------------------- | ------------------------------ |
-| `TORC_CLIENT__API_URL`                | `client.api_url`               |
-| `TORC_CLIENT__FORMAT`                 | `client.format`                |
-| `TORC_CLIENT__LOG_LEVEL`              | `client.log_level`             |
-| `TORC_CLIENT__USERNAME`               | `client.username`              |
-| `TORC_CLIENT__RUN__POLL_INTERVAL`     | `client.run.poll_interval`     |
-| `TORC_CLIENT__RUN__OUTPUT_DIR`        | `client.run.output_dir`        |
-| `TORC_CLIENT__RUN__MAX_PARALLEL_JOBS` | `client.run.max_parallel_jobs` |
-| `TORC_CLIENT__RUN__NUM_CPUS`          | `client.run.num_cpus`          |
-| `TORC_CLIENT__RUN__MEMORY_GB`         | `client.run.memory_gb`         |
-| `TORC_CLIENT__RUN__NUM_GPUS`          | `client.run.num_gpus`          |
-| `TORC_CLIENT__TLS__CA_CERT`           | `client.tls.ca_cert`           |
-| `TORC_CLIENT__TLS__INSECURE`          | `client.tls.insecure`          |
+| Variable                                   | Maps To                             |
+| ------------------------------------------ | ----------------------------------- |
+| `TORC_CLIENT__API_URL`                     | `client.api_url`                    |
+| `TORC_CLIENT__FORMAT`                      | `client.format`                     |
+| `TORC_CLIENT__LOG_LEVEL`                   | `client.log_level`                  |
+| `TORC_CLIENT__USERNAME`                    | `client.username`                   |
+| `TORC_CLIENT__RUN__POLL_INTERVAL`          | `client.run.poll_interval`          |
+| `TORC_CLIENT__RUN__CLAIM_BACKOFF_MAX_SECS` | `client.run.claim_backoff_max_secs` |
+| `TORC_CLIENT__RUN__OUTPUT_DIR`             | `client.run.output_dir`             |
+| `TORC_CLIENT__RUN__MAX_PARALLEL_JOBS`      | `client.run.max_parallel_jobs`      |
+| `TORC_CLIENT__RUN__NUM_CPUS`               | `client.run.num_cpus`               |
+| `TORC_CLIENT__RUN__MEMORY_GB`              | `client.run.memory_gb`              |
+| `TORC_CLIENT__RUN__NUM_GPUS`               | `client.run.num_gpus`               |
+| `TORC_CLIENT__TLS__CA_CERT`                | `client.tls.ca_cert`                |
+| `TORC_CLIENT__TLS__INSECURE`               | `client.tls.insecure`               |
 
 ### Server Variables
 

--- a/src/bin/torc-slurm-job-runner.rs
+++ b/src/bin/torc-slurm-job-runner.rs
@@ -67,7 +67,7 @@ mod unix_main {
         /// Upper bound (seconds) on the adaptive claim/poll backoff used while
         /// the runner is idle. Defaults to `client.run.claim_backoff_max_secs`
         /// in config (300 seconds out of the box).
-        #[arg(long)]
+        #[arg(long, value_parser = torc::client::utils::parse_finite_non_negative_secs)]
         claim_backoff_max_secs: Option<f64>,
 
         /// Set to true if this is a subtask and multiple workers are running on one Slurm allocation

--- a/src/bin/torc-slurm-job-runner.rs
+++ b/src/bin/torc-slurm-job-runner.rs
@@ -64,6 +64,12 @@ mod unix_main {
         #[arg(short, long)]
         poll_interval: Option<i64>,
 
+        /// Upper bound (seconds) on the adaptive claim/poll backoff used while
+        /// the runner is idle. Defaults to `client.run.claim_backoff_max_secs`
+        /// in config (300 seconds out of the box).
+        #[arg(long)]
+        claim_backoff_max_secs: Option<f64>,
+
         /// Set to true if this is a subtask and multiple workers are running on one Slurm allocation
         #[arg(long, default_value = "false")]
         is_subtask: bool,
@@ -455,6 +461,10 @@ mod unix_main {
             unique_label,
             node_tracker,
         );
+        job_runner.override_claim_backoff_max_secs(Some(
+            args.claim_backoff_max_secs
+                .unwrap_or(file_config.client.run.claim_backoff_max_secs),
+        ));
 
         // Register SIGTERM and SIGCHLD signal handlers.
         //

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -263,6 +263,11 @@ SEE ALSO:
         /// Job completion poll interval in seconds
         #[arg(short, long)]
         poll_interval: Option<f64>,
+        /// Upper bound (seconds) on the adaptive claim/poll backoff used while
+        /// the runner is idle. Defaults to `client.run.claim_backoff_max_secs`
+        /// in config (300 seconds out of the box).
+        #[arg(long)]
+        claim_backoff_max_secs: Option<f64>,
         /// Output directory for jobs
         #[arg(short, long)]
         output_dir: Option<PathBuf>,
@@ -451,6 +456,12 @@ EXAMPLES:
         /// Job completion poll interval in seconds
         #[arg(short, long)]
         poll_interval: Option<i32>,
+        /// Upper bound (seconds) on the adaptive claim/poll backoff used while
+        /// runners are idle. Defaults to `client.run.claim_backoff_max_secs`
+        /// in config (300 seconds out of the box). Propagated to the
+        /// generated Slurm submission scripts as `--claim-backoff-max-secs`.
+        #[arg(long)]
+        claim_backoff_max_secs: Option<f64>,
     },
     /// Watch a workflow and automatically recover from failures
     ///

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -266,7 +266,7 @@ SEE ALSO:
         /// Upper bound (seconds) on the adaptive claim/poll backoff used while
         /// the runner is idle. Defaults to `client.run.claim_backoff_max_secs`
         /// in config (300 seconds out of the box).
-        #[arg(long)]
+        #[arg(long, value_parser = crate::client::utils::parse_finite_non_negative_secs)]
         claim_backoff_max_secs: Option<f64>,
         /// Output directory for jobs
         #[arg(short, long)]
@@ -460,7 +460,7 @@ EXAMPLES:
         /// runners are idle. Defaults to `client.run.claim_backoff_max_secs`
         /// in config (300 seconds out of the box). Propagated to the
         /// generated Slurm submission scripts as `--claim-backoff-max-secs`.
-        #[arg(long)]
+        #[arg(long, value_parser = crate::client::utils::parse_finite_non_negative_secs)]
         claim_backoff_max_secs: Option<f64>,
     },
     /// Watch a workflow and automatically recover from failures

--- a/src/client/commands/slurm.rs
+++ b/src/client/commands/slurm.rs
@@ -434,7 +434,7 @@ EXAMPLES:
         /// submission scripts as `--claim-backoff-max-secs`. When unset, the
         /// runner falls back to `client.run.claim_backoff_max_secs` in its
         /// own config (300 seconds out of the box).
-        #[arg(long)]
+        #[arg(long, value_parser = crate::client::utils::parse_finite_non_negative_secs)]
         claim_backoff_max_secs: Option<f64>,
         /// Scheduler config ID (ignored if --auto is set)
         #[arg(long)]

--- a/src/client/commands/slurm.rs
+++ b/src/client/commands/slurm.rs
@@ -429,6 +429,13 @@ EXAMPLES:
         /// Poll interval in seconds (default: from config file or 30)
         #[arg(short, long)]
         poll_interval: Option<i32>,
+        /// Upper bound (seconds) on the adaptive claim/poll backoff used while
+        /// runners are idle. When set, propagated to the generated Slurm
+        /// submission scripts as `--claim-backoff-max-secs`. When unset, the
+        /// runner falls back to `client.run.claim_backoff_max_secs` in its
+        /// own config (300 seconds out of the box).
+        #[arg(long)]
+        claim_backoff_max_secs: Option<f64>,
         /// Scheduler config ID (ignored if --auto is set)
         #[arg(long)]
         scheduler_config_id: Option<i64>,
@@ -1309,6 +1316,7 @@ pub fn handle_slurm_commands(config: &Configuration, command: &SlurmCommands, fo
             num_hpc_jobs,
             output,
             poll_interval,
+            claim_backoff_max_secs,
             scheduler_config_id,
         } => {
             let user_name = get_env_user_name();
@@ -1397,7 +1405,7 @@ pub fn handle_slurm_commands(config: &Configuration, command: &SlurmCommands, fo
                 effective_poll_interval,
                 *max_parallel_jobs,
                 *keep_submission_scripts,
-                None,
+                *claim_backoff_max_secs,
             ) {
                 Ok(()) => {
                     eprintln!("Successfully running {} Slurm job(s)", num_hpc_jobs);

--- a/src/client/commands/slurm.rs
+++ b/src/client/commands/slurm.rs
@@ -1397,7 +1397,7 @@ pub fn handle_slurm_commands(config: &Configuration, command: &SlurmCommands, fo
                 effective_poll_interval,
                 *max_parallel_jobs,
                 *keep_submission_scripts,
-                Some(torc_config.client.run.claim_backoff_max_secs),
+                None,
             ) {
                 Ok(()) => {
                     eprintln!("Successfully running {} Slurm job(s)", num_hpc_jobs);
@@ -5100,7 +5100,7 @@ fn handle_regenerate(
                 effective_poll_interval,
                 None,  // max_parallel_jobs
                 false, // keep_submission_scripts
-                Some(torc_config.client.run.claim_backoff_max_secs),
+                None,  // claim_backoff_max_secs (rely on runner-side config)
             ) {
                 Ok(()) => {
                     println!(

--- a/src/client/commands/slurm.rs
+++ b/src/client/commands/slurm.rs
@@ -1397,6 +1397,7 @@ pub fn handle_slurm_commands(config: &Configuration, command: &SlurmCommands, fo
                 effective_poll_interval,
                 *max_parallel_jobs,
                 *keep_submission_scripts,
+                Some(torc_config.client.run.claim_backoff_max_secs),
             ) {
                 Ok(()) => {
                     eprintln!("Successfully running {} Slurm job(s)", num_hpc_jobs);
@@ -1625,6 +1626,7 @@ pub fn schedule_slurm_nodes(
     poll_interval: i32,
     max_parallel_jobs: Option<i32>,
     keep_submission_scripts: bool,
+    claim_backoff_max_secs: Option<f64>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let scheduler = match utils::send_with_retries(
         config,
@@ -1765,6 +1767,7 @@ pub fn schedule_slurm_nodes(
             tls_ca_cert,
             tls_insecure,
             startup_delay_seconds,
+            claim_backoff_max_secs,
         ) {
             error!("Error creating submission script: {}", e);
             return Err(e.into());
@@ -5097,6 +5100,7 @@ fn handle_regenerate(
                 effective_poll_interval,
                 None,  // max_parallel_jobs
                 false, // keep_submission_scripts
+                Some(torc_config.client.run.claim_backoff_max_secs),
             ) {
                 Ok(()) => {
                     println!(

--- a/src/client/hpc/hpc_interface.rs
+++ b/src/client/hpc/hpc_interface.rs
@@ -59,6 +59,9 @@ pub trait HpcInterface: Send + Sync {
     /// * `tls_ca_cert` - Optional path to a PEM-encoded CA certificate
     /// * `tls_insecure` - Whether to skip certificate verification
     /// * `startup_delay_seconds` - Maximum startup jitter in seconds (0 to disable)
+    /// * `claim_backoff_max_secs` - Optional upper bound for the adaptive
+    ///   claim/poll backoff used inside the runner. When `Some`, propagated to
+    ///   the runner via `--claim-backoff-max-secs`.
     #[allow(clippy::too_many_arguments)]
     fn create_submission_script(
         &self,
@@ -75,6 +78,7 @@ pub trait HpcInterface: Send + Sync {
         tls_ca_cert: Option<&str>,
         tls_insecure: bool,
         startup_delay_seconds: u64,
+        claim_backoff_max_secs: Option<f64>,
     ) -> Result<()>;
 
     /// Get the current HPC job ID from environment variables

--- a/src/client/hpc/hpc_manager.rs
+++ b/src/client/hpc/hpc_manager.rs
@@ -155,6 +155,7 @@ impl HpcManager {
             tls_ca_cert,
             tls_insecure,
             startup_delay_seconds,
+            None,
         )?;
 
         trace!("Created submission script {:?}", filename);

--- a/src/client/hpc/slurm_interface.rs
+++ b/src/client/hpc/slurm_interface.rs
@@ -220,6 +220,7 @@ impl HpcInterface for SlurmInterface {
         tls_ca_cert: Option<&str>,
         tls_insecure: bool,
         startup_delay_seconds: u64,
+        claim_backoff_max_secs: Option<f64>,
     ) -> Result<()> {
         let mut script = format!(
             "#!/bin/bash\n\
@@ -266,6 +267,10 @@ impl HpcInterface for SlurmInterface {
 
         if let Some(max_jobs) = max_parallel_jobs {
             command.push_str(&format!(" --max-parallel-jobs {}", max_jobs));
+        }
+
+        if let Some(secs) = claim_backoff_max_secs {
+            command.push_str(&format!(" --claim-backoff-max-secs {}", secs));
         }
 
         // Propagate TLS settings as CLI flags.

--- a/src/client/job_runner.rs
+++ b/src/client/job_runner.rs
@@ -916,8 +916,8 @@ impl JobRunner {
         info!(
             "Starting torc job runner version={} client_api_version={} server_version={} server_api_version={} \
             workflow_id={} hostname={} output_dir={} resources={:?} rules={:?} \
-            job_completion_poll_interval={}s max_parallel_jobs={:?} end_time={:?} strict_scheduler_match={} \
-            execution_mode={:?} limit_resources={}",
+            job_completion_poll_interval={}s claim_backoff_max_secs={}s max_parallel_jobs={:?} \
+            end_time={:?} strict_scheduler_match={} execution_mode={:?} limit_resources={}",
             version,
             version_check::CLIENT_API_VERSION,
             server_version,
@@ -928,6 +928,7 @@ impl JobRunner {
             self.resources,
             self.rules,
             self.job_completion_poll_interval,
+            self.claim_backoff_max_secs,
             self.max_parallel_jobs,
             self.end_time,
             self.torc_config.client.slurm.strict_scheduler_match,

--- a/src/client/job_runner.rs
+++ b/src/client/job_runner.rs
@@ -752,8 +752,14 @@ impl JobRunner {
     /// `None` leaves the value loaded from `client.run.claim_backoff_max_secs`
     /// unchanged. The override is clamped to at least
     /// `job_completion_poll_interval`, matching the constructor's invariant.
+    /// Non-finite values (`NaN`, `+/-inf`) are ignored to keep
+    /// `Duration::from_secs_f64` from panicking later — CLI parsing already
+    /// rejects these, this is a defense-in-depth guard for config-sourced
+    /// values that bypass the CLI parser.
     pub fn override_claim_backoff_max_secs(&mut self, secs: Option<f64>) {
-        if let Some(s) = secs {
+        if let Some(s) = secs
+            && s.is_finite()
+        {
             self.claim_backoff_max_secs = s.max(self.job_completion_poll_interval);
         }
     }
@@ -3813,6 +3819,19 @@ mod tests {
         let mut runner = make_runner(ComputeNodesResources::new(1, 1.0, 0, 1));
         runner.override_claim_backoff_max_secs(Some(0.1));
         assert!((runner.claim_backoff_max_secs - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn override_claim_backoff_max_secs_ignores_non_finite() {
+        // NaN / +inf / -inf in a config file must not crash the runner via
+        // Duration::from_secs_f64 later. The guard drops them silently and
+        // keeps the constructor-loaded value.
+        let mut runner = make_runner(ComputeNodesResources::new(1, 1.0, 0, 1));
+        let before = runner.claim_backoff_max_secs;
+        runner.override_claim_backoff_max_secs(Some(f64::NAN));
+        runner.override_claim_backoff_max_secs(Some(f64::INFINITY));
+        runner.override_claim_backoff_max_secs(Some(f64::NEG_INFINITY));
+        assert!((runner.claim_backoff_max_secs - before).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/src/client/job_runner.rs
+++ b/src/client/job_runner.rs
@@ -747,6 +747,17 @@ impl JobRunner {
         }
     }
 
+    /// Override the claim-backoff cap loaded from config, e.g. from a CLI flag.
+    ///
+    /// `None` leaves the value loaded from `client.run.claim_backoff_max_secs`
+    /// unchanged. The override is clamped to at least
+    /// `job_completion_poll_interval`, matching the constructor's invariant.
+    pub fn override_claim_backoff_max_secs(&mut self, secs: Option<f64>) {
+        if let Some(s) = secs {
+            self.claim_backoff_max_secs = s.max(self.job_completion_poll_interval);
+        }
+    }
+
     /// Execute an API call with automatic retries for network errors.
     ///
     /// This is a convenience method that wraps [`utils::send_with_retries`] with
@@ -3539,6 +3550,7 @@ impl JobRunner {
                         self.torc_config.client.slurm.poll_interval,
                         max_parallel_jobs,
                         self.torc_config.client.slurm.keep_submission_scripts,
+                        Some(self.claim_backoff_max_secs),
                     ) {
                         Ok(()) => {
                             info!("Successfully scheduled {} Slurm job(s)", num_allocations);
@@ -3775,6 +3787,31 @@ mod tests {
         let cap = 300.0;
         let next = next_poll_interval(base, base, cap, false, false);
         assert!(next >= base);
+    }
+
+    #[test]
+    fn override_claim_backoff_max_secs_applies_value() {
+        let mut runner = make_runner(ComputeNodesResources::new(1, 1.0, 0, 1));
+        runner.override_claim_backoff_max_secs(Some(120.0));
+        assert!((runner.claim_backoff_max_secs - 120.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn override_claim_backoff_max_secs_none_keeps_existing() {
+        let mut runner = make_runner(ComputeNodesResources::new(1, 1.0, 0, 1));
+        let before = runner.claim_backoff_max_secs;
+        runner.override_claim_backoff_max_secs(None);
+        assert!((runner.claim_backoff_max_secs - before).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn override_claim_backoff_max_secs_clamps_to_base_poll_interval() {
+        // make_runner uses job_completion_poll_interval = 1.0; an override
+        // below that must clamp up to the base so the cap never falls below
+        // the poll interval.
+        let mut runner = make_runner(ComputeNodesResources::new(1, 1.0, 0, 1));
+        runner.override_claim_backoff_max_secs(Some(0.1));
+        assert!((runner.claim_backoff_max_secs - 1.0).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/src/client/utils.rs
+++ b/src/client/utils.rs
@@ -616,6 +616,24 @@ pub fn format_local_timestamp(rfc3339_utc: &str) -> String {
     }
 }
 
+/// clap value parser for a finite, non-negative `f64` seconds value.
+///
+/// Rejects `NaN`, `+/-inf`, and negative values at parse time so bad input
+/// fails fast with a CLI error instead of crashing the runner mid-loop in
+/// `Duration::from_secs_f64` (which panics on non-finite inputs).
+pub fn parse_finite_non_negative_secs(s: &str) -> Result<f64, String> {
+    let v: f64 = s
+        .parse()
+        .map_err(|e: std::num::ParseFloatError| e.to_string())?;
+    if !v.is_finite() {
+        return Err(format!("must be a finite number, got {}", s));
+    }
+    if v < 0.0 {
+        return Err(format!("must be >= 0, got {}", v));
+    }
+    Ok(v)
+}
+
 /// Same as [`format_local_timestamp`] but for unix-epoch seconds (e.g.
 /// `file.st_mtime`).
 pub fn format_local_timestamp_epoch(epoch_secs: f64) -> String {
@@ -658,6 +676,32 @@ mod tests {
     fn test_format_local_timestamp_includes_offset() {
         let formatted = format_local_timestamp("2026-05-25T12:00:00Z");
         assert_local_with_offset(&formatted);
+    }
+
+    #[test]
+    fn parse_finite_non_negative_secs_accepts_valid() {
+        assert_eq!(parse_finite_non_negative_secs("0").unwrap(), 0.0);
+        assert_eq!(parse_finite_non_negative_secs("300").unwrap(), 300.0);
+        assert_eq!(parse_finite_non_negative_secs("1.5").unwrap(), 1.5);
+    }
+
+    #[test]
+    fn parse_finite_non_negative_secs_rejects_non_finite() {
+        assert!(parse_finite_non_negative_secs("inf").is_err());
+        assert!(parse_finite_non_negative_secs("-inf").is_err());
+        assert!(parse_finite_non_negative_secs("NaN").is_err());
+    }
+
+    #[test]
+    fn parse_finite_non_negative_secs_rejects_negative() {
+        assert!(parse_finite_non_negative_secs("-1").is_err());
+        assert!(parse_finite_non_negative_secs("-0.1").is_err());
+    }
+
+    #[test]
+    fn parse_finite_non_negative_secs_rejects_garbage() {
+        assert!(parse_finite_non_negative_secs("not-a-number").is_err());
+        assert!(parse_finite_non_negative_secs("").is_err());
     }
 
     #[test]

--- a/src/client/workflow_manager.rs
+++ b/src/client/workflow_manager.rs
@@ -316,10 +316,6 @@ impl WorkflowManager {
                     });
                     let poll_interval = poll_interval_override
                         .unwrap_or(self.torc_config.client.slurm.poll_interval);
-                    let claim_backoff_max_secs = Some(
-                        claim_backoff_max_secs_override
-                            .unwrap_or(self.torc_config.client.run.claim_backoff_max_secs),
-                    );
 
                     match crate::client::commands::slurm::schedule_slurm_nodes(
                         &self.config,
@@ -332,7 +328,7 @@ impl WorkflowManager {
                         poll_interval,
                         max_parallel_jobs,
                         self.torc_config.client.slurm.keep_submission_scripts,
-                        claim_backoff_max_secs,
+                        claim_backoff_max_secs_override,
                     ) {
                         Ok(()) => {
                             info!(

--- a/src/client/workflow_manager.rs
+++ b/src/client/workflow_manager.rs
@@ -214,6 +214,7 @@ impl WorkflowManager {
         max_parallel_jobs_override: Option<i32>,
         output_dir: &str,
         poll_interval_override: Option<i32>,
+        claim_backoff_max_secs_override: Option<f64>,
     ) -> Result<(), TorcError> {
         // Check if workflow is uninitialized
         match apis::workflows_api::is_workflow_uninitialized(&self.config, self.workflow_id) {
@@ -315,6 +316,10 @@ impl WorkflowManager {
                     });
                     let poll_interval = poll_interval_override
                         .unwrap_or(self.torc_config.client.slurm.poll_interval);
+                    let claim_backoff_max_secs = Some(
+                        claim_backoff_max_secs_override
+                            .unwrap_or(self.torc_config.client.run.claim_backoff_max_secs),
+                    );
 
                     match crate::client::commands::slurm::schedule_slurm_nodes(
                         &self.config,
@@ -327,6 +332,7 @@ impl WorkflowManager {
                         poll_interval,
                         max_parallel_jobs,
                         self.torc_config.client.slurm.keep_submission_scripts,
+                        claim_backoff_max_secs,
                     ) {
                         Ok(()) => {
                             info!(

--- a/src/config/loader.rs
+++ b/src/config/loader.rs
@@ -195,6 +195,13 @@ log_level = "info"
 # Job completion poll interval in seconds
 poll_interval = 5.0
 
+# Upper bound (seconds) on the adaptive claim/poll backoff used while the
+# runner is idle. After an iteration with no completions and no claimed
+# jobs, the wait between iterations doubles from `poll_interval` toward
+# this cap and resets on any progress. Set to `poll_interval` or lower
+# to disable backoff.
+claim_backoff_max_secs = 300.0
+
 # Output directory for job logs and artifacts
 output_dir = "torc_output"
 

--- a/src/exec_cmd.rs
+++ b/src/exec_cmd.rs
@@ -176,6 +176,7 @@ pub fn run(args: ExecArgs, config: &Configuration, user: &str) {
         url: args.url,
         output_dir: args.output_dir,
         poll_interval: 5.0,
+        claim_backoff_max_secs: None,
         max_parallel_jobs: args.max_parallel_jobs,
         time_limit: None,
         end_time: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -663,6 +663,7 @@ fn main() {
             memory_gb,
             num_gpus,
             poll_interval,
+            claim_backoff_max_secs,
             output_dir,
             time_limit,
             end_time,
@@ -721,6 +722,9 @@ fn main() {
                     .clone()
                     .unwrap_or_else(|| run_config.output_dir.clone()),
                 poll_interval: poll_interval.unwrap_or(run_config.poll_interval),
+                claim_backoff_max_secs: Some(
+                    claim_backoff_max_secs.unwrap_or(run_config.claim_backoff_max_secs),
+                ),
                 max_parallel_jobs: max_parallel_jobs.or(run_config.max_parallel_jobs),
                 time_limit: time_limit.clone(),
                 end_time: end_time.clone(),
@@ -796,6 +800,7 @@ fn main() {
             max_parallel_jobs,
             output_dir,
             poll_interval,
+            claim_backoff_max_secs,
         } => {
             let workflow_id = if is_spec_file(workflow_spec_or_id) {
                 // Resolve the spec source once (handles `-` reading from stdin) so the
@@ -932,6 +937,7 @@ fn main() {
                         *max_parallel_jobs,
                         output_dir,
                         *poll_interval,
+                        *claim_backoff_max_secs,
                     ) {
                         Ok(()) => {
                             print_workflow_message(

--- a/src/main.rs
+++ b/src/main.rs
@@ -722,9 +722,7 @@ fn main() {
                     .clone()
                     .unwrap_or_else(|| run_config.output_dir.clone()),
                 poll_interval: poll_interval.unwrap_or(run_config.poll_interval),
-                claim_backoff_max_secs: Some(
-                    claim_backoff_max_secs.unwrap_or(run_config.claim_backoff_max_secs),
-                ),
+                claim_backoff_max_secs: *claim_backoff_max_secs,
                 max_parallel_jobs: max_parallel_jobs.or(run_config.max_parallel_jobs),
                 time_limit: time_limit.clone(),
                 end_time: end_time.clone(),

--- a/src/run_jobs_cmd.rs
+++ b/src/run_jobs_cmd.rs
@@ -88,7 +88,7 @@ pub struct Args {
     /// iterations doubles from `poll_interval` toward this cap and resets on
     /// any progress. Set to `poll_interval` or lower to disable backoff.
     /// Falls back to `client.run.claim_backoff_max_secs` in config (default 300).
-    #[arg(long)]
+    #[arg(long, value_parser = crate::client::utils::parse_finite_non_negative_secs)]
     pub claim_backoff_max_secs: Option<f64>,
     /// Maximum number of parallel jobs to run concurrently.
     /// When NOT set: Uses resource-based job allocation (considers CPU, memory, GPU requirements).

--- a/src/run_jobs_cmd.rs
+++ b/src/run_jobs_cmd.rs
@@ -83,6 +83,13 @@ pub struct Args {
     /// Job completion poll interval in seconds
     #[arg(short, long, default_value = "5.0")]
     pub poll_interval: f64,
+    /// Upper bound (seconds) on the adaptive claim/poll backoff. After an
+    /// iteration with no completions and no claimed jobs, the wait between
+    /// iterations doubles from `poll_interval` toward this cap and resets on
+    /// any progress. Set to `poll_interval` or lower to disable backoff.
+    /// Falls back to `client.run.claim_backoff_max_secs` in config (default 300).
+    #[arg(long)]
+    pub claim_backoff_max_secs: Option<f64>,
     /// Maximum number of parallel jobs to run concurrently.
     /// When NOT set: Uses resource-based job allocation (considers CPU, memory, GPU requirements).
     /// When set: Uses simple queue-based allocation with this parallel limit (ignores resource requirements).
@@ -367,6 +374,7 @@ pub fn run_with_log_stream(args: &Args, log_stream: LogStream) -> WorkerResult {
         unique_label,
         None, // No per-node tracking for local runner
     );
+    job_runner.override_claim_backoff_max_secs(args.claim_backoff_max_secs);
 
     register_sigchld_wakeup(&job_runner);
 

--- a/tests/test_slurm_commands.rs
+++ b/tests/test_slurm_commands.rs
@@ -382,6 +382,7 @@ fn test_create_submission_script() {
         None,
         false,
         0,
+        None,
     );
 
     assert!(
@@ -462,6 +463,7 @@ fn test_create_submission_script_with_extra() {
         None,
         false,
         0,
+        None,
     );
 
     assert!(
@@ -510,6 +512,7 @@ fn test_create_submission_script_without_srun() {
         None,
         false,
         0,
+        None,
     );
 
     assert!(
@@ -566,6 +569,7 @@ fn test_create_submission_script_with_srun() {
         None,
         false,
         0,
+        None,
     );
 
     assert!(
@@ -615,6 +619,7 @@ fn test_create_submission_script_with_srun_mpi() {
         None,
         false,
         0,
+        None,
     );
 
     assert!(
@@ -661,6 +666,7 @@ fn test_create_submission_script_with_invalid_srun_mpi_rejected() {
         None,
         false,
         0,
+        None,
     );
 
     assert!(result.is_err(), "Expected invalid srun_mpi to be rejected");
@@ -721,6 +727,7 @@ fn test_create_submission_script_with_startup_delay() {
         None,
         false,
         30,
+        None,
     );
 
     assert!(
@@ -765,6 +772,7 @@ fn test_create_submission_script_without_startup_delay() {
         None,
         false,
         0,
+        None,
     );
 
     assert!(
@@ -779,6 +787,96 @@ fn test_create_submission_script_without_startup_delay() {
     assert!(
         !script_content.contains("--startup-delay-seconds"),
         "Should NOT have --startup-delay-seconds flag when delay is 0"
+    );
+
+    let _ = fs::remove_file(&script_path);
+}
+
+#[test]
+fn test_create_submission_script_with_claim_backoff_max_secs() {
+    let interface = SlurmInterface::new().expect("Failed to create SlurmInterface");
+
+    let temp_dir = env::temp_dir();
+    let script_path = temp_dir.join("test_submission_script_claim_backoff.sh");
+
+    let mut config = std::collections::HashMap::new();
+    config.insert("account".to_string(), "test_account".to_string());
+    config.insert("walltime".to_string(), "01:00:00".to_string());
+
+    let result = interface.create_submission_script(
+        "test_job",
+        "http://localhost:8080/torc-service/v1",
+        12345,
+        "/tmp/output",
+        5,
+        None,
+        &script_path,
+        &config,
+        false,
+        None,
+        None,
+        false,
+        0,
+        Some(600.0),
+    );
+
+    assert!(
+        result.is_ok(),
+        "Failed to create submission script: {:?}",
+        result.err()
+    );
+
+    let script_content =
+        fs::read_to_string(&script_path).expect("Failed to read submission script");
+
+    assert!(
+        script_content.contains("--claim-backoff-max-secs 600"),
+        "Should have --claim-backoff-max-secs flag when override is Some"
+    );
+
+    let _ = fs::remove_file(&script_path);
+}
+
+#[test]
+fn test_create_submission_script_without_claim_backoff_max_secs() {
+    let interface = SlurmInterface::new().expect("Failed to create SlurmInterface");
+
+    let temp_dir = env::temp_dir();
+    let script_path = temp_dir.join("test_submission_script_no_claim_backoff.sh");
+
+    let mut config = std::collections::HashMap::new();
+    config.insert("account".to_string(), "test_account".to_string());
+    config.insert("walltime".to_string(), "01:00:00".to_string());
+
+    let result = interface.create_submission_script(
+        "test_job",
+        "http://localhost:8080/torc-service/v1",
+        12345,
+        "/tmp/output",
+        5,
+        None,
+        &script_path,
+        &config,
+        false,
+        None,
+        None,
+        false,
+        0,
+        None,
+    );
+
+    assert!(
+        result.is_ok(),
+        "Failed to create submission script: {:?}",
+        result.err()
+    );
+
+    let script_content =
+        fs::read_to_string(&script_path).expect("Failed to read submission script");
+
+    assert!(
+        !script_content.contains("--claim-backoff-max-secs"),
+        "Should NOT have --claim-backoff-max-secs flag when override is None"
     );
 
     let _ = fs::remove_file(&script_path);


### PR DESCRIPTION
Add --claim-backoff-max-secs to torc run, torc submit, and torc-slurm-job-runner so the adaptive claim/poll backoff cap can be set per invocation. When set on torc submit, the override is propagated into the generated Slurm submission scripts. torc config init now writes the 300-second default into the generated config file.