### PR TITLE
watch: count jobs by status via the server status endpoint

### DIFF
--- a/src/client/commands/watch.rs
+++ b/src/client/commands/watch.rs
@@ -56,7 +56,6 @@ where
 {
     utils::send_with_retries(config, api_call, WAIT_FOR_HEALTHY_DATABASE_MINUTES)
 }
-use crate::client::commands::pagination::{JobListParams, paginate_jobs};
 use crate::client::hpc::common::HpcJobStatus;
 use crate::client::hpc::hpc_interface::HpcInterface;
 use crate::client::hpc::slurm_interface::SlurmInterface;
@@ -113,23 +112,33 @@ pub struct WatchArgs {
     pub walltime: Option<String>,
 }
 
-/// Get job counts by status for a workflow
+/// Get job counts by status for a workflow.
+///
+/// Delegates aggregation to the server's `get_workflow_status` endpoint (a
+/// single SQL `GROUP BY`) instead of downloading every job to count them
+/// client-side. This runs on every poll, so the cheap call matters. Keys
+/// match `format!("{:?}", JobStatus)` for backward compatibility with callers.
 fn get_job_counts(
     config: &Configuration,
     workflow_id: i64,
 ) -> Result<HashMap<String, i64>, String> {
-    let jobs = paginate_jobs(config, workflow_id, JobListParams::new())
-        .map_err(|e| format!("Failed to list jobs: {}", e))?;
-    let mut counts = HashMap::new();
+    let status = apis::workflows_api::get_workflow_status(config, workflow_id)
+        .map_err(|e| format!("Failed to get workflow status: {}", e))?;
+    let c = status.jobs_by_status;
 
-    for job in &jobs {
-        if let Some(status) = &job.status {
-            let status_str = format!("{:?}", status);
-            *counts.entry(status_str).or_insert(0) += 1;
-        }
-    }
-
-    Ok(counts)
+    Ok(HashMap::from([
+        ("Uninitialized".to_string(), c.uninitialized),
+        ("Blocked".to_string(), c.blocked),
+        ("Ready".to_string(), c.ready),
+        ("Pending".to_string(), c.pending),
+        ("Running".to_string(), c.running),
+        ("Completed".to_string(), c.completed),
+        ("Failed".to_string(), c.failed),
+        ("Canceled".to_string(), c.canceled),
+        ("Terminated".to_string(), c.terminated),
+        ("Disabled".to_string(), c.disabled),
+        ("PendingFailed".to_string(), c.pending_failed),
+    ]))
 }
 
 /// Count ready jobs that need an unplanned Slurm allocation.


### PR DESCRIPTION
## Summary

Follow-up to #363. `torc watch`'s `get_job_counts` ran **inside the poll loop** and downloaded every job each interval just to tally statuses client-side — the same anti-pattern #363 fixed for `torc status`.

It now calls the `get_workflow_status` endpoint (added in #363), which computes the counts in SQL via `GROUP BY`. The function still returns the same status-keyed `HashMap<String, i64>`, so both callers (`poll_until_complete`'s per-poll log and the final summary) are unchanged. The now-unused `paginate_jobs`/`JobListParams` import is removed.

## Why not the TUI Summary view too?

The TUI Summary view shares the same "count jobs by status" shape, but its all-jobs fetch doubles as the session's `jobs_all` cache — consumed by the DAG and result-detail views, some of which have no fetch of their own and rely on Summary (the default view) pre-warming it. Decoupling that is cache surgery with real regression risk, not a clean endpoint reuse, so it's intentionally left as-is.

## Testing

- `cargo clippy --features "client,tui,plot_resources" -- -D warnings` clean
- The underlying endpoint is covered by integration tests in #363; this is a pure delegation preserving the existing map keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)