### PR TITLE
TUI: use get_workflow_status for Summary, show tripwire, fix startup load

### DIFF
--- a/src/tui/api.rs
+++ b/src/tui/api.rs
@@ -3,9 +3,9 @@ use crate::client::apis::configuration::{BasicAuth, Configuration, TlsConfig};
 use crate::client::config::TorcConfig;
 use crate::client::workflow_spec::WorkflowSpec;
 use crate::models::{
-    ComputeNodeModel, FileModel, IsCompleteResponse, JobDependencyModel, JobModel, JobStatus,
-    ResultModel, RunningJobModel, ScheduledComputeNodesModel, SlurmStatsModel, UserDataModel,
-    WorkflowActionModel, WorkflowModel,
+    ComputeNodeModel, FileModel, JobDependencyModel, JobModel, JobStatus, ResultModel,
+    RunningJobModel, ScheduledComputeNodesModel, SlurmStatsModel, UserDataModel,
+    WorkflowActionModel, WorkflowModel, WorkflowStatusResponse,
 };
 use anyhow::{Context, Result};
 
@@ -108,9 +108,11 @@ impl TorcClient {
             .context("Failed to get workflow")
     }
 
-    pub fn is_workflow_complete(&self, workflow_id: i64) -> Result<IsCompleteResponse> {
-        apis::workflows_api::is_workflow_complete(&self.config, workflow_id)
-            .context("Failed to check workflow completion")
+    /// Server-side aggregated workflow status (job counts, completion flags, and
+    /// the runtime-blocked packing signal) in a single O(1) call.
+    pub fn get_workflow_status(&self, workflow_id: i64) -> Result<WorkflowStatusResponse> {
+        apis::workflows_api::get_workflow_status(&self.config, workflow_id)
+            .context("Failed to get workflow status")
     }
 
     pub fn list_jobs(

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -634,9 +634,10 @@ impl ComputeNodesSort {
     }
 }
 
-/// Aggregated high-level information about a single workflow, computed from
-/// list_jobs + get_workflow + is_workflow_complete and rendered by the
-/// Summary detail view.
+/// Aggregated high-level information about a single workflow, sourced from the
+/// server-side `get_workflow_status` (job counts, completion flags, and the
+/// runtime-blocked packing signal) plus `get_workflow` for the description, and
+/// rendered by the Summary detail view.
 #[derive(Debug, Clone)]
 pub struct WorkflowSummary {
     pub workflow_id: i64,
@@ -648,6 +649,13 @@ pub struct WorkflowSummary {
     pub total_jobs: usize,
     /// Counts indexed by `JobStatus as usize` (0 = Uninitialized .. 10 = PendingFailed).
     pub counts: [usize; 11],
+    /// Ready jobs whose required runtime exceeds the remaining walltime of every
+    /// active allocation (the runtime-blocked packing tripwire). 0 when none.
+    pub runtime_blocked_ready_jobs: i64,
+    /// Longest required runtime (seconds) among ready jobs, when any are blocked.
+    pub longest_ready_runtime_seconds: Option<i64>,
+    /// Greatest remaining walltime (seconds) across active bounded allocations.
+    pub max_allocation_remaining_seconds: Option<i64>,
 }
 
 pub struct App {
@@ -905,6 +913,11 @@ impl App {
 
         // Try to load workflows, but don't fail if server is not available
         let _ = app.refresh_workflows();
+        // Populate the detail view for the initially-selected workflow so the
+        // Summary pane renders on startup instead of showing "Loading summary…"
+        // until the user presses Enter. Best-effort: a missing server or empty
+        // workflow list just leaves the placeholder in place.
+        let _ = app.load_detail_data();
 
         Ok(app)
     }
@@ -1295,31 +1308,41 @@ impl App {
             if let Some(workflow_id) = workflow_id_opt {
                 match self.detail_view {
                     DetailViewType::Summary => {
-                        if self.jobs_workflow_id != Some(workflow_id) {
-                            self.jobs_all = self.client.list_jobs(workflow_id, None, None)?;
-                            self.jobs_workflow_id = Some(workflow_id);
-                            self.jobs_fetched_at = Some(chrono::Utc::now());
-                        }
-                        self.jobs = self.jobs_all.clone();
-                        self.apply_jobs_sort();
+                        // Use the server-side aggregated status instead of pulling
+                        // every job to count client-side. This is one O(1) call and
+                        // also carries the runtime-blocked packing signal. The
+                        // description is not part of the status response, so fetch
+                        // the (cheap) workflow record for it.
+                        let status = self.client.get_workflow_status(workflow_id)?;
                         let workflow = self.client.get_workflow(workflow_id)?;
-                        let completion = self.client.is_workflow_complete(workflow_id)?;
 
-                        let mut counts = [0usize; 11];
-                        for job in &self.jobs_all {
-                            if let Some(s) = &job.status {
-                                counts[*s as usize] += 1;
-                            }
-                        }
+                        let c = &status.jobs_by_status;
+                        let counts: [usize; 11] = [
+                            c.uninitialized.max(0) as usize,
+                            c.blocked.max(0) as usize,
+                            c.ready.max(0) as usize,
+                            c.pending.max(0) as usize,
+                            c.running.max(0) as usize,
+                            c.completed.max(0) as usize,
+                            c.failed.max(0) as usize,
+                            c.canceled.max(0) as usize,
+                            c.terminated.max(0) as usize,
+                            c.disabled.max(0) as usize,
+                            c.pending_failed.max(0) as usize,
+                        ];
                         self.summary = Some(WorkflowSummary {
                             workflow_id,
-                            workflow_name: workflow.name,
-                            workflow_user: workflow.user,
+                            workflow_name: status.workflow_name,
+                            workflow_user: status.workflow_user,
                             description: workflow.description,
-                            is_complete: completion.is_complete,
-                            is_canceled: completion.is_canceled,
-                            total_jobs: self.jobs_all.len(),
+                            is_complete: status.is_complete,
+                            is_canceled: status.is_canceled,
+                            total_jobs: status.total_jobs.max(0) as usize,
                             counts,
+                            runtime_blocked_ready_jobs: status.runtime_blocked_ready_jobs,
+                            longest_ready_runtime_seconds: status.longest_ready_runtime_seconds,
+                            max_allocation_remaining_seconds: status
+                                .max_allocation_remaining_seconds,
                         });
                     }
                     DetailViewType::Jobs => {
@@ -4170,11 +4193,12 @@ impl App {
             return;
         };
 
-        let job_name = self
-            .jobs_all
-            .iter()
-            .find(|j| j.id == Some(result.job_id))
-            .map(|j| j.name.clone())
+        // The server denormalizes the job name onto every result (LEFT JOIN to
+        // job), so use it directly. It is only NULL when the job row was deleted,
+        // in which case there is nothing better to show than the id.
+        let job_name = result
+            .job_name
+            .clone()
             .unwrap_or_else(|| format!("Job {}", result.job_id));
 
         let mut viewer = LogViewer::new(result.job_id, job_name);

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -664,13 +664,21 @@ fn draw_summary(f: &mut Frame, area: Rect, app: &mut App) {
         return;
     };
 
-    // Vertical layout: header (3) | progress line (1) | status table (flex) | description (3)
+    // Vertical layout: header (3) | progress (1) | tripwire (0 or 2) | status
+    // table (flex) | description (3). The runtime-blocked tripwire only takes
+    // space when the condition exists.
+    let tripwire_height: u16 = if summary.runtime_blocked_ready_jobs > 0 {
+        2
+    } else {
+        0
+    };
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .margin(1)
         .constraints([
             Constraint::Length(3),
             Constraint::Length(1),
+            Constraint::Length(tripwire_height),
             Constraint::Min(3),
             Constraint::Length(3),
         ])
@@ -731,6 +739,38 @@ fn draw_summary(f: &mut Frame, area: Rect, app: &mut App) {
     ]);
     f.render_widget(Paragraph::new(progress_line), chunks[1]);
 
+    // --- Runtime-blocked packing tripwire (only when present) ---
+    if summary.runtime_blocked_ready_jobs > 0 {
+        let mut spans = vec![Span::styled(
+            format!(
+                "⚠ {} ready job(s) runtime-blocked",
+                summary.runtime_blocked_ready_jobs
+            ),
+            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+        )];
+        if let (Some(longest), Some(remaining)) = (
+            summary.longest_ready_runtime_seconds,
+            summary.max_allocation_remaining_seconds,
+        ) {
+            spans.push(Span::styled(
+                format!(
+                    " (longest {} vs {} remaining)",
+                    format_secs_short(longest),
+                    format_secs_short(remaining)
+                ),
+                Style::default().fg(Color::Red),
+            ));
+        }
+        let tripwire = Paragraph::new(vec![
+            Line::from(spans),
+            Line::from(Span::styled(
+                "  run 'torc workflows diagnose' for details",
+                Style::default().fg(Color::DarkGray),
+            )),
+        ]);
+        f.render_widget(tripwire, chunks[2]);
+    }
+
     // --- Per-status counts table (skip rows with count 0) ---
     let header_style = Style::default()
         .fg(Color::Yellow)
@@ -775,7 +815,7 @@ fn draw_summary(f: &mut Frame, area: Rect, app: &mut App) {
         ],
     )
     .header(header);
-    f.render_widget(counts_table, chunks[2]);
+    f.render_widget(counts_table, chunks[3]);
 
     // --- Description (optional) ---
     let desc_text = summary.description.as_deref().unwrap_or("—");
@@ -787,7 +827,32 @@ fn draw_summary(f: &mut Frame, area: Rect, app: &mut App) {
         Line::from(Span::styled(desc_text, Style::default().fg(Color::White))),
     ])
     .wrap(Wrap { trim: true });
-    f.render_widget(desc, chunks[3]);
+    f.render_widget(desc, chunks[4]);
+}
+
+/// Format a duration in seconds as a compact "3d 1h" / "45m" string for the
+/// Summary tripwire.
+fn format_secs_short(secs: i64) -> String {
+    if secs <= 0 {
+        return "0m".to_string();
+    }
+    let days = secs / 86_400;
+    let hours = (secs % 86_400) / 3_600;
+    let minutes = (secs % 3_600) / 60;
+    let mut parts: Vec<String> = Vec::new();
+    if days > 0 {
+        parts.push(format!("{}d", days));
+    }
+    if hours > 0 {
+        parts.push(format!("{}h", hours));
+    }
+    if minutes > 0 && days == 0 {
+        parts.push(format!("{}m", minutes));
+    }
+    if parts.is_empty() {
+        return "<1m".to_string();
+    }
+    parts.join(" ")
 }
 
 fn draw_jobs_table(f: &mut Frame, area: Rect, app: &mut App) {


### PR DESCRIPTION
## Summary

Follow-up to #374. Makes the TUI Summary pane efficient, surfaces the runtime-blocked packing tripwire there, and fixes a startup glitch.

## Changes

**Summary pane now uses `get_workflow_status`**
- Previously it pulled **every job** (unpaginated `list_jobs`) to count statuses client-side, plus `get_workflow` + `is_workflow_complete` — three calls including a potentially large transfer. Now it's a single O(1) `get_workflow_status` (counts, completion flags, and the runtime-blocked signal) plus `get_workflow` for the description. Big win for large workflows.
- Added `get_workflow_status` to the TUI client wrapper; removed the now-unused `is_workflow_complete` wrapper + import.

**Tripwire in the Summary pane**
- Renders a red warning ("⚠ N ready job(s) runtime-blocked …, run 'torc workflows diagnose'") **only when the condition exists**, via a conditionally-sized layout chunk that takes zero height otherwise.

**Startup fix**
- `App::new` selected the most-recent workflow but never loaded its detail, so the Summary showed "Loading summary…" until the user pressed Enter. Now it loads the initial selection's detail on startup (best-effort; a down server / empty list just leaves the placeholder).

**Results pane decoupled from `jobs_all`**
- The log viewer looked up the job *name* in `jobs_all` (which the Summary pane used to populate). Switched it to the server-denormalized `result.job_name` (LEFT JOIN to `job`), with the id as the only fallback. The Results pane no longer depends on the Summary having loaded the full job list.

## Notes
- `jobs_all` is retained — it still backs the Jobs pane (table source + reversible client-side column filtering) and the Dag pane (graph building).
- Workflow-list `Up`/`Down` still loads detail on `Enter` (unchanged) to avoid network thrash while scrolling the heavier detail views; only startup was broken.
- No schema/server changes — TUI-only, building on the fields added in #374.

## Verification
- `cargo clippy --all --all-targets --all-features -D warnings`, `cargo fmt --check`, `dprint check` — clean
- `cargo nextest` — lib + workflow-status integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)