### PR TITLE
Fix double run_id bump in recover/watch reset path

### DIFF
--- a/examples/scripts/cpu_intensive.py
+++ b/examples/scripts/cpu_intensive.py
@@ -120,7 +120,7 @@ if __name__ == "__main__":
     try:
         primes = main()
         print("\n✓ CPU-intensive job with multiprocessing completed successfully")
-        sys.exit(1)
+        sys.exit(0)
     except Exception as e:
         print(f"\n✗ Error: {e}", file=sys.stderr)
         import traceback

--- a/examples/scripts/cpu_intensive.py
+++ b/examples/scripts/cpu_intensive.py
@@ -120,7 +120,7 @@ if __name__ == "__main__":
     try:
         primes = main()
         print("\n✓ CPU-intensive job with multiprocessing completed successfully")
-        sys.exit(0)
+        sys.exit(1)
     except Exception as e:
         print(f"\n✗ Error: {e}", file=sys.stderr)
         import traceback

--- a/src/client/commands/recover.rs
+++ b/src/client/commands/recover.rs
@@ -827,19 +827,25 @@ pub fn reset_failed_jobs(
         return Ok(0);
     }
 
-    let job_count = job_ids.len();
-
     // NOTE: do not reset workflow status here. `reset_workflow_status` bumps
     // run_id, and every caller of this function follows it with
     // `reinitialize_workflow`, which already resets workflow status (and bumps
     // run_id) exactly once. Resetting here too bumps run_id twice per recovery,
     // leaving a gap (e.g. a recovered job jumping from run 1 to run 3). Reset
     // only the failed jobs so the run_id bump stays single.
-    apis::workflows_api::reset_job_status(config, workflow_id, Some(true))
+    //
+    // `reset_job_status` resets all retryable failed jobs workflow-wide (the
+    // `job_ids` argument here only gates the no-op early return above), so use
+    // the server-reported `updated_count` for an accurate count, not job_ids.len().
+    let response = apis::workflows_api::reset_job_status(config, workflow_id, Some(true))
         .map_err(|e| format!("Failed to reset failed job status: {}", e))?;
-    info!("  Reset failed job status for workflow {}", workflow_id);
+    let reset_count = response.updated_count.max(0) as usize;
+    info!(
+        "  Reset {} failed job(s) for workflow {}",
+        reset_count, workflow_id
+    );
 
-    Ok(job_count)
+    Ok(reset_count)
 }
 
 /// Reinitialize the workflow (set up dependencies and fire on_workflow_start actions)

--- a/src/client/commands/recover.rs
+++ b/src/client/commands/recover.rs
@@ -829,10 +829,12 @@ pub fn reset_failed_jobs(
 
     let job_count = job_ids.len();
 
-    apis::workflows_api::reset_workflow_status(config, workflow_id, None)
-        .map_err(|e| format!("Failed to reset workflow status: {}", e))?;
-    info!("  Reset workflow status for workflow {}", workflow_id);
-
+    // NOTE: do not reset workflow status here. `reset_workflow_status` bumps
+    // run_id, and every caller of this function follows it with
+    // `reinitialize_workflow`, which already resets workflow status (and bumps
+    // run_id) exactly once. Resetting here too bumps run_id twice per recovery,
+    // leaving a gap (e.g. a recovered job jumping from run 1 to run 3). Reset
+    // only the failed jobs so the run_id bump stays single.
     apis::workflows_api::reset_job_status(config, workflow_id, Some(true))
         .map_err(|e| format!("Failed to reset failed job status: {}", e))?;
     info!("  Reset failed job status for workflow {}", workflow_id);

--- a/tests/test_workflow_manager.rs
+++ b/tests/test_workflow_manager.rs
@@ -481,6 +481,50 @@ fn test_reinitialize_workflow_real(start_server: &ServerProcess) {
 }
 
 #[rstest]
+fn test_recover_reset_sequence_bumps_run_id_once(start_server: &ServerProcess) {
+    let config = start_server.config.clone();
+    let (manager, workflow) =
+        create_test_workflow_manager(config.clone(), "test_recover_run_id_once");
+    let workflow_id = workflow.id.unwrap();
+
+    // Initialize and run a job so the workflow has an established run.
+    let (job_id, _run_id) = execute_workflow_with_job(
+        &config,
+        &manager,
+        workflow_id,
+        "test_job",
+        "echo 'test'",
+        None,
+    )
+    .expect("execute workflow with job");
+
+    let before = apis::workflows_api::get_workflow(&config, workflow_id)
+        .expect("get workflow")
+        .run_id
+        .unwrap_or(0);
+
+    // The recover reset sequence: reset the failed jobs, then reinitialize.
+    // Together these must advance run_id by exactly 1 -- reset_failed_jobs no
+    // longer resets workflow status, so the single bump comes from
+    // reinitialize_workflow. Before the fix this bumped twice and skipped a
+    // run_id.
+    torc::client::commands::recover::reset_failed_jobs(&config, workflow_id, &[job_id])
+        .expect("reset_failed_jobs");
+    torc::client::commands::recover::reinitialize_workflow(&config, workflow_id)
+        .expect("reinitialize_workflow");
+
+    let after = apis::workflows_api::get_workflow(&config, workflow_id)
+        .expect("get workflow after")
+        .run_id
+        .unwrap_or(0);
+    assert_eq!(
+        after,
+        before + 1,
+        "recover reset sequence must bump run_id exactly once"
+    );
+}
+
+#[rstest]
 fn test_get_run_id(start_server: &ServerProcess) {
     let config = start_server.config.clone();
     let (manager, workflow) = create_test_workflow_manager(config.clone(), "test_get_run_id");


### PR DESCRIPTION
## Problem

After a failure, the sequence `torc recover <id>` then `torc run <id>` advanced the workflow's `run_id` by **2** instead of 1 — a recovered job's result jumped from `run_id=1` to `run_id=3`, leaving `run_id=2` with no results.

## Root cause

`run_id` is incremented in exactly one place: `reset_workflow_status` (`run_id = run_id + 1`). The recovery flow called it **twice**:

1. `reset_failed_jobs` → `reset_workflow_status` (bump)
2. `reinitialize_workflow` → `WorkflowManager::reinitialize` → `reset_workflow_status` (bump)

Every caller of `reset_failed_jobs` immediately follows it with `reinitialize_workflow`, so the reset inside `reset_failed_jobs` was always redundant. (The subsequent `torc run <id>` does *not* add a third bump — `run_jobs_cmd` only re-initializes when the workflow is fully uninitialized, which it isn't after recover.)

## Fix

Drop the redundant `reset_workflow_status` from `reset_failed_jobs`; it now only resets the failed jobs, and the single `run_id` bump comes from the `reinitialize_workflow` step every caller already performs.

This corrects `torc recover` (normal + interactive paths) and the identical pattern in `torc watch`'s auto-recovery (`watch.rs:1009`). Nothing relied on `reset_failed_jobs` bumping `run_id`.

## Testing

- New test `test_recover_reset_sequence_bumps_run_id_once` runs the actual recover reset pair (`reset_failed_jobs` + `reinitialize_workflow`) and asserts `run_id` advances by exactly 1 (fails with `+2` on the old code).
- `cargo fmt --check`, `cargo clippy --all --all-targets --all-features -D warnings`, `dprint check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)