### PR TITLE
feat(cli): add self update command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,6 +242,89 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "axoasset"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1be1b9c2739b635e04c7bbcde9e89dd5e874b9e86e28f1b41c44eb830635d83e"
+dependencies = [
+ "camino",
+ "image",
+ "lazy_static",
+ "miette",
+ "mime",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "url",
+ "walkdir",
+]
+
+[[package]]
+name = "axoprocess"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a4b4798a6c02e91378537c63cd6e91726900b595450daa5d487bc3c11e95e1b"
+dependencies = [
+ "miette",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "axotag"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc923121fbc4cc72e9008436b5650b98e56f94b5799df59a1b4f572b5c6a7e6b"
+dependencies = [
+ "miette",
+ "semver",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "axoupdater"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab66f118bab79524a27139b7341cdf1c4f839c6274ef89a6d8fb4365cb218cf"
+dependencies = [
+ "axoasset",
+ "axoprocess",
+ "axotag",
+ "camino",
+ "homedir",
+ "miette",
+ "self-replace",
+ "serde",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,6 +529,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,6 +547,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
 dependencies = [
  "libbz2-rs-sys",
+]
+
+[[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -510,7 +608,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -593,6 +691,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "codepage"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,6 +713,16 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "compact_str"
@@ -1562,6 +1679,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1692,8 +1815,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1877,6 +2002,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "homedir"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68df315d2857b2d8d2898be54a85e1d001bbbe0dbb5f8ef847b48dd3a23c4527"
+dependencies = [
+ "cfg-if",
+ "nix 0.30.1",
+ "widestring",
+ "windows 0.61.3",
+]
+
+[[package]]
 name = "hostname"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1884,7 +2021,7 @@ checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1981,6 +2118,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2031,7 +2183,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -2156,6 +2308,18 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
 ]
 
 [[package]]
@@ -2291,6 +2455,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2413,7 +2626,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2503,6 +2716,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "lzma-rust2"
 version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2574,7 +2793,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
 dependencies = [
  "cfg-if",
+ "miette-derive",
  "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2622,6 +2853,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2649,6 +2890,18 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -3013,7 +3266,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.18",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3377,8 +3630,14 @@ dependencies = [
  "nix 0.31.3",
  "tokio",
  "tracing",
- "windows",
+ "windows 0.62.2",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "quanta"
@@ -3402,6 +3661,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3432,8 +3747,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3456,12 +3781,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3699,6 +4043,7 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "js-sys",
@@ -3707,13 +4052,17 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3723,6 +4072,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3946,12 +4309,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -4049,6 +4478,17 @@ checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "self-replace"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7"
+dependencies = [
+ "fastrand",
+ "tempfile",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4390,6 +4830,22 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple_asn1"
@@ -4757,7 +5213,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-io-kit",
  "objc2-open-directory",
- "windows",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -5016,6 +5472,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -5052,6 +5509,16 @@ checksum = "59df6849caa43bb7567f9a36f863c447d95a11d5903c9cc334ba32576a27eadd"
 dependencies = [
  "openssl",
  "openssl-sys",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
  "tokio",
 ]
 
@@ -5137,6 +5604,7 @@ dependencies = [
  "anyhow",
  "async-stream",
  "async-trait",
+ "axoupdater",
  "axum",
  "base64 0.22.1",
  "bcrypt",
@@ -5500,6 +5968,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39abd59bf32521c7f2301b52d05a6a2c975b6003521cbd0c6dc1582f0a22104"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5779,6 +6253,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "wezterm-bidi"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5873,6 +6366,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5905,14 +6404,36 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections 0.2.0",
+ "windows-core 0.61.2",
+ "windows-future 0.2.1",
+ "windows-link 0.1.3",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
- "windows-numerics",
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5921,7 +6442,20 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -5932,9 +6466,20 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading 0.1.0",
 ]
 
 [[package]]
@@ -5943,9 +6488,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core",
- "windows-link",
- "windows-threading",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -5972,9 +6517,25 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-numerics"
@@ -5982,8 +6543,17 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core",
- "windows-link",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -5992,7 +6562,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -6001,7 +6580,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -6037,7 +6616,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -6073,11 +6652,20 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ libc = "0.2"
 file-rotate = "0.8"
 clap = { version = "4.6", features = ["derive", "env", "color", "wrap_help"] }
 clap_complete = "4.6"
+axoupdater = { version = "0.10.0", default-features = false, features = ["blocking", "github_releases"] }
 tokio = { version = "1.52", features = ["rt-multi-thread", "macros", "net", "signal", "process", "io-util"] }
 url = "2.5"
 validator = { version = "0.20", features = ["derive"] }
@@ -216,6 +217,7 @@ client = [
     "dep:kdl",
     "dep:clap",
     "dep:clap_complete",
+    "dep:axoupdater",
     "dep:env_logger",
     "dep:serde_with",
     "dep:serde_repr",
@@ -364,6 +366,7 @@ serde_repr = { workspace = true, optional = true }
 url = { workspace = true }
 clap = { workspace = true, optional = true }
 clap_complete = { workspace = true, optional = true }
+axoupdater = { workspace = true, optional = true }
 env_logger = { workspace = true, optional = true }
 tabled = { workspace = true, optional = true }
 rusqlite = { workspace = true, optional = true }

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -42,6 +42,20 @@ xattr -cr /path/to/torc*
 
 Alternatively, you can right-click each binary and select "Open" to add a security exception.
 
+### Updating Standalone Installer Installations
+
+If Torc was installed with the standalone installer, update it to the latest release with:
+
+```bash
+torc self update
+```
+
+To update to a specific release, pass its tag (for example, `torc self update v0.36.0`).
+Installations from a release archive must be updated by downloading and replacing the archive.
+Update crates.io installations with `cargo install torc --force`, Docker installations with
+`docker pull ghcr.io/natlabrockies/torc:latest`, and site-managed installations through the site
+administrator.
+
 ## Site-Specific Installations
 
 Some HPC facilities maintain pre-installed Torc binaries and shared servers. Check if your site is

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,6 +22,7 @@ use crate::client::commands::resource_requirements::ResourceRequirementsCommands
 use crate::client::commands::results::ResultCommands;
 use crate::client::commands::ro_crate::RoCrateCommands;
 use crate::client::commands::scheduled_compute_nodes::ScheduledComputeNodeCommands;
+use crate::client::commands::self_update::SelfCommands;
 use crate::client::commands::slurm::SlurmCommands;
 use crate::client::commands::tasks::TasksCommands;
 use crate::client::commands::user_data::UserDataCommands;
@@ -84,6 +85,7 @@ const HELP_TEMPLATE: &str = "\
   \x1b[1;36mconfig\x1b[0m                   Manage configuration settings
   \x1b[1;36mtasks\x1b[0m                    Wait for async tasks
   \x1b[1;36mplot-resources\x1b[0m           Generate HTML resource plots
+  \x1b[1;36mself\x1b[0m                     Manage the local torc executable
   \x1b[1;36mcompletions\x1b[0m              Generate shell completions
   \x1b[1;36mhelp\x1b[0m                     Print help for a subcommand
 {after-help}";
@@ -1041,6 +1043,12 @@ EXAMPLES:
 "
     )]
     PlotResources(plot_resources_cmd::Args),
+    /// Manage the local torc executable
+    #[command(name = "self")]
+    SelfCommand {
+        #[command(subcommand)]
+        command: SelfCommands,
+    },
     /// Check if the server is running and accessible
     #[command(hide = true)]
     Ping,
@@ -1064,4 +1072,25 @@ EXAMPLES:
         #[arg(value_enum)]
         shell: clap_complete::Shell,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::{CommandFactory, error::ErrorKind};
+
+    use crate::cli::Cli;
+
+    #[test]
+    fn self_update_help_is_available() {
+        let error = Cli::command()
+            .try_get_matches_from_mut(["torc", "self", "update", "--help"])
+            .expect_err("help should return a clap display error");
+
+        assert_eq!(error.kind(), ErrorKind::DisplayHelp);
+        let help = error.to_string();
+        assert!(help.contains("torc self update"));
+        assert!(help.contains("TARGET_VERSION"));
+        assert!(help.contains("--token"));
+        assert!(help.contains("GITHUB_TOKEN"));
+    }
 }

--- a/src/client/commands.rs
+++ b/src/client/commands.rs
@@ -21,6 +21,7 @@ pub mod resource_requirements;
 pub mod results;
 pub mod ro_crate;
 pub mod scheduled_compute_nodes;
+pub mod self_update;
 pub mod slurm;
 pub mod table_format;
 pub mod tasks;

--- a/src/client/commands/self_update.rs
+++ b/src/client/commands/self_update.rs
@@ -1,0 +1,220 @@
+use std::error::Error;
+use std::fmt;
+
+use axoupdater::{AxoUpdater, AxoupdateError, UpdateRequest, Version};
+use clap::{Args, Subcommand};
+
+const APP_NAME: &str = "torc";
+const RELEASE_URL_PREFIX: &str = "https://github.com/NatLabRockies/torc/releases/tag/";
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum SelfCommands {
+    /// Update torc when installed by the standalone installer
+    #[command(after_long_help = "\
+EXAMPLES:
+    # Update to the latest available release
+    torc self update
+
+    # Update to a specific release tag
+    torc self update v0.36.0
+
+    # Use a GitHub token if unauthenticated API requests are rate-limited
+    torc self update --token <TOKEN>
+")]
+    Update(SelfUpdateArgs),
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct SelfUpdateArgs {
+    /// Release tag or version to install (defaults to the latest stable release)
+    #[arg(value_name = "TARGET_VERSION")]
+    pub target_version: Option<String>,
+
+    /// GitHub token for release API requests; also read from GITHUB_TOKEN
+    #[arg(long, env = "GITHUB_TOKEN", hide_env_values = true)]
+    pub token: Option<String>,
+}
+
+#[derive(Debug)]
+pub enum SelfUpdateError {
+    StandaloneInstallerRequired { detail: String },
+    GitHubRateLimited,
+    Updater(Box<AxoupdateError>),
+}
+
+impl fmt::Display for SelfUpdateError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SelfUpdateError::StandaloneInstallerRequired { detail } => {
+                write!(
+                    formatter,
+                    "Self-update is only available for torc binaries installed by the standalone installer.\n\n{detail}\n\n{}",
+                    unsupported_install_guidance()
+                )
+            }
+            SelfUpdateError::GitHubRateLimited => write!(
+                formatter,
+                "GitHub API rate limit exceeded while checking torc releases. Provide a token with `--token` or GITHUB_TOKEN and try again."
+            ),
+            SelfUpdateError::Updater(error) => {
+                write!(formatter, "torc self-update failed: {error}")
+            }
+        }
+    }
+}
+
+impl Error for SelfUpdateError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            SelfUpdateError::Updater(error) => Some(error.as_ref()),
+            SelfUpdateError::StandaloneInstallerRequired { .. }
+            | SelfUpdateError::GitHubRateLimited => None,
+        }
+    }
+}
+
+impl From<AxoupdateError> for SelfUpdateError {
+    fn from(error: AxoupdateError) -> Self {
+        SelfUpdateError::Updater(Box::new(error))
+    }
+}
+
+pub fn handle_self_commands(command: &SelfCommands) -> Result<(), SelfUpdateError> {
+    match command {
+        SelfCommands::Update(args) => update(args),
+    }
+}
+
+fn update(args: &SelfUpdateArgs) -> Result<(), SelfUpdateError> {
+    let mut updater = AxoUpdater::new_for(APP_NAME);
+    updater.disable_installer_output();
+
+    if let Some(token) = args.token.as_deref() {
+        updater.set_github_token(token);
+    }
+
+    if let Err(error) = updater.load_receipt() {
+        return Err(SelfUpdateError::StandaloneInstallerRequired {
+            detail: format!("No matching standalone installer receipt was found: {error}"),
+        });
+    }
+
+    if !updater.check_receipt_is_for_this_executable()? {
+        return Err(SelfUpdateError::StandaloneInstallerRequired {
+            detail: "A standalone installer receipt exists, but it does not belong to the current torc executable."
+                .to_string(),
+        });
+    }
+
+    eprintln!("Checking for torc updates...");
+    updater.configure_version_specifier(update_request(args.target_version.as_deref()));
+
+    match updater.run_sync() {
+        Ok(Some(result)) => {
+            if let Some(old_version) = result.old_version {
+                eprintln!(
+                    "Updated torc from v{old_version} to v{}.",
+                    result.new_version
+                );
+            } else {
+                eprintln!("Updated torc to v{}.", result.new_version);
+            }
+            eprintln!("{}{}", RELEASE_URL_PREFIX, result.new_version_tag);
+            Ok(())
+        }
+        Ok(None) => {
+            eprintln!(
+                "torc is already up to date (v{}).",
+                env!("CARGO_PKG_VERSION")
+            );
+            Ok(())
+        }
+        Err(error) if args.token.is_none() && is_github_rate_limit(&error) => {
+            Err(SelfUpdateError::GitHubRateLimited)
+        }
+        Err(error) => Err(SelfUpdateError::Updater(Box::new(error))),
+    }
+}
+
+fn update_request(target_version: Option<&str>) -> UpdateRequest {
+    match target_version {
+        Some(target) if Version::parse(target).is_ok() => {
+            UpdateRequest::SpecificVersion(target.to_string())
+        }
+        Some(target) => UpdateRequest::SpecificTag(target.to_string()),
+        None => UpdateRequest::Latest,
+    }
+}
+
+fn is_github_rate_limit(error: &AxoupdateError) -> bool {
+    match error {
+        AxoupdateError::Reqwest(error) => error
+            .status()
+            .is_some_and(|status| matches!(status.as_u16(), 403 | 429)),
+        _ => false,
+    }
+}
+
+fn unsupported_install_guidance() -> &'static str {
+    concat!(
+        "Update this torc installation with the tool that installed it:\n",
+        "  - cargo/crates.io: run `cargo install torc --force`\n",
+        "  - package manager: use that package manager's upgrade command\n",
+        "  - Docker: run `docker pull ghcr.io/natlabrockies/torc:<tag>` and recreate containers\n",
+        "  - site-managed shared install: ask your site administrator to update torc\n",
+        "  - manual release archive: download a new archive from GitHub Releases and replace the binaries",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    #[test]
+    fn self_update_plain_semver_uses_specific_version() {
+        assert!(matches!(
+            update_request(Some("0.36.0")),
+            UpdateRequest::SpecificVersion(version) if version == "0.36.0"
+        ));
+    }
+
+    #[test]
+    fn self_update_tag_uses_specific_tag() {
+        assert!(matches!(
+            update_request(Some("v0.36.0")),
+            UpdateRequest::SpecificTag(tag) if tag == "v0.36.0"
+        ));
+    }
+
+    #[test]
+    fn self_update_without_target_uses_latest() {
+        assert!(matches!(update_request(None), UpdateRequest::Latest));
+    }
+
+    #[test]
+    #[serial]
+    fn self_update_missing_receipt_reports_standalone_installer_requirement() {
+        let tempdir = tempfile::tempdir().expect("create tempdir");
+        let previous_config_path = std::env::var_os("AXOUPDATER_CONFIG_PATH");
+        unsafe { std::env::set_var("AXOUPDATER_CONFIG_PATH", tempdir.path()) };
+
+        let error = update(&SelfUpdateArgs {
+            target_version: None,
+            token: None,
+        })
+        .expect_err("missing receipt should fail before network access");
+
+        match previous_config_path {
+            Some(value) => unsafe { std::env::set_var("AXOUPDATER_CONFIG_PATH", value) },
+            None => unsafe { std::env::remove_var("AXOUPDATER_CONFIG_PATH") },
+        }
+
+        let message = error.to_string();
+        assert!(message.contains("standalone installer"));
+        assert!(message.contains("cargo install torc --force"));
+        assert!(message.contains("docker pull ghcr.io/natlabrockies/torc:<tag>"));
+        assert!(message.contains("site administrator"));
+        assert!(message.contains("manual release archive"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ use torc::client::commands::resource_requirements::handle_resource_requirements_
 use torc::client::commands::results::handle_result_commands;
 use torc::client::commands::ro_crate::handle_ro_crate_commands;
 use torc::client::commands::scheduled_compute_nodes::handle_scheduled_compute_node_commands;
+use torc::client::commands::self_update::handle_self_commands;
 use torc::client::commands::slurm::handle_slurm_commands;
 use torc::client::commands::tasks::handle_tasks_commands;
 use torc::client::commands::user_data::handle_user_data_commands;
@@ -478,6 +479,7 @@ fn main() {
             | Commands::Exec { .. }
             | Commands::Watch { .. }
             | Commands::Tui(..)
+            | Commands::SelfCommand { .. }
             | Commands::Completions { .. }
     );
 
@@ -563,6 +565,7 @@ fn main() {
             | Commands::Tui(..)
             | Commands::Config { .. }
             | Commands::Hpc { .. }
+            | Commands::SelfCommand { .. }
             | Commands::Exec { dry_run: true, .. }
     );
 
@@ -1197,6 +1200,12 @@ fn main() {
         }
         Commands::Config { command } => {
             handle_config_commands(command);
+        }
+        Commands::SelfCommand { command } => {
+            if let Err(error) = handle_self_commands(command) {
+                eprintln!("Error: {error}");
+                std::process::exit(1);
+            }
         }
         Commands::Tui(args) => {
             let basic_auth = config.basic_auth.clone();


### PR DESCRIPTION
Closes #379

## Summary

Adds a draft implementation of `torc self update [TARGET_VERSION]` under the new `self`
namespace. The command is local-only, uses `axoupdater` receipts to guard eligible standalone
installer updates, supports `--token`/`GITHUB_TOKEN`, and gives install-source guidance when the
current executable cannot be self-updated.

Draft PR: not ready to merge until maintainer review and forge CI are complete.

## Acceptance criteria

- [x] Addressed — Adds `torc self update [TARGET_VERSION]` under a new `self` namespace.
  Evidence: `src/cli.rs` wires `SelfCommand` as `name = "self"`; `cargo +1.95.0 run --quiet --bin torc -- self update --help` prints `Usage: torc self update [OPTIONS] [TARGET_VERSION]`.
- [x] Addressed — Command is local-only: it does not require a Torc server, does not run server
  version checks, and ignores `--standalone` startup. Evidence: `src/main.rs` excludes
  `Commands::SelfCommand { .. }` from `requires_server`; no server config is passed to the command
  handler.
- [x] Addressed — Uses `AxoUpdater::new_for("torc")`, loads the standalone installer receipt, and
  checks that the receipt belongs to `std::env::current_exe()` before updating. Evidence:
  `src/client/commands/self_update.rs` calls `AxoUpdater::new_for(APP_NAME)`, `load_receipt()`, and
  `check_receipt_is_for_this_executable()` before `run_sync()`.
- [x] Addressed — Supports an optional target release tag/version and a GitHub token via `--token`
  and `GITHUB_TOKEN`. Evidence: `SelfUpdateArgs` has optional `TARGET_VERSION` and
  `#[arg(long, env = "GITHUB_TOKEN")]`; tests cover tag vs plain semver target routing.
- [x] Addressed — Missing or mismatched receipt exits non-zero and explains that self-update is only
  available for standalone installer installs. Evidence: missing-receipt unit test and manual CLI
  command return exit 1 with the standalone installer requirement.
- [x] Addressed — Unsupported installs get useful guidance for cargo/crates.io, package-manager,
  Docker, site-managed, and manual archive installs. Evidence: `unsupported_install_guidance()` and
  missing-receipt test assert the guidance categories.
- [x] Addressed — GitHub API rate-limit failures recommend using a token instead of surfacing an
  opaque error. Evidence: `is_github_rate_limit()` maps unauthenticated 403/429 reqwest errors to a
  token-focused message.
- [x] Addressed — Tests cover at least missing-receipt behavior and CLI help output. Evidence:
  `cargo +1.95.0 test self_update` runs 5 passing tests including missing receipt and help output.

## Deviations from the original plan

- No release workflow or installer publishing changes are included. Current repository releases ship
  archives, not cargo-dist installer assets/receipts, so actual successful self-update requires a
  standalone installer distribution path to exist. This should stay as a follow-up if desired.
- Used `cargo +1.95.0` locally because the active default toolchain was Rust 1.92 while the crate now
  requires Rust 1.95.

## Testing Strategy

```bash
cargo +1.95.0 test self_update
cargo +1.95.0 run --quiet --bin torc -- self update --help
tmpdir=$(mktemp -d); AXOUPDATER_CONFIG_PATH="$tmpdir" cargo +1.95.0 run --quiet --bin torc -- self update; status=$?; rm -rf "$tmpdir"; test "$status" -ne 0
cargo +1.95.0 fmt --all -- --check
DATABASE_URL=sqlite:db/sqlite/dev.db sqlx database setup --source torc-server/migrations
cargo +1.95.0 clippy --all --all-targets --all-features -- -D warnings
PATH="$HOME/.dprint/bin:$PATH" dprint check
```

## References

- #379
- https://github.com/NatLabRockies/torc/issues/379
