### PR TITLE
TUI/Dash improvements: log resolution, user-data tab, workflow details (#358)

### DIFF
--- a/src/client/commands/workflows.rs
+++ b/src/client/commands/workflows.rs
@@ -2526,6 +2526,9 @@ fn handle_get(config: &Configuration, id: &Option<i64>, user: &str, format: &str
                 if let Some(run_id) = workflow.run_id {
                     println!("  Run ID: {}", run_id);
                 }
+                if let Some(submission_dir) = &workflow.submission_directory {
+                    println!("  Submission Directory: {}", submission_dir);
+                }
                 println!("  Canceled: {}", workflow.is_canceled.unwrap_or(false));
                 println!("  Archived: {}", workflow.is_archived.unwrap_or(false));
                 if let Some(defaults_map) = &workflow.slurm_defaults {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -181,6 +181,20 @@ where
                         }
                         _ => {}
                     },
+                    Some(PopupType::WorkflowDetails(_)) => match key.code {
+                        KeyCode::Char('q') | KeyCode::Esc => app.close_popup(),
+                        KeyCode::Down => {
+                            if let Some(PopupType::WorkflowDetails(popup)) = app.popup.as_mut() {
+                                popup.scroll_down();
+                            }
+                        }
+                        KeyCode::Up => {
+                            if let Some(PopupType::WorkflowDetails(popup)) = app.popup.as_mut() {
+                                popup.scroll_up();
+                            }
+                        }
+                        _ => {}
+                    },
                     Some(PopupType::LogViewer(viewer)) => {
                         if viewer.is_searching {
                             match key.code {
@@ -515,6 +529,9 @@ where
                     }
                     KeyCode::Tab => app.next_detail_view(),
                     KeyCode::BackTab => app.previous_detail_view(),
+                    // Show expanded details (incl. submission directory) for the
+                    // highlighted workflow.
+                    KeyCode::Char('D') => app.show_workflow_details(),
                     // Page through the active list (Workflows / Jobs / Results /
                     // Compute Nodes) one TUI_PAGE_SIZE page at a time, on demand.
                     KeyCode::Char(']') => {
@@ -626,6 +643,9 @@ where
                     KeyCode::Char('l') if app.focus == Focus::Details => match app.detail_view {
                         DetailViewType::Jobs => {
                             app.show_job_logs();
+                        }
+                        DetailViewType::Results => {
+                            app.show_result_logs();
                         }
                         DetailViewType::ScheduledNodes => {
                             app.show_slurm_logs();

--- a/src/tui/api.rs
+++ b/src/tui/api.rs
@@ -4,7 +4,8 @@ use crate::client::config::TorcConfig;
 use crate::client::workflow_spec::WorkflowSpec;
 use crate::models::{
     ComputeNodeModel, FileModel, IsCompleteResponse, JobDependencyModel, JobModel, JobStatus,
-    ResultModel, ScheduledComputeNodesModel, SlurmStatsModel, WorkflowActionModel, WorkflowModel,
+    ResultModel, ScheduledComputeNodesModel, SlurmStatsModel, UserDataModel, WorkflowActionModel,
+    WorkflowModel,
 };
 use anyhow::{Context, Result};
 
@@ -211,6 +212,31 @@ impl TorcClient {
             None,   // all_runs
         )
         .context("Failed to list results")?;
+
+        Ok((response.items, response.has_more))
+    }
+
+    /// Returns the page items plus the server's `has_more` flag for the
+    /// workflow's user_data entries.
+    pub fn list_user_data(
+        &self,
+        workflow_id: i64,
+        offset: Option<i64>,
+        limit: Option<i64>,
+    ) -> Result<(Vec<UserDataModel>, bool)> {
+        let response = apis::user_data_api::list_user_data(
+            &self.config,
+            workflow_id,
+            None,   // consumer_job_id
+            None,   // producer_job_id
+            offset, // offset
+            limit,  // limit
+            None,   // sort_by
+            None,   // reverse_sort
+            None,   // name
+            None,   // is_ephemeral
+        )
+        .context("Failed to list user data")?;
 
         Ok((response.items, response.has_more))
     }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -14,7 +14,7 @@ use crate::client::log_paths::{
 use crate::client::sse_client::SseEvent;
 use crate::models::{
     ComputeNodeModel, FileModel, JobModel, JobStatus, ResultModel, ScheduledComputeNodesModel,
-    SlurmStatsModel, WorkflowModel,
+    SlurmStatsModel, UserDataModel, WorkflowModel,
 };
 
 use crate::client::apis::configuration::{BasicAuth, TlsConfig};
@@ -23,7 +23,7 @@ use crate::client::config::TorcConfig;
 use super::api::TorcClient;
 use super::components::{
     ConfirmationDialog, ErrorDialog, FileViewer, JobDetailsPopup, LogViewer, ProcessViewer,
-    RecoverPromptDialog, StatusMessage,
+    RecoverPromptDialog, StatusMessage, WorkflowDetailsPopup,
 };
 use super::dag::{DagLayout, JobNode};
 
@@ -32,6 +32,7 @@ pub enum DetailViewType {
     Summary,
     Jobs,
     Files,
+    UserData,
     Events,
     Results,
     ComputeNodes,
@@ -160,6 +161,7 @@ impl JobAction {
 pub enum PopupType {
     Help,
     JobDetails(JobDetailsPopup),
+    WorkflowDetails(WorkflowDetailsPopup),
     LogViewer(LogViewer),
     FileViewer(FileViewer),
     ProcessViewer(ProcessViewer),
@@ -189,6 +191,7 @@ impl DetailViewType {
             Self::Summary => "◆ Summary",
             Self::Jobs => "▶ Jobs",
             Self::Files => "◫ Files",
+            Self::UserData => "◈ User Data",
             Self::Events => "⚡ Events",
             Self::Results => "✓ Results",
             Self::ComputeNodes => "▣ Compute",
@@ -203,6 +206,7 @@ impl DetailViewType {
             Self::Summary,
             Self::Jobs,
             Self::Files,
+            Self::UserData,
             Self::Events,
             Self::Results,
             Self::ComputeNodes,
@@ -216,7 +220,8 @@ impl DetailViewType {
         match self {
             Self::Summary => Self::Jobs,
             Self::Jobs => Self::Files,
-            Self::Files => Self::Events,
+            Self::Files => Self::UserData,
+            Self::UserData => Self::Events,
             Self::Events => Self::Results,
             Self::Results => Self::ComputeNodes,
             Self::ComputeNodes => Self::ScheduledNodes,
@@ -231,7 +236,8 @@ impl DetailViewType {
             Self::Summary => Self::Dag,
             Self::Jobs => Self::Summary,
             Self::Files => Self::Jobs,
-            Self::Events => Self::Files,
+            Self::UserData => Self::Files,
+            Self::Events => Self::UserData,
             Self::Results => Self::Events,
             Self::ComputeNodes => Self::Results,
             Self::ScheduledNodes => Self::ComputeNodes,
@@ -575,6 +581,13 @@ pub struct App {
     pub files: Vec<FileModel>,
     pub files_all: Vec<FileModel>,
     pub files_state: TableState,
+    pub user_data: Vec<UserDataModel>,
+    pub user_data_all: Vec<UserDataModel>,
+    pub user_data_state: TableState,
+    /// Offset of the currently-loaded User Data page.
+    pub user_data_offset: i64,
+    /// True when the last User Data fetch filled a full page.
+    pub user_data_has_more: bool,
     pub events: Vec<SseEvent>,
     pub events_all: Vec<SseEvent>,
     pub events_state: TableState,
@@ -704,6 +717,11 @@ impl App {
             files: Vec::new(),
             files_all: Vec::new(),
             files_state: TableState::default(),
+            user_data: Vec::new(),
+            user_data_all: Vec::new(),
+            user_data_state: TableState::default(),
+            user_data_offset: 0,
+            user_data_has_more: false,
             events: Vec::new(),
             events_all: Vec::new(),
             events_state: TableState::default(),
@@ -859,6 +877,7 @@ impl App {
                     DetailViewType::SlurmStats => {
                         (&mut self.slurm_stats_state, self.slurm_stats.len())
                     }
+                    DetailViewType::UserData => (&mut self.user_data_state, self.user_data.len()),
                     DetailViewType::Summary | DetailViewType::Dag => return, // No table to navigate
                 };
                 if len > 0 {
@@ -905,6 +924,7 @@ impl App {
                     DetailViewType::SlurmStats => {
                         (&mut self.slurm_stats_state, self.slurm_stats.len())
                     }
+                    DetailViewType::UserData => (&mut self.user_data_state, self.user_data.len()),
                     DetailViewType::Summary | DetailViewType::Dag => return, // No table to navigate
                 };
                 if len > 0 {
@@ -952,6 +972,7 @@ impl App {
                     DetailViewType::SlurmStats => {
                         (&mut self.slurm_stats_state, self.slurm_stats.len())
                     }
+                    DetailViewType::UserData => (&mut self.user_data_state, self.user_data.len()),
                     DetailViewType::Summary | DetailViewType::Dag => return,
                 };
                 if len > 0 {
@@ -999,6 +1020,7 @@ impl App {
                     DetailViewType::SlurmStats => {
                         (&mut self.slurm_stats_state, self.slurm_stats.len())
                     }
+                    DetailViewType::UserData => (&mut self.user_data_state, self.user_data.len()),
                     DetailViewType::Summary | DetailViewType::Dag => return,
                 };
                 if len > 0 {
@@ -1040,6 +1062,7 @@ impl App {
                     DetailViewType::SlurmStats => {
                         (&mut self.slurm_stats_state, self.slurm_stats.len())
                     }
+                    DetailViewType::UserData => (&mut self.user_data_state, self.user_data.len()),
                     DetailViewType::Summary | DetailViewType::Dag => return,
                 };
                 if len > 0 {
@@ -1077,6 +1100,7 @@ impl App {
                     DetailViewType::SlurmStats => {
                         (&mut self.slurm_stats_state, self.slurm_stats.len())
                     }
+                    DetailViewType::UserData => (&mut self.user_data_state, self.user_data.len()),
                     DetailViewType::Summary | DetailViewType::Dag => return,
                 };
                 if len > 0 {
@@ -1147,6 +1171,20 @@ impl App {
                         self.files = self.files_all.clone();
                         if !self.files.is_empty() {
                             self.files_state.select(Some(0));
+                        }
+                    }
+                    DetailViewType::UserData => {
+                        (self.user_data_all, self.user_data_has_more) =
+                            self.client.list_user_data(
+                                workflow_id,
+                                Some(self.user_data_offset),
+                                Some(TUI_PAGE_SIZE),
+                            )?;
+                        self.user_data = self.user_data_all.clone();
+                        if self.user_data.is_empty() {
+                            self.user_data_state.select(None);
+                        } else {
+                            self.user_data_state.select(Some(0));
                         }
                     }
                     DetailViewType::Events => {
@@ -1244,6 +1282,7 @@ impl App {
         // afterward.
         let jobs_sel = self.jobs_state.selected();
         let files_sel = self.files_state.selected();
+        let user_data_sel = self.user_data_state.selected();
         let results_sel = self.results_state.selected();
         let compute_nodes_sel = self.compute_nodes_state.selected();
         let scheduled_nodes_sel = self.scheduled_nodes_state.selected();
@@ -1276,6 +1315,11 @@ impl App {
 
         restore_selection(&mut self.jobs_state, jobs_sel, self.jobs.len());
         restore_selection(&mut self.files_state, files_sel, self.files.len());
+        restore_selection(
+            &mut self.user_data_state,
+            user_data_sel,
+            self.user_data.len(),
+        );
         restore_selection(&mut self.results_state, results_sel, self.results.len());
         restore_selection(
             &mut self.compute_nodes_state,
@@ -1577,6 +1621,8 @@ impl App {
         self.results_has_more = false;
         self.compute_nodes_offset = 0;
         self.compute_nodes_has_more = false;
+        self.user_data_offset = 0;
+        self.user_data_has_more = false;
     }
 
     /// True when a next page may exist for the active paginated view.
@@ -1587,6 +1633,7 @@ impl App {
                 DetailViewType::Jobs => self.jobs_has_more,
                 DetailViewType::Results => self.results_has_more,
                 DetailViewType::ComputeNodes => self.compute_nodes_has_more,
+                DetailViewType::UserData => self.user_data_has_more,
                 _ => false,
             },
             _ => false,
@@ -1619,6 +1666,10 @@ impl App {
                     self.compute_nodes_offset += TUI_PAGE_SIZE;
                     self.reload_detail_page_preserving_filter()?;
                 }
+                DetailViewType::UserData => {
+                    self.user_data_offset += TUI_PAGE_SIZE;
+                    self.reload_detail_page_preserving_filter()?;
+                }
                 _ => {}
             },
             _ => {}
@@ -1649,6 +1700,10 @@ impl App {
                 }
                 DetailViewType::ComputeNodes if self.compute_nodes_offset > 0 => {
                     self.compute_nodes_offset = (self.compute_nodes_offset - TUI_PAGE_SIZE).max(0);
+                    self.reload_detail_page_preserving_filter()?;
+                }
+                DetailViewType::UserData if self.user_data_offset > 0 => {
+                    self.user_data_offset = (self.user_data_offset - TUI_PAGE_SIZE).max(0);
                     self.reload_detail_page_preserving_filter()?;
                 }
                 _ => {}
@@ -1914,6 +1969,7 @@ impl App {
             DetailViewType::Summary => vec![], // Summary view doesn't support filtering
             DetailViewType::Jobs => vec!["Status", "Name", "Command"],
             DetailViewType::Files => vec!["Name", "Path"],
+            DetailViewType::UserData => vec!["Name", "Data"],
             DetailViewType::Events => vec!["Event Type", "Data"],
             DetailViewType::Results => vec!["Status", "Return Code"],
             DetailViewType::ComputeNodes => vec!["Hostname", "Active"],
@@ -1992,6 +2048,15 @@ impl App {
                         return;
                     };
                     (FilterTarget::Details, "Name", file.name.clone())
+                }
+                DetailViewType::UserData => {
+                    let Some(idx) = self.user_data_state.selected() else {
+                        return;
+                    };
+                    let Some(ud) = self.user_data.get(idx) else {
+                        return;
+                    };
+                    (FilterTarget::Details, "Name", ud.name.clone())
                 }
                 _ => return,
             },
@@ -2262,6 +2327,27 @@ impl App {
                     self.slurm_stats_state.select(None);
                 }
             }
+            DetailViewType::UserData => {
+                self.user_data = self
+                    .user_data_all
+                    .iter()
+                    .filter(|ud| match column.as_str() {
+                        "Name" => ud.name.to_lowercase().contains(&value),
+                        "Data" => ud
+                            .data
+                            .as_ref()
+                            .map(|v| v.to_string().to_lowercase().contains(&value))
+                            .unwrap_or(false),
+                        _ => false,
+                    })
+                    .cloned()
+                    .collect();
+                if !self.user_data.is_empty() {
+                    self.user_data_state.select(Some(0));
+                } else {
+                    self.user_data_state.select(None);
+                }
+            }
             DetailViewType::Summary | DetailViewType::Dag => {
                 // Summary and DAG views don't support filtering
             }
@@ -2306,6 +2392,12 @@ impl App {
                 self.files = self.files_all.clone();
                 if !self.files.is_empty() {
                     self.files_state.select(Some(0));
+                }
+            }
+            DetailViewType::UserData => {
+                self.user_data = self.user_data_all.clone();
+                if !self.user_data.is_empty() {
+                    self.user_data_state.select(Some(0));
                 }
             }
             DetailViewType::Events => {
@@ -2613,6 +2705,38 @@ impl App {
         self.workflows_state
             .selected()
             .and_then(|idx| self.workflows.get(idx))
+    }
+
+    /// Open a popup with expanded details for the highlighted workflow,
+    /// including the submission directory and configuration fields that don't
+    /// fit in the Workflows table. Fetches a fresh copy so the details reflect
+    /// the current server state.
+    pub fn show_workflow_details(&mut self) {
+        let Some(workflow_id) = self
+            .get_selected_workflow()
+            .and_then(|w| w.id)
+            .or(self.selected_workflow_id)
+        else {
+            self.set_status(StatusMessage::warning("No workflow selected"));
+            return;
+        };
+
+        let workflow = match self.client.get_workflow(workflow_id) {
+            Ok(w) => w,
+            Err(e) => {
+                self.set_status(StatusMessage::error(&format!(
+                    "Could not load workflow details: {}",
+                    e
+                )));
+                return;
+            }
+        };
+
+        let rows = build_workflow_detail_rows(&workflow);
+        let popup = WorkflowDetailsPopup::new(workflow_id, workflow.name.clone(), rows);
+        self.previous_focus = self.focus;
+        self.focus = Focus::Popup;
+        self.popup = Some(PopupType::WorkflowDetails(popup));
     }
 
     pub fn request_workflow_action(&mut self, action: WorkflowAction) {
@@ -3403,6 +3527,39 @@ impl App {
 
     // === Log Viewer ===
 
+    /// Find the loaded `WorkflowModel` for the currently-selected workflow.
+    /// Used to resolve log paths against the workflow's recorded
+    /// `submission_directory` so logs open regardless of the TUI's CWD.
+    fn selected_workflow_model(&self) -> Option<&WorkflowModel> {
+        let id = self.selected_workflow_id?;
+        self.workflows
+            .iter()
+            .chain(self.workflows_all.iter())
+            .find(|w| w.id == Some(id))
+    }
+
+    /// Resolve the effective output directory for locating log files.
+    ///
+    /// Job and Slurm log files are written relative to the directory the
+    /// workflow was submitted from. When the configured `output_dir` is
+    /// relative and the workflow recorded a `submission_directory`, resolve
+    /// against it so logs open from anywhere on the filesystem -- not just
+    /// when the TUI is launched from the original submission directory. An
+    /// absolute `output_dir`, or a workflow without a recorded submission
+    /// directory (older workflows), falls back to the configured path as-is.
+    fn resolve_log_output_dir(&self) -> PathBuf {
+        if self.output_dir.is_absolute() {
+            return self.output_dir.clone();
+        }
+        if let Some(dir) = self
+            .selected_workflow_model()
+            .and_then(|w| w.submission_directory.as_deref())
+        {
+            return std::path::Path::new(dir).join(&self.output_dir);
+        }
+        self.output_dir.clone()
+    }
+
     pub fn show_job_logs(&mut self) {
         if let Some(job) = self.get_selected_job() {
             let job_id = job.id.unwrap_or(0);
@@ -3439,61 +3596,9 @@ impl App {
                 .filter(|r| r.job_id == viewer.job_id)
                 .max_by_key(|r| (r.run_id, r.attempt_id.unwrap_or(1)))
             {
-                // Construct log paths using the standard path pattern
-                let output_dir = &self.output_dir;
-
                 let attempt_id = result.attempt_id.unwrap_or(1);
-                let stdout_path = get_job_stdout_path(
-                    output_dir,
-                    workflow_id,
-                    viewer.job_id,
-                    result.run_id,
-                    attempt_id,
-                );
-                let stderr_path = get_job_stderr_path(
-                    output_dir,
-                    workflow_id,
-                    viewer.job_id,
-                    result.run_id,
-                    attempt_id,
-                );
-                let combined_path = get_job_combined_path(
-                    output_dir,
-                    workflow_id,
-                    viewer.job_id,
-                    result.run_id,
-                    attempt_id,
-                );
-
-                // Try separate .o file first, then fall back to combined .log
-                if let Ok(content) = std::fs::read_to_string(&stdout_path) {
-                    viewer.stdout_path = Some(stdout_path);
-                    viewer.stdout_content = content;
-                } else if let Ok(content) = std::fs::read_to_string(&combined_path) {
-                    viewer.stdout_path = Some(combined_path.clone());
-                    viewer.stdout_content = content;
-                } else {
-                    viewer.stdout_path = Some(stdout_path.clone());
-                    viewer.stdout_content = format!(
-                        "Could not read file: {}\n\nThe file may not exist if:\n- The job has not run yet\n- The output directory is different\n- You are on a different system\n- The job used a stdio mode that doesn't capture stdout",
-                        stdout_path
-                    );
-                }
-
-                // Try separate .e file first, then fall back to combined .log
-                if let Ok(content) = std::fs::read_to_string(&stderr_path) {
-                    viewer.stderr_path = Some(stderr_path);
-                    viewer.stderr_content = content;
-                } else if let Ok(content) = std::fs::read_to_string(&combined_path) {
-                    viewer.stderr_path = Some(combined_path);
-                    viewer.stderr_content = content;
-                } else {
-                    viewer.stderr_path = Some(stderr_path.clone());
-                    viewer.stderr_content = format!(
-                        "Could not read file: {}\n\nThe file may not exist if:\n- The job has not run yet\n- The output directory is different\n- You are on a different system\n- The job used a stdio mode that doesn't capture stderr",
-                        stderr_path
-                    );
-                }
+                let job_id = viewer.job_id;
+                self.populate_log_viewer(viewer, workflow_id, job_id, result.run_id, attempt_id);
             } else {
                 viewer.stdout_content =
                     "No results found for this job.\n\nThe job may not have run yet.".to_string();
@@ -3502,6 +3607,94 @@ impl App {
         }
 
         Ok(())
+    }
+
+    /// Open the stdout/stderr logs for the result currently selected on the
+    /// Results tab. Reuses the Jobs-tab log-loading logic, but targets the
+    /// specific run/attempt of the selected result rather than the job's
+    /// latest attempt.
+    pub fn show_result_logs(&mut self) {
+        let Some(result) = self
+            .results_state
+            .selected()
+            .and_then(|idx| self.results.get(idx))
+            .cloned()
+        else {
+            self.set_status(StatusMessage::warning("No result selected"));
+            return;
+        };
+
+        let job_name = self
+            .jobs_all
+            .iter()
+            .find(|j| j.id == Some(result.job_id))
+            .map(|j| j.name.clone())
+            .unwrap_or_else(|| format!("Job {}", result.job_id));
+
+        let mut viewer = LogViewer::new(result.job_id, job_name);
+        self.populate_log_viewer(
+            &mut viewer,
+            result.workflow_id,
+            result.job_id,
+            result.run_id,
+            result.attempt_id.unwrap_or(1),
+        );
+
+        self.previous_focus = self.focus;
+        self.focus = Focus::Popup;
+        self.popup = Some(PopupType::LogViewer(viewer));
+    }
+
+    /// Fill a `LogViewer`'s stdout/stderr content for a specific job attempt,
+    /// trying the separate `.o`/`.e` files first and falling back to the
+    /// combined `.log`. Paths resolve against the workflow's submission
+    /// directory via `resolve_log_output_dir` so they open regardless of the
+    /// TUI's current directory. Shared by the Jobs and Results tabs.
+    fn populate_log_viewer(
+        &self,
+        viewer: &mut LogViewer,
+        workflow_id: i64,
+        job_id: i64,
+        run_id: i64,
+        attempt_id: i64,
+    ) {
+        let output_dir = self.resolve_log_output_dir();
+        let output_dir = output_dir.as_path();
+
+        let stdout_path = get_job_stdout_path(output_dir, workflow_id, job_id, run_id, attempt_id);
+        let stderr_path = get_job_stderr_path(output_dir, workflow_id, job_id, run_id, attempt_id);
+        let combined_path =
+            get_job_combined_path(output_dir, workflow_id, job_id, run_id, attempt_id);
+
+        // Try separate .o file first, then fall back to combined .log
+        if let Ok(content) = std::fs::read_to_string(&stdout_path) {
+            viewer.stdout_path = Some(stdout_path);
+            viewer.stdout_content = content;
+        } else if let Ok(content) = std::fs::read_to_string(&combined_path) {
+            viewer.stdout_path = Some(combined_path.clone());
+            viewer.stdout_content = content;
+        } else {
+            viewer.stdout_path = Some(stdout_path.clone());
+            viewer.stdout_content = format!(
+                "Could not read file: {}\n\nThe file may not exist if:\n- The job has not run yet\n- The output directory is different\n- You are on a different system\n- The job used a stdio mode that doesn't capture stdout",
+                stdout_path
+            );
+        }
+
+        // Try separate .e file first, then fall back to combined .log
+        if let Ok(content) = std::fs::read_to_string(&stderr_path) {
+            viewer.stderr_path = Some(stderr_path);
+            viewer.stderr_content = content;
+        } else if let Ok(content) = std::fs::read_to_string(&combined_path) {
+            viewer.stderr_path = Some(combined_path);
+            viewer.stderr_content = content;
+        } else {
+            viewer.stderr_path = Some(stderr_path.clone());
+            viewer.stderr_content = format!(
+                "Could not read file: {}\n\nThe file may not exist if:\n- The job has not run yet\n- The output directory is different\n- You are on a different system\n- The job used a stdio mode that doesn't capture stderr",
+                stderr_path
+            );
+        }
     }
 
     // === Slurm Log Viewer ===
@@ -3545,7 +3738,8 @@ impl App {
     }
 
     fn load_slurm_logs(&self, viewer: &mut LogViewer, scheduler_id: &str) -> Result<()> {
-        let output_dir = &self.output_dir;
+        let output_dir = self.resolve_log_output_dir();
+        let output_dir = output_dir.as_path();
 
         let workflow_id = self.selected_workflow_id.unwrap_or(0);
         let stdout_path = get_slurm_stdout_path(output_dir, workflow_id, scheduler_id);
@@ -3997,6 +4191,88 @@ fn restore_selection(state: &mut TableState, prev: Option<usize>, len: usize) {
         Some(idx) if len > 0 => state.select(Some(idx.min(len - 1))),
         _ => state.select(None),
     }
+}
+
+/// Build the `(label, value)` rows shown in the Workflow Details popup. Covers
+/// the scalar fields and summarizes the larger configuration blocks so the
+/// user can see everything the Workflows table omits -- most importantly the
+/// submission directory, which is needed to locate logs and outputs.
+fn build_workflow_detail_rows(w: &WorkflowModel) -> Vec<(String, String)> {
+    let mut rows: Vec<(String, String)> = Vec::new();
+    let dash = || "—".to_string();
+
+    rows.push(("Name".to_string(), w.name.clone()));
+    rows.push(("User".to_string(), w.user.clone()));
+    if let Some(project) = &w.project {
+        rows.push(("Project".to_string(), project.clone()));
+    }
+    if let Some(desc) = &w.description {
+        rows.push(("Description".to_string(), desc.clone()));
+    }
+    rows.push((
+        "Submission Directory".to_string(),
+        w.submission_directory.clone().unwrap_or_else(dash),
+    ));
+    rows.push((
+        "Timestamp".to_string(),
+        w.timestamp
+            .as_deref()
+            .map(crate::client::utils::format_local_timestamp)
+            .unwrap_or_else(dash),
+    ));
+    rows.push((
+        "Run ID".to_string(),
+        w.run_id.map(|r| r.to_string()).unwrap_or_else(dash),
+    ));
+    rows.push((
+        "Canceled".to_string(),
+        w.is_canceled.unwrap_or(false).to_string(),
+    ));
+    rows.push((
+        "Archived".to_string(),
+        w.is_archived.unwrap_or(false).to_string(),
+    ));
+    if let Some(v) = w.use_pending_failed {
+        rows.push(("Use Pending-Failed".to_string(), v.to_string()));
+    }
+    if let Some(v) = w.enable_ro_crate {
+        rows.push(("RO-Crate Enabled".to_string(), v.to_string()));
+    }
+    if let Some(env) = &w.env
+        && !env.is_empty()
+    {
+        rows.push((
+            "Environment Variables".to_string(),
+            format!("{} set", env.len()),
+        ));
+    }
+    if let Some(metadata) = &w.metadata
+        && !metadata.is_empty()
+    {
+        rows.push((
+            "Metadata Keys".to_string(),
+            format!("{} set", metadata.len()),
+        ));
+    }
+    if let Some(defaults) = &w.slurm_defaults
+        && !defaults.is_empty()
+    {
+        rows.push((
+            "Slurm Defaults".to_string(),
+            format!("{} set", defaults.len()),
+        ));
+    }
+    if w.resource_monitor_config.is_some() {
+        rows.push(("Resource Monitor".to_string(), "configured".to_string()));
+    }
+    if w.execution_config.is_some() {
+        rows.push(("Execution Config".to_string(), "configured".to_string()));
+    }
+    if w.dynamic_jobs.is_some() {
+        rows.push(("Dynamic Jobs".to_string(), "configured".to_string()));
+    }
+
+    rows
 }
 
 /// Outcome of resolving a user-typed Jobs status filter against the known

--- a/src/tui/components.rs
+++ b/src/tui/components.rs
@@ -474,6 +474,7 @@ pub enum HelpContext {
     DetailSummary,
     DetailJobs,
     DetailFiles,
+    DetailUserData,
     DetailEvents,
     DetailResults,
     DetailComputeNodes,
@@ -517,6 +518,7 @@ impl HelpPopup {
             Self::key_line("] / [", "Load next / previous page (on demand)"),
             Self::key_line("g / G", "Jump to top / bottom of table"),
             Self::key_line("Enter", "Load details / Confirm action"),
+            Self::key_line("D", "Show expanded workflow details"),
             Self::key_line("f", "Filter current pane (Workflows or Details)"),
             Self::key_line("=", "Filter to the selected row's value"),
             Self::key_line("c", "Clear filter on current pane"),
@@ -558,6 +560,7 @@ impl HelpPopup {
             }
             HelpContext::DetailResults => {
                 lines.extend(Self::section("Results Tab"));
+                lines.push(Self::key_line("l", "View logs"));
                 lines.push(Self::key_line(
                     "E",
                     "Sort by Runtime (cycles desc / asc / off)",
@@ -592,6 +595,14 @@ impl HelpPopup {
                 lines.push(Self::key_line("Tab", "Change filter column"));
                 lines.push(Self::key_line("Enter", "Apply filter"));
                 lines.push(Self::key_line("Esc", "Cancel filter"));
+            }
+            HelpContext::DetailUserData => {
+                lines.extend(Self::section("User Data Tab"));
+                lines.push(Self::key_line(
+                    up_down_arrows(),
+                    "Scroll through user data entries",
+                ));
+                lines.push(Self::key_line("] / [", "Load next / previous page"));
             }
             HelpContext::DetailSummary
             | HelpContext::DetailFiles
@@ -750,6 +761,81 @@ impl JobDetailsPopup {
                 Style::default().fg(Color::DarkGray),
             )]),
         ];
+
+        let paragraph = Paragraph::new(lines)
+            .style(Style::default().fg(Color::White))
+            .wrap(Wrap { trim: false })
+            .scroll((self.scroll_offset, 0));
+
+        f.render_widget(paragraph, inner);
+    }
+}
+
+/// Popup showing expanded details for a single workflow. Rows are built by the
+/// caller as `(label, value)` pairs so this component stays decoupled from the
+/// workflow model. Scrollable for workflows with many configured fields.
+pub struct WorkflowDetailsPopup {
+    pub workflow_id: i64,
+    pub workflow_name: String,
+    pub rows: Vec<(String, String)>,
+    pub scroll_offset: u16,
+}
+
+impl WorkflowDetailsPopup {
+    pub fn new(workflow_id: i64, workflow_name: String, rows: Vec<(String, String)>) -> Self {
+        Self {
+            workflow_id,
+            workflow_name,
+            rows,
+            scroll_offset: 0,
+        }
+    }
+
+    pub fn scroll_down(&mut self) {
+        self.scroll_offset = self.scroll_offset.saturating_add(1);
+    }
+
+    pub fn scroll_up(&mut self) {
+        self.scroll_offset = self.scroll_offset.saturating_sub(1);
+    }
+
+    pub fn render(&self, f: &mut Frame, area: Rect) {
+        let popup_width = 90.min(area.width.saturating_sub(4));
+        let popup_height = 24.min(area.height.saturating_sub(2));
+
+        let popup_x = (area.width.saturating_sub(popup_width)) / 2;
+        let popup_y = (area.height.saturating_sub(popup_height)) / 2;
+
+        let popup_area = Rect::new(popup_x, popup_y, popup_width, popup_height);
+
+        f.render_widget(Clear, popup_area);
+
+        let block = Block::default()
+            .title(format!(
+                " Workflow Details: {} (ID {}) ",
+                self.workflow_name, self.workflow_id
+            ))
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Cyan));
+
+        let inner = block.inner(popup_area);
+        f.render_widget(block, popup_area);
+
+        let mut lines: Vec<Line> = self
+            .rows
+            .iter()
+            .map(|(label, value)| {
+                Line::from(vec![
+                    Span::styled(format!("{}: ", label), Style::default().fg(Color::DarkGray)),
+                    Span::raw(value.clone()),
+                ])
+            })
+            .collect();
+        lines.push(Line::from(""));
+        lines.push(Line::from(vec![Span::styled(
+            "Press q or Esc to close, ↑/↓ to scroll",
+            Style::default().fg(Color::DarkGray),
+        )]));
 
         let paragraph = Paragraph::new(lines)
             .style(Style::default().fg(Color::White))

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -39,6 +39,7 @@ fn help_context_for(app: &App) -> HelpContext {
             DetailViewType::Summary => HelpContext::DetailSummary,
             DetailViewType::Jobs => HelpContext::DetailJobs,
             DetailViewType::Files => HelpContext::DetailFiles,
+            DetailViewType::UserData => HelpContext::DetailUserData,
             DetailViewType::Events => HelpContext::DetailEvents,
             DetailViewType::Results => HelpContext::DetailResults,
             DetailViewType::ComputeNodes => HelpContext::DetailComputeNodes,
@@ -164,6 +165,9 @@ pub fn draw(f: &mut Frame, app: &mut App) {
                 dialog.render(f, f.area());
             }
             PopupType::JobDetails(details) => {
+                details.render(f, f.area());
+            }
+            PopupType::WorkflowDetails(details) => {
                 details.render(f, f.area());
             }
             PopupType::LogViewer(viewer) => {
@@ -511,17 +515,12 @@ fn draw_tabs(f: &mut Frame, area: Rect, app: &App) {
     let all_types = DetailViewType::all();
     let titles: Vec<&str> = all_types.iter().map(|t| t.as_str()).collect();
 
-    let selected = match app.detail_view {
-        DetailViewType::Summary => 0,
-        DetailViewType::Jobs => 1,
-        DetailViewType::Files => 2,
-        DetailViewType::Events => 3,
-        DetailViewType::Results => 4,
-        DetailViewType::ComputeNodes => 5,
-        DetailViewType::ScheduledNodes => 6,
-        DetailViewType::SlurmStats => 7,
-        DetailViewType::Dag => 8,
-    };
+    // Derive the highlighted index from the canonical tab order so it stays
+    // correct as tabs are added or reordered.
+    let selected = all_types
+        .iter()
+        .position(|t| *t == app.detail_view)
+        .unwrap_or(0);
 
     let tabs = Tabs::new(titles)
         .block(
@@ -547,6 +546,7 @@ fn draw_detail_table(f: &mut Frame, area: Rect, app: &mut App) {
         DetailViewType::Summary => draw_summary(f, area, app),
         DetailViewType::Jobs => draw_jobs_table(f, area, app),
         DetailViewType::Files => draw_files_table(f, area, app),
+        DetailViewType::UserData => draw_user_data_table(f, area, app),
         DetailViewType::Events => draw_events_table(f, area, app),
         DetailViewType::Results => draw_results_table(f, area, app),
         DetailViewType::ComputeNodes => draw_compute_nodes_table(f, area, app),
@@ -993,6 +993,85 @@ fn draw_files_table(f: &mut Frame, area: Rect, app: &mut App) {
     f.render_stateful_widget(table, area, &mut app.files_state);
 }
 
+fn draw_user_data_table(f: &mut Frame, area: Rect, app: &mut App) {
+    let is_focused = app.focus == Focus::Details;
+    let selected_style = Style::default()
+        .add_modifier(Modifier::REVERSED)
+        .fg(Color::Cyan);
+    let header_style = Style::default()
+        .fg(Color::Yellow)
+        .add_modifier(Modifier::BOLD);
+
+    let header = Row::new(vec!["ID", "Name", "Ephemeral", "Data"])
+        .style(header_style)
+        .bottom_margin(1);
+
+    let rows = app.user_data.iter().map(|ud| {
+        let id = ud.id.map(|i| i.to_string()).unwrap_or_default();
+        let name = ud.name.clone();
+        let ephemeral = match ud.is_ephemeral {
+            Some(true) => "yes".to_string(),
+            Some(false) => "no".to_string(),
+            None => String::new(),
+        };
+        // Render the JSON payload on a single line so it fits the table; the
+        // full structure is preserved server-side and visible via the CLI.
+        let data = ud.data.as_ref().map(|v| v.to_string()).unwrap_or_default();
+
+        Row::new(vec![
+            Cell::from(id),
+            Cell::from(name),
+            Cell::from(ephemeral),
+            Cell::from(data),
+        ])
+    });
+
+    let filter = filter_suffix(app, FilterTarget::Details);
+    let page = page_suffix(app.user_data_offset, app.user_data_has_more);
+    let (title, border_style) = if is_focused {
+        (
+            Line::from(vec![
+                Span::styled("◈ ", Style::default().fg(Color::Green)),
+                Span::styled("User Data", Style::default().fg(Color::White)),
+                Span::styled(filter, Style::default().fg(Color::Magenta)),
+                Span::styled(page, Style::default().fg(Color::DarkGray)),
+            ]),
+            Style::default().fg(Color::Green),
+        )
+    } else {
+        (
+            Line::from(vec![
+                Span::styled("◈ ", Style::default().fg(Color::Cyan)),
+                Span::styled("User Data", Style::default().fg(Color::White)),
+                Span::styled(filter, Style::default().fg(Color::Magenta)),
+                Span::styled(page, Style::default().fg(Color::DarkGray)),
+            ]),
+            Style::default().fg(Color::DarkGray),
+        )
+    };
+
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Length(8),
+            Constraint::Length(28),
+            Constraint::Length(10),
+            Constraint::Percentage(100),
+        ],
+    )
+    .header(header)
+    .block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(title)
+            .border_style(border_style),
+    )
+    .row_highlight_style(selected_style)
+    .highlight_symbol("▸ ");
+
+    f.render_stateful_widget(table, area, &mut app.user_data_state);
+}
+
 fn draw_events_table(f: &mut Frame, area: Rect, app: &mut App) {
     let is_focused = app.focus == Focus::Details;
     let selected_style = Style::default()
@@ -1159,6 +1238,10 @@ fn draw_results_table(f: &mut Frame, area: Rect, app: &mut App) {
                 Span::styled("Results", Style::default().fg(Color::White)),
                 Span::styled(filter, Style::default().fg(Color::Magenta)),
                 Span::styled(page, Style::default().fg(Color::DarkGray)),
+                Span::styled(
+                    " │ l: logs  m: peak mem  p: peak cpu",
+                    Style::default().fg(Color::DarkGray),
+                ),
             ]),
             Style::default().fg(Color::Green),
         )

--- a/torc-dash/static/js/app-debugging.js
+++ b/torc-dash/static/js/app-debugging.js
@@ -95,10 +95,18 @@ Object.assign(TorcDashboard.prototype, {
 
         try {
             // Get jobs and results for the workflow
-            const [jobs, results] = await Promise.all([
+            const [jobs, results, workflow] = await Promise.all([
                 api.listJobs(workflowId),
                 api.listResults(workflowId),
+                api.getWorkflow(workflowId),
             ]);
+
+            // Resolve a relative output dir against the workflow's submission
+            // directory so log paths open regardless of the dash server's CWD.
+            const logBaseDir = this.resolveLogBaseDir(
+                this.debugOutputDir,
+                workflow?.submission_directory || null
+            );
 
             const failedOnly = document.getElementById('debug-failed-only')?.checked;
 
@@ -110,7 +118,7 @@ Object.assign(TorcDashboard.prototype, {
                 // {output_dir}/job_stdio/job_wf{workflow_id}_j{job_id}_r{run_id}_a{attempt_id}.o (stdout)
                 // {output_dir}/job_stdio/job_wf{workflow_id}_j{job_id}_r{run_id}_a{attempt_id}.e (stderr)
                 const attemptId = r.attempt_id ?? 1;
-                const stdioBase = `${this.debugOutputDir}/job_stdio/job_wf${r.workflow_id}_j${r.job_id}_r${r.run_id}_a${attemptId}`;
+                const stdioBase = `${logBaseDir}/job_stdio/job_wf${r.workflow_id}_j${r.job_id}_r${r.run_id}_a${attemptId}`;
                 resultMap[r.job_id].push({
                     ...r,
                     stdoutPath: `${stdioBase}.o`,

--- a/torc-dash/static/js/app-details.js
+++ b/torc-dash/static/js/app-details.js
@@ -792,10 +792,18 @@ Object.assign(TorcDashboard.prototype, {
         const extension = this.currentSlurmLogTab === 'stdout' ? 'o' : 'e';
         const workflowId = this.selectedWorkflowId || 0;
         // Resolve a relative output dir against the workflow's submission
-        // directory so logs open regardless of the dash server's CWD.
-        const submissionDir = this.workflows?.find(
-            w => String(w.id) === String(this.selectedWorkflowId)
-        )?.submission_directory || null;
+        // directory so logs open regardless of the dash server's CWD. Fetch the
+        // workflow directly rather than reading this.workflows, whose paginated
+        // list may not contain the selected workflow after a refresh.
+        let submissionDir = null;
+        if (this.selectedWorkflowId) {
+            try {
+                const workflow = await api.getWorkflow(this.selectedWorkflowId);
+                submissionDir = workflow?.submission_directory || null;
+            } catch (e) {
+                submissionDir = null;
+            }
+        }
         const baseDir = this.resolveLogBaseDir(outputDir, submissionDir);
         const filePath = `${baseDir}/slurm_output_wf${workflowId}_sl${this.currentSlurmJobId}.${extension}`;
 

--- a/torc-dash/static/js/app-details.js
+++ b/torc-dash/static/js/app-details.js
@@ -791,7 +791,13 @@ Object.assign(TorcDashboard.prototype, {
         const outputDir = this.slurmLogsOutputDir || 'torc_output';
         const extension = this.currentSlurmLogTab === 'stdout' ? 'o' : 'e';
         const workflowId = this.selectedWorkflowId || 0;
-        const filePath = `${outputDir}/slurm_output_wf${workflowId}_sl${this.currentSlurmJobId}.${extension}`;
+        // Resolve a relative output dir against the workflow's submission
+        // directory so logs open regardless of the dash server's CWD.
+        const submissionDir = this.workflows?.find(
+            w => String(w.id) === String(this.selectedWorkflowId)
+        )?.submission_directory || null;
+        const baseDir = this.resolveLogBaseDir(outputDir, submissionDir);
+        const filePath = `${baseDir}/slurm_output_wf${workflowId}_sl${this.currentSlurmJobId}.${extension}`;
 
         logPath.textContent = filePath;
         logContent.classList.toggle('stderr', this.currentSlurmLogTab !== 'stdout');

--- a/torc-dash/static/js/app-job-details.js
+++ b/torc-dash/static/js/app-job-details.js
@@ -474,20 +474,6 @@ Object.assign(TorcDashboard.prototype, {
         });
     },
 
-    // Resolve an output directory for locating log files. Relative paths are
-    // joined to the workflow's submission directory (the directory the
-    // workflow was submitted from, where logs are written) so they resolve
-    // regardless of the dash server's working directory. Absolute paths
-    // (POSIX `/...` / `~...` or Windows `C:\...`) are returned unchanged.
-    resolveLogBaseDir(outputDir, submissionDir) {
-        const isAbsolute = /^(\/|~|[A-Za-z]:[\\/])/.test(outputDir);
-        if (isAbsolute || !submissionDir) {
-            return outputDir;
-        }
-        const trimmed = submissionDir.replace(/\/+$/, '');
-        return `${trimmed}/${outputDir}`;
-    },
-
     async loadJobLogContent() {
         const data = this.jobDetailsData;
         const logPathEl = document.getElementById('job-log-path');

--- a/torc-dash/static/js/app-job-details.js
+++ b/torc-dash/static/js/app-job-details.js
@@ -69,6 +69,7 @@ Object.assign(TorcDashboard.prototype, {
                 resourceRequirements,
                 allJobs,
                 jobDependencies,
+                workflow,
             ] = await Promise.all([
                 api.getJob(jobId),
                 api.listResults(workflowId),
@@ -79,6 +80,7 @@ Object.assign(TorcDashboard.prototype, {
                 api.listResourceRequirements(workflowId),
                 api.listJobs(workflowId),
                 api.getJobsDependencies(workflowId),
+                api.getWorkflow(workflowId),
             ]);
 
             const jobResults = results.filter(r => r.job_id === jobIdNum);
@@ -133,6 +135,7 @@ Object.assign(TorcDashboard.prototype, {
                 resourceReq: jobResourceReq,
                 blockedByJobs,
                 blocksJobs,
+                submissionDirectory: workflow?.submission_directory || null,
             };
 
             this.renderJobDetailsSummary(job);
@@ -471,6 +474,20 @@ Object.assign(TorcDashboard.prototype, {
         });
     },
 
+    // Resolve an output directory for locating log files. Relative paths are
+    // joined to the workflow's submission directory (the directory the
+    // workflow was submitted from, where logs are written) so they resolve
+    // regardless of the dash server's working directory. Absolute paths
+    // (POSIX `/...` / `~...` or Windows `C:\...`) are returned unchanged.
+    resolveLogBaseDir(outputDir, submissionDir) {
+        const isAbsolute = /^(\/|~|[A-Za-z]:[\\/])/.test(outputDir);
+        if (isAbsolute || !submissionDir) {
+            return outputDir;
+        }
+        const trimmed = submissionDir.replace(/\/+$/, '');
+        return `${trimmed}/${outputDir}`;
+    },
+
     async loadJobLogContent() {
         const data = this.jobDetailsData;
         const logPathEl = document.getElementById('job-log-path');
@@ -493,10 +510,15 @@ Object.assign(TorcDashboard.prototype, {
         const outputDir = document.getElementById('job-logs-output-dir')?.value || 'torc_output';
         const isStdout = (this._jobLogTab || 'stdout') === 'stdout';
 
+        // Resolve a relative output directory against the workflow's submission
+        // directory so logs open regardless of the dash server's current
+        // directory. Absolute output dirs are used as-is.
+        const baseDir = this.resolveLogBaseDir(outputDir, data.submissionDirectory);
+
         // Construct log file path based on naming convention
         // Include attempt_id in the path (defaults to 1 if not present)
         const attemptId = result.attempt_id ?? 1;
-        const stdioBase = `${outputDir}/job_stdio/job_wf${result.workflow_id}_j${result.job_id}_r${result.run_id}_a${attemptId}`;
+        const stdioBase = `${baseDir}/job_stdio/job_wf${result.workflow_id}_j${result.job_id}_r${result.run_id}_a${attemptId}`;
         // Try the separate file (.o/.e) first, then fall back to combined (.log)
         const primaryPath = isStdout ? `${stdioBase}.o` : `${stdioBase}.e`;
         const combinedPath = `${stdioBase}.log`;

--- a/torc-dash/static/js/app-utils.js
+++ b/torc-dash/static/js/app-utils.js
@@ -35,6 +35,28 @@ Object.assign(TorcDashboard.prototype, {
         return str.length > maxLen ? str.substring(0, maxLen) + '...' : str;
     },
 
+    // Resolve an output directory for locating log files. A relative path is
+    // joined to the workflow's submission directory (the directory the
+    // workflow was submitted from, where logs are written) so it resolves
+    // regardless of the dash server's working directory. Absolute paths --
+    // POSIX (`/...`), home (`~...`), Windows drive (`C:\...`), or UNC
+    // (`\\host\share`) -- are returned unchanged.
+    //
+    // Lives here (loaded before every consumer) rather than in a feature
+    // module so it has no implicit cross-module load-order dependency.
+    resolveLogBaseDir(outputDir, submissionDir) {
+        const isAbsolute = /^(\/|~|[A-Za-z]:[\\/]|\\\\)/.test(outputDir);
+        if (isAbsolute || !submissionDir) {
+            return outputDir;
+        }
+        // Strip trailing separators (forward or back slash) before joining so a
+        // submission directory captured on a Windows host doesn't yield a
+        // doubled/invalid separator. Forward slashes work as path separators on
+        // both POSIX and Windows, so join with `/`.
+        const trimmed = submissionDir.replace(/[\\/]+$/, '');
+        return `${trimmed}/${outputDir}`;
+    },
+
     formatDate(dateStr) {
         if (!dateStr) return '-';
         try {


### PR DESCRIPTION
Addresses the items in #358.

## Changes

- **Open logs from anywhere (TUI + Dash).** Job/Slurm log paths now resolve a relative output dir against the workflow's recorded `submission_directory`, so logs open regardless of the viewer's current directory — not just from the original submission directory. Applied in the TUI (`resolve_log_output_dir`) and all three Dash log-path sites: job details, Slurm logs, and the debugging tab (`resolveLogBaseDir`). Absolute output dirs and older workflows with no recorded submission directory fall back to the previous behavior.
- **User Data tab (TUI).** New scrollable, paginated "User Data" tab (ID / Name / Ephemeral / Data) with Name/Data filtering and help text.
- **Expanded workflow details (TUI).** New `D` key opens a scrollable Workflow Details popup showing the submission directory and other configuration fields the table omits.
- **Open logs from the Results tab (TUI).** `l` on the Results tab opens the selected result's stdout/stderr, targeting that specific run/attempt and reusing the Jobs-tab log-loading logic.
- **CLI.** `torc workflows get <id>` now prints the submission directory in its text output (JSON already included it).

## Issue items mapping
- Item 1 (TUI + Dash log resolution) ✅
- Items 2 & 5 (user-data table, duplicates) ✅
- Item 3 (expanded workflow details) ✅
- Item 4 (open logs from results tab) ✅
- Plus: show submission directory in `torc workflows get` ✅

## Testing
- `cargo fmt --check` — clean
- `cargo clippy --all --all-targets --all-features -- -D warnings` — clean
- `cargo nextest run` (TUI/user_data scope) — 30 passed
- `node --check` on the three modified Dash JS files — clean

No server SQL or migration files were changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)