### PR TITLE
Deactivate compute nodes on cancel and orphan cleanup

### DIFF
--- a/src/client/commands/orphan_detection.rs
+++ b/src/client/commands/orphan_detection.rs
@@ -39,6 +39,8 @@ pub struct OrphanCleanupResult {
     pub pending_allocations_cleaned: usize,
     /// Number of running jobs failed due to no active compute nodes
     pub running_jobs_failed: usize,
+    /// Number of compute nodes deactivated because their Slurm allocation is gone
+    pub compute_nodes_deactivated: usize,
     /// Details of each orphaned job that was failed
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub failed_job_details: Vec<OrphanedJobDetail>,
@@ -59,6 +61,7 @@ impl OrphanCleanupResult {
         self.slurm_jobs_failed > 0
             || self.pending_allocations_cleaned > 0
             || self.running_jobs_failed > 0
+            || self.compute_nodes_deactivated > 0
     }
 
     /// Total number of jobs that were failed
@@ -84,6 +87,7 @@ pub fn cleanup_orphaned_jobs(
         slurm_jobs_failed: 0,
         pending_allocations_cleaned: 0,
         running_jobs_failed: 0,
+        compute_nodes_deactivated: 0,
         failed_job_details: Vec::new(),
     };
 
@@ -102,6 +106,13 @@ pub fn cleanup_orphaned_jobs(
         fail_orphaned_running_jobs(config, workflow_id, dry_run)?;
     result.running_jobs_failed = running_failed;
     result.failed_job_details.extend(running_details);
+
+    // Step 4: Deactivate compute nodes still marked active whose Slurm allocation
+    // is gone. This catches nodes stranded by an ungraceful job runner exit (e.g.
+    // after `torc cancel` issues `scancel`), which Step 1 misses because it only
+    // looks at scheduled compute nodes still in "active" status.
+    result.compute_nodes_deactivated =
+        deactivate_orphaned_compute_nodes(config, workflow_id, dry_run)?;
 
     Ok(result)
 }
@@ -667,6 +678,181 @@ fn fail_orphaned_running_jobs(
     Ok((failed_count, details))
 }
 
+/// Deactivate compute nodes that are still marked `is_active = true` but whose
+/// Slurm allocation is no longer running.
+///
+/// This handles compute nodes stranded by an ungraceful job runner exit: when a
+/// runner is killed by `scancel` (via `torc cancel`) or a Slurm timeout, it never
+/// reaches its own deactivation path, so the `ComputeNode` row stays active
+/// forever and blocks `torc recover`.
+///
+/// Unlike [`fail_orphaned_slurm_jobs`], this does not require the scheduled
+/// compute node to still be in "active" status (a cancel moves it to "canceled")
+/// and does not require any jobs to still be in "running" status. It walks every
+/// Slurm-type scheduled compute node regardless of status, and for those whose
+/// Slurm job is gone, deactivates the associated active compute nodes.
+///
+/// Returns the number of compute nodes that were deactivated.
+fn deactivate_orphaned_compute_nodes(
+    config: &Configuration,
+    workflow_id: i64,
+    dry_run: bool,
+) -> Result<usize, String> {
+    // Cheap early-out: nothing to do if no compute nodes are active.
+    let active_nodes = paginate_compute_nodes(
+        config,
+        workflow_id,
+        ComputeNodeListParams::new()
+            .with_is_active(true)
+            .with_limit(1),
+    )
+    .map_err(|e| format!("Failed to list active compute nodes: {}", e))?;
+    if active_nodes.is_empty() {
+        return Ok(0);
+    }
+
+    // Slurm is the source of truth. If we can't talk to it, do nothing.
+    let slurm = match SlurmInterface::new() {
+        Ok(s) => s,
+        Err(e) => {
+            debug!(
+                "Could not create SlurmInterface for compute node sweep: {}",
+                e
+            );
+            return Ok(0);
+        }
+    };
+
+    // Walk every Slurm-type scheduled compute node, regardless of status.
+    let scheduled_nodes = paginate_scheduled_compute_nodes(
+        config,
+        workflow_id,
+        ScheduledComputeNodeListParams::new(),
+    )
+    .map_err(|e| format!("Failed to list scheduled compute nodes: {}", e))?;
+
+    let mut total_deactivated = 0;
+
+    for scheduled_node in scheduled_nodes
+        .iter()
+        .filter(|node| node.scheduler_type.to_lowercase() == "slurm")
+    {
+        let scheduled_compute_node_id = match scheduled_node.id {
+            Some(id) => id,
+            None => continue,
+        };
+        let slurm_job_id = scheduled_node.scheduler_id.to_string();
+
+        // Skip allocations that are still alive in Slurm.
+        match slurm.get_status(&slurm_job_id) {
+            Ok(info)
+                if info.status == HpcJobStatus::Running || info.status == HpcJobStatus::Queued =>
+            {
+                continue;
+            }
+            Ok(_) => {}
+            Err(e) => {
+                warn!(
+                    "Error checking Slurm status for job {}: {}; leaving compute nodes untouched",
+                    slurm_job_id, e
+                );
+                continue;
+            }
+        }
+
+        match deactivate_compute_nodes_for_scheduled_node(
+            config,
+            workflow_id,
+            scheduled_compute_node_id,
+            &slurm_job_id,
+            dry_run,
+        ) {
+            Ok(count) => total_deactivated += count,
+            Err(e) => warn!(
+                "Failed to deactivate compute nodes for scheduled compute node {}: {}",
+                scheduled_compute_node_id, e
+            ),
+        }
+    }
+
+    if total_deactivated > 0 {
+        let action = if dry_run {
+            "Would deactivate"
+        } else {
+            "Deactivated"
+        };
+        info!(
+            "{} {} orphaned compute node(s) whose Slurm allocation is gone",
+            action, total_deactivated
+        );
+    }
+
+    Ok(total_deactivated)
+}
+
+/// Mark all still-active compute nodes associated with a scheduled compute node
+/// as inactive.
+///
+/// Used by [`deactivate_orphaned_compute_nodes`] during cleanup, and by
+/// `torc cancel` after `scancel` (the job runner is killed and never deactivates
+/// itself). `slurm_job_id` is used only for logging context.
+///
+/// Returns the number of compute nodes that were deactivated.
+pub fn deactivate_compute_nodes_for_scheduled_node(
+    config: &Configuration,
+    workflow_id: i64,
+    scheduled_compute_node_id: i64,
+    slurm_job_id: &str,
+    dry_run: bool,
+) -> Result<usize, String> {
+    let compute_nodes = paginate_compute_nodes(
+        config,
+        workflow_id,
+        ComputeNodeListParams::new().with_scheduled_compute_node_id(scheduled_compute_node_id),
+    )
+    .map_err(|e| format!("Failed to list compute nodes: {}", e))?;
+
+    let mut count = 0;
+
+    for compute_node in &compute_nodes {
+        // Only touch nodes that are still marked active.
+        if compute_node.is_active != Some(true) {
+            continue;
+        }
+        let compute_node_id = match compute_node.id {
+            Some(id) => id,
+            None => continue,
+        };
+
+        if dry_run {
+            info!(
+                "[DRY RUN] Would deactivate compute node {} (Slurm job {} no longer running)",
+                compute_node_id, slurm_job_id
+            );
+            count += 1;
+            continue;
+        }
+
+        let mut updated_node = compute_node.clone();
+        updated_node.is_active = Some(false);
+        apis::compute_nodes_api::update_compute_node(config, compute_node_id, updated_node)
+            .map_err(|e| {
+                format!(
+                    "Failed to deactivate compute node {}: {}",
+                    compute_node_id, e
+                )
+            })?;
+
+        info!(
+            "Deactivated compute node {} (Slurm job {} no longer running)",
+            compute_node_id, slurm_job_id
+        );
+        count += 1;
+    }
+
+    Ok(count)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -677,6 +863,7 @@ mod tests {
             slurm_jobs_failed: 0,
             pending_allocations_cleaned: 0,
             running_jobs_failed: 0,
+            compute_nodes_deactivated: 0,
             failed_job_details: Vec::new(),
         };
         assert!(!empty.any_cleaned());
@@ -685,6 +872,7 @@ mod tests {
             slurm_jobs_failed: 1,
             pending_allocations_cleaned: 0,
             running_jobs_failed: 0,
+            compute_nodes_deactivated: 0,
             failed_job_details: Vec::new(),
         };
         assert!(with_slurm.any_cleaned());
@@ -693,6 +881,7 @@ mod tests {
             slurm_jobs_failed: 0,
             pending_allocations_cleaned: 1,
             running_jobs_failed: 0,
+            compute_nodes_deactivated: 0,
             failed_job_details: Vec::new(),
         };
         assert!(with_pending.any_cleaned());
@@ -701,9 +890,19 @@ mod tests {
             slurm_jobs_failed: 0,
             pending_allocations_cleaned: 0,
             running_jobs_failed: 1,
+            compute_nodes_deactivated: 0,
             failed_job_details: Vec::new(),
         };
         assert!(with_running.any_cleaned());
+
+        let with_deactivated = OrphanCleanupResult {
+            slurm_jobs_failed: 0,
+            pending_allocations_cleaned: 0,
+            running_jobs_failed: 0,
+            compute_nodes_deactivated: 1,
+            failed_job_details: Vec::new(),
+        };
+        assert!(with_deactivated.any_cleaned());
     }
 
     #[test]
@@ -712,6 +911,7 @@ mod tests {
             slurm_jobs_failed: 3,
             pending_allocations_cleaned: 2,
             running_jobs_failed: 1,
+            compute_nodes_deactivated: 5,
             failed_job_details: Vec::new(),
         };
         assert_eq!(result.total_jobs_failed(), 4);

--- a/src/client/commands/orphan_detection.rs
+++ b/src/client/commands/orphan_detection.rs
@@ -72,10 +72,11 @@ impl OrphanCleanupResult {
 
 /// Detect and clean up orphaned jobs from terminated Slurm allocations.
 ///
-/// This function performs three types of cleanup:
+/// This function performs four types of cleanup:
 /// 1. Fails jobs from active scheduled compute nodes whose Slurm jobs are no longer running
 /// 2. Cleans up pending scheduled compute nodes whose Slurm jobs were cancelled
 /// 3. Fails running jobs that have no active compute nodes (fallback for non-Slurm)
+/// 4. Deactivates compute nodes still marked active whose Slurm allocation is gone
 ///
 /// If `dry_run` is true, reports what would be done without making changes.
 pub fn cleanup_orphaned_jobs(
@@ -291,29 +292,10 @@ fn fail_orphaned_slurm_jobs(
                 }
             }
 
-            if !dry_run {
-                // Mark this compute node as inactive since its Slurm job is gone
-                let mut updated_node = compute_node.clone();
-                updated_node.is_active = Some(false);
-                match apis::compute_nodes_api::update_compute_node(
-                    config,
-                    compute_node_id,
-                    updated_node,
-                ) {
-                    Ok(_) => {
-                        debug!(
-                            "Marked compute node {} as inactive (Slurm job {} no longer running)",
-                            compute_node_id, slurm_job_id
-                        );
-                    }
-                    Err(e) => {
-                        warn!(
-                            "Failed to mark compute node {} as inactive: {}",
-                            compute_node_id, e
-                        );
-                    }
-                }
-            }
+            // Compute-node deactivation is handled centrally by Step 4
+            // (`deactivate_orphaned_compute_nodes`) so that every deactivation is
+            // counted in `OrphanCleanupResult::compute_nodes_deactivated`. Step 4
+            // runs after this step and sweeps the still-active node here.
         }
 
         if !dry_run {

--- a/src/client/commands/workflows.rs
+++ b/src/client/commands/workflows.rs
@@ -1506,6 +1506,36 @@ pub fn handle_cancel(config: &Configuration, workflow_id: &Option<i64>, format: 
                                         node.scheduler_id
                                     );
                                 }
+
+                                // `scancel` kills the job runner ungracefully, so it never
+                                // deactivates its own compute node. Do it here, otherwise the
+                                // ComputeNode rows stay is_active=true and block `torc recover`.
+                                match super::orphan_detection::deactivate_compute_nodes_for_scheduled_node(
+                                    config,
+                                    node.workflow_id,
+                                    node_id,
+                                    &node.scheduler_id.to_string(),
+                                    false,
+                                ) {
+                                    Ok(count) => {
+                                        if count > 0 && format != "json" {
+                                            println!(
+                                                "  Deactivated {} compute node(s) for node {}",
+                                                count, node.scheduler_id
+                                            );
+                                        }
+                                    }
+                                    Err(e) => {
+                                        let error_msg = format!(
+                                            "Failed to deactivate compute nodes for node {}: {}",
+                                            node.scheduler_id, e
+                                        );
+                                        errors.push(error_msg.clone());
+                                        if format != "json" {
+                                            eprintln!("  {}", error_msg);
+                                        }
+                                    }
+                                }
                             }
                         }
                         Err(e) => {
@@ -2992,6 +3022,12 @@ fn handle_sync_status(
                         result.running_jobs_failed
                     );
                 }
+                if result.compute_nodes_deactivated > 0 {
+                    println!(
+                        "  - {} compute node(s) deactivated (Slurm allocation gone)",
+                        result.compute_nodes_deactivated
+                    );
+                }
 
                 if !result.failed_job_details.is_empty() {
                     println!("\nAffected jobs:");
@@ -3011,10 +3047,12 @@ fn handle_sync_status(
                 }
 
                 if !dry_run {
-                    println!(
-                        "\nTotal: {} job(s) marked as failed",
-                        result.total_jobs_failed()
-                    );
+                    if result.total_jobs_failed() > 0 {
+                        println!(
+                            "\nTotal: {} job(s) marked as failed",
+                            result.total_jobs_failed()
+                        );
+                    }
                     println!(
                         "\nYou can now run `torc recover {}` to retry failed jobs.",
                         workflow_id

--- a/tests/test_orphaned_jobs.rs
+++ b/tests/test_orphaned_jobs.rs
@@ -3,8 +3,39 @@ mod common;
 use common::{ServerProcess, create_test_workflow, start_server};
 use rstest::rstest;
 use serde_json::json;
+use serial_test::serial;
 use torc::client::apis;
 use torc::models;
+
+/// RAII guard that sets an environment variable and restores its previous value
+/// (or removes it if it was unset) on drop, so a test cannot leak env state into
+/// other tests sharing the process.
+struct EnvVarGuard {
+    key: String,
+    original: Option<String>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &str, value: &str) -> Self {
+        let original = std::env::var(key).ok();
+        unsafe { std::env::set_var(key, value) };
+        Self {
+            key: key.to_string(),
+            original,
+        }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        unsafe {
+            match &self.original {
+                Some(v) => std::env::set_var(&self.key, v),
+                None => std::env::remove_var(&self.key),
+            }
+        }
+    }
+}
 
 /// Helper function to create a test Slurm scheduler
 fn create_test_slurm_scheduler(
@@ -438,14 +469,15 @@ fn test_orphaned_job_simulation(start_server: &ServerProcess) {
 /// compute node is active), so the node stayed `is_active = true` and blocked
 /// `torc recover`. The new Step 4 sweep must now deactivate it.
 #[rstest]
+#[serial(slurm)]
 fn test_cleanup_deactivates_active_node_after_cancel(start_server: &ServerProcess) {
     let config = &start_server.config;
 
     // Drive SlurmInterface with the fake squeue. With a scheduler_id that is not
     // present in the fake jobs file, squeue reports the job as gone, which is
     // exactly the post-`scancel` state we want to simulate. USER is required by
-    // SlurmInterface::new(). nextest runs each test in its own process, so these
-    // env mutations are isolated.
+    // SlurmInterface::new(). The env mutations are scoped to RAII guards (restored
+    // on drop) and `#[serial(slurm)]` keeps them from racing other Slurm tests.
     let fake_squeue = std::env::current_dir()
         .unwrap()
         .join("tests/scripts/fake_squeue.sh");
@@ -454,15 +486,12 @@ fn test_cleanup_deactivates_active_node_after_cancel(start_server: &ServerProces
         "fake_squeue.sh not found at {:?}",
         fake_squeue
     );
-    unsafe {
-        std::env::set_var(
-            "TORC_FAKE_SQUEUE",
-            fake_squeue.to_string_lossy().to_string(),
-        );
-        if std::env::var("USER").is_err() && std::env::var("USERNAME").is_err() {
-            std::env::set_var("USER", "test-user");
-        }
-    }
+    let _squeue_guard = EnvVarGuard::set("TORC_FAKE_SQUEUE", &fake_squeue.to_string_lossy());
+    let _user_guard = if std::env::var("USER").is_err() && std::env::var("USERNAME").is_err() {
+        Some(EnvVarGuard::set("USER", "test-user"))
+    } else {
+        None
+    };
 
     // Create workflow and a Slurm scheduler config.
     let workflow = create_test_workflow(config, "test_cleanup_deactivates_after_cancel");

--- a/tests/test_orphaned_jobs.rs
+++ b/tests/test_orphaned_jobs.rs
@@ -428,6 +428,113 @@ fn test_orphaned_job_simulation(start_server: &ServerProcess) {
     assert_eq!(fetched_scheduled.status, "complete");
 }
 
+/// Regression test for the bug where `torc cancel` left compute nodes active.
+///
+/// Reproduces the reported scenario: a workflow has an active compute node whose
+/// scheduled compute node is in "canceled" status (as `torc cancel` leaves it),
+/// no jobs are still running, and the underlying Slurm allocation is gone. Before
+/// the fix, `cleanup_orphaned_jobs` skipped such nodes entirely (Step 1 only looks
+/// at "active" scheduled nodes; the running-job fallback short-circuits while any
+/// compute node is active), so the node stayed `is_active = true` and blocked
+/// `torc recover`. The new Step 4 sweep must now deactivate it.
+#[rstest]
+fn test_cleanup_deactivates_active_node_after_cancel(start_server: &ServerProcess) {
+    let config = &start_server.config;
+
+    // Drive SlurmInterface with the fake squeue. With a scheduler_id that is not
+    // present in the fake jobs file, squeue reports the job as gone, which is
+    // exactly the post-`scancel` state we want to simulate. USER is required by
+    // SlurmInterface::new(). nextest runs each test in its own process, so these
+    // env mutations are isolated.
+    let fake_squeue = std::env::current_dir()
+        .unwrap()
+        .join("tests/scripts/fake_squeue.sh");
+    assert!(
+        fake_squeue.exists(),
+        "fake_squeue.sh not found at {:?}",
+        fake_squeue
+    );
+    unsafe {
+        std::env::set_var(
+            "TORC_FAKE_SQUEUE",
+            fake_squeue.to_string_lossy().to_string(),
+        );
+        if std::env::var("USER").is_err() && std::env::var("USERNAME").is_err() {
+            std::env::set_var("USER", "test-user");
+        }
+    }
+
+    // Create workflow and a Slurm scheduler config.
+    let workflow = create_test_workflow(config, "test_cleanup_deactivates_after_cancel");
+    let workflow_id = workflow.id.unwrap();
+    let scheduler = create_test_slurm_scheduler(config, workflow_id, "cancel_test_scheduler");
+    let scheduler_config_id = scheduler.id.unwrap();
+
+    // Scheduled compute node in "canceled" status, as `torc cancel` leaves it.
+    // The scheduler_id (Slurm job ID) is intentionally not in the fake squeue
+    // jobs file so the allocation reads as gone.
+    let scheduled_node = models::ScheduledComputeNodesModel::new(
+        workflow_id,
+        9876543, // Slurm job ID, absent from fake squeue -> reported gone
+        scheduler_config_id,
+        "slurm".to_string(),
+        "canceled".to_string(),
+    );
+    let created_scheduled =
+        apis::scheduled_compute_nodes_api::create_scheduled_compute_node(config, scheduled_node)
+            .expect("Failed to create scheduled compute node");
+    let scheduled_compute_node_id = created_scheduled.id.unwrap();
+
+    // Active compute node linked to that scheduled node, with no running jobs.
+    let mut compute_node = models::ComputeNodeModel::new(
+        workflow_id,
+        "cancel-test-host".to_string(),
+        std::process::id() as i64,
+        chrono::Utc::now().to_rfc3339(),
+        8,
+        16.0,
+        0,
+        1,
+        "slurm".to_string(),
+        Some(json!({ "scheduler_id": scheduled_compute_node_id })),
+    );
+    compute_node.is_active = Some(true);
+    let created_node = apis::compute_nodes_api::create_compute_node(config, compute_node)
+        .expect("Failed to create compute node");
+    let compute_node_id = created_node.id.unwrap();
+
+    // Precondition: the node is active before cleanup.
+    let before = apis::compute_nodes_api::get_compute_node(config, compute_node_id)
+        .expect("Failed to get compute node");
+    assert_eq!(
+        before.is_active,
+        Some(true),
+        "compute node should start active"
+    );
+
+    // Run the real cleanup path used by `torc workflows sync-status` / `torc recover`.
+    let result = torc::client::commands::orphan_detection::cleanup_orphaned_jobs(
+        config,
+        workflow_id,
+        false, // not a dry run
+    )
+    .expect("cleanup_orphaned_jobs failed");
+
+    assert_eq!(
+        result.compute_nodes_deactivated, 1,
+        "expected exactly one compute node to be deactivated"
+    );
+
+    // The node must now be inactive so `torc recover` can proceed.
+    let after = apis::compute_nodes_api::get_compute_node(config, compute_node_id)
+        .expect("Failed to get compute node after cleanup");
+    assert_eq!(
+        after.is_active,
+        Some(false),
+        "compute node should be deactivated after cleanup"
+    );
+}
+
 /// Test that list_jobs returns empty when filtering by non-existent active_compute_node_id
 #[rstest]
 fn test_list_jobs_no_active_compute_node(start_server: &ServerProcess) {


### PR DESCRIPTION
## Problem

After `torc cancel <id>` killed hung Slurm jobs, the workflow's compute nodes stayed `is_active = true`, so `torc recover` kept failing with *"Cannot recover: there are still active compute nodes"* — and `torc workflows sync-status` reported *"No orphaned jobs found"* without fixing anything.

Root cause is two cooperating defects:

1. **`torc cancel` never deactivated compute nodes.** It issued `scancel` and set each `ScheduledComputeNode` to `"canceled"`, but `scancel` kills the job runners ungracefully, so they never reach their own deactivation path. Nothing else cleared `ComputeNode.is_active`.

2. **Orphan cleanup couldn't recover from that state.** Its only compute-node deactivation path (`fail_orphaned_slurm_jobs`) filters scheduled compute nodes to `status = "active"`, but a cancel moves them to `"canceled"`, so they're skipped. The running-job fallback also short-circuits whenever *any* active compute node exists — exactly the stuck state.

## Fix

1. `handle_cancel` now deactivates the compute nodes associated with each canceled scheduled compute node, via a new shared helper `deactivate_compute_nodes_for_scheduled_node`.

2. `cleanup_orphaned_jobs` gains **Step 4** (`deactivate_orphaned_compute_nodes`): it sweeps every Slurm-type scheduled compute node regardless of status and deactivates still-active compute nodes whose Slurm allocation is gone. This makes `sync-status`/`recover` self-healing for workflows already stranded (e.g. the reported #237).

`OrphanCleanupResult` reports `compute_nodes_deactivated`; `sync-status` surfaces it in text and JSON.

## Test

Adds `test_cleanup_deactivates_active_node_after_cancel`, which reproduces the bug through the real `cleanup_orphaned_jobs` path: an active compute node whose scheduled node is `"canceled"`, no running jobs, and a Slurm allocation that reads as gone (driven by the existing `fake_squeue.sh`). Asserts `compute_nodes_deactivated == 1` and the node ends up `is_active == Some(false)`. No new Slurm test infrastructure.

## Verification

- `cargo build` / `cargo clippy --all --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo nextest run` on the new + existing orphan tests — pass

To recover an already-stranded workflow: `torc workflows sync-status <id>` now deactivates the nodes, after which `torc recover <id>` proceeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)