### PR TITLE
Fix recover wizard ignoring user's Slurm allocation count

### DIFF
--- a/src/client/commands/recover.rs
+++ b/src/client/commands/recover.rs
@@ -24,6 +24,9 @@ use crate::client::workflow_manager::WorkflowManager;
 use crate::config::TorcConfig;
 use crate::models::JobStatus;
 
+/// Maximum time to wait for the server's database to become healthy when claiming actions.
+const WAIT_FOR_HEALTHY_DATABASE_MINUTES: u64 = 20;
+
 fn torc_command() -> Result<Command, String> {
     if let Ok(path) = std::env::var("TORC_BIN")
         && !path.trim().is_empty()
@@ -1776,27 +1779,32 @@ pub fn mark_on_workflow_start_schedule_actions_executed(
             && !action.executed
             && let Some(action_id) = action.id
         {
-            match apis::workflow_actions_api::claim_action(
+            // Delegate to the shared helper, which treats a 409 Conflict (already claimed by
+            // another process) as `Ok(false)` and surfaces any other failure as an error. We
+            // propagate that error rather than logging and continuing: if the claim genuinely
+            // fails, the action stays armed and would re-fire on a compute node, reintroducing
+            // the duplicate-allocation bug — better to stop and report it.
+            match crate::client::utils::claim_action(
                 config,
                 workflow_id,
                 action_id,
-                crate::models::ClaimActionRequest {
-                    compute_node_id: None,
-                },
+                None, // login-node submission, no compute node
+                WAIT_FOR_HEALTHY_DATABASE_MINUTES,
             ) {
-                Ok(_) => {
+                Ok(true) => {
                     info!(
                         "Marked on_workflow_start schedule_nodes action {} as executed to avoid duplicate allocations",
                         action_id
                     );
                 }
+                Ok(false) => {
+                    debug!("Action {} already claimed", action_id);
+                }
                 Err(e) => {
-                    // 409 Conflict means another process already claimed it, which is fine.
-                    if format!("{:?}", e).contains("409") {
-                        debug!("Action {} already claimed", action_id);
-                    } else {
-                        warn!("Failed to mark action {} as executed: {:?}", action_id, e);
-                    }
+                    return Err(format!(
+                        "Failed to mark on_workflow_start schedule_nodes action {} as executed: {}",
+                        action_id, e
+                    ));
                 }
             }
         }

--- a/src/client/commands/recover.rs
+++ b/src/client/commands/recover.rs
@@ -1536,6 +1536,11 @@ fn recover_workflow_interactive(
             start_one_worker_per_node,
             ..
         } => {
+            // Reinitialization above re-armed the workflow's on_workflow_start schedule_nodes
+            // action. Mark it executed before submitting so it doesn't re-fire on the first
+            // compute node and submit the action's original allocation count instead of the
+            // user's choice. (The Regenerate path does the equivalent inside handle_regenerate.)
+            mark_on_workflow_start_schedule_actions_executed(config, args.workflow_id)?;
             info!(
                 "Submitting {} allocation(s) with scheduler ID {}...",
                 num_allocations, scheduler_id
@@ -1746,6 +1751,58 @@ fn prompt_scheduler_choice(
             start_one_worker_per_node,
         });
     }
+}
+
+/// Mark the workflow's `on_workflow_start` `schedule_nodes` actions as executed.
+///
+/// `reinitialize_workflow` re-arms these actions (the server clears their `executed` flag and
+/// re-triggers them). When recovery reuses an existing scheduler and submits a user-chosen number
+/// of allocations directly via `torc slurm schedule-nodes`, a re-armed action would otherwise fire
+/// again on the first compute node that starts and submit the action's original `num_allocations`,
+/// ignoring the user's entry. Claiming the actions here marks them executed and prevents that
+/// duplicate, action-defined submission. The `regenerate` path performs the equivalent step inside
+/// `handle_regenerate`. Recovery actions (`is_recovery`) are left untouched.
+pub fn mark_on_workflow_start_schedule_actions_executed(
+    config: &Configuration,
+    workflow_id: i64,
+) -> Result<(), String> {
+    let actions = apis::workflow_actions_api::get_workflow_actions(config, workflow_id)
+        .map_err(|e| format!("Failed to list workflow actions: {}", e))?;
+
+    for action in actions {
+        if action.trigger_type == "on_workflow_start"
+            && action.action_type == "schedule_nodes"
+            && !action.is_recovery
+            && !action.executed
+            && let Some(action_id) = action.id
+        {
+            match apis::workflow_actions_api::claim_action(
+                config,
+                workflow_id,
+                action_id,
+                crate::models::ClaimActionRequest {
+                    compute_node_id: None,
+                },
+            ) {
+                Ok(_) => {
+                    info!(
+                        "Marked on_workflow_start schedule_nodes action {} as executed to avoid duplicate allocations",
+                        action_id
+                    );
+                }
+                Err(e) => {
+                    // 409 Conflict means another process already claimed it, which is fine.
+                    if format!("{:?}", e).contains("409") {
+                        debug!("Action {} already claimed", action_id);
+                    } else {
+                        warn!("Failed to mark action {} as executed: {:?}", action_id, e);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
 }
 
 /// Submit allocations using an existing scheduler config via `torc slurm schedule-nodes`.

--- a/tests/test_workflow_actions.rs
+++ b/tests/test_workflow_actions.rs
@@ -808,3 +808,111 @@ fn test_action_executed_flag_reset_on_reinitialize(start_server: &ServerProcess)
         "executed should be false (pending, not claimed)"
     );
 }
+
+/// Regression test for the recover wizard re-submitting the action-defined allocation count.
+///
+/// After reinitialization re-arms the workflow's `on_workflow_start` `schedule_nodes` action, the
+/// recover wizard's "reuse existing scheduler" path calls
+/// `mark_on_workflow_start_schedule_actions_executed` before submitting the user's chosen number of
+/// allocations. This prevents the re-armed action from firing again on the first compute node and
+/// submitting its own (original) `num_allocations`. The helper must mark exactly the matching
+/// actions executed and leave everything else untouched.
+#[rstest]
+fn test_mark_on_workflow_start_schedule_actions_executed(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let workflow = create_test_workflow(config, "mark_on_start_schedule_workflow");
+    let workflow_id = workflow.id.unwrap();
+
+    let schedule_config = json!({
+        "scheduler_type": "slurm",
+        "scheduler_id": 1,
+        "num_allocations": 5,
+    });
+
+    // Target: on_workflow_start + schedule_nodes (non-recovery) — should be marked executed.
+    let target = apis::workflow_actions_api::create_workflow_action(
+        config,
+        workflow_id,
+        workflow_action(
+            workflow_id,
+            "on_workflow_start",
+            "schedule_nodes",
+            schedule_config.clone(),
+            None,
+        ),
+    )
+    .expect("Failed to create target action");
+    let target_id = target.id.unwrap();
+
+    // Decoy 1: on_workflow_start + run_commands — wrong action_type, must be left alone.
+    let run_cmd = apis::workflow_actions_api::create_workflow_action(
+        config,
+        workflow_id,
+        workflow_action(
+            workflow_id,
+            "on_workflow_start",
+            "run_commands",
+            json!({ "commands": ["echo hi"] }),
+            None,
+        ),
+    )
+    .expect("Failed to create run_commands action");
+    let run_cmd_id = run_cmd.id.unwrap();
+
+    // Decoy 2: on_jobs_ready + schedule_nodes — wrong trigger_type, must be left alone.
+    let other_trigger = apis::workflow_actions_api::create_workflow_action(
+        config,
+        workflow_id,
+        workflow_action(
+            workflow_id,
+            "on_jobs_ready",
+            "schedule_nodes",
+            schedule_config.clone(),
+            None,
+        ),
+    )
+    .expect("Failed to create on_jobs_ready action");
+    let other_trigger_id = other_trigger.id.unwrap();
+
+    // Decoy 3: on_workflow_start + schedule_nodes but is_recovery=true — must be left alone.
+    let mut recovery_body = workflow_action(
+        workflow_id,
+        "on_workflow_start",
+        "schedule_nodes",
+        schedule_config,
+        None,
+    );
+    recovery_body.is_recovery = true;
+    let recovery =
+        apis::workflow_actions_api::create_workflow_action(config, workflow_id, recovery_body)
+            .expect("Failed to create recovery action");
+    let recovery_id = recovery.id.unwrap();
+
+    // Run the fix under test.
+    torc::client::commands::recover::mark_on_workflow_start_schedule_actions_executed(
+        config,
+        workflow_id,
+    )
+    .expect("mark_on_workflow_start_schedule_actions_executed failed");
+
+    let actions = apis::workflow_actions_api::get_workflow_actions(config, workflow_id)
+        .expect("Failed to get workflow actions");
+    let find = |id: i64| actions.iter().find(|a| a.id == Some(id)).unwrap();
+
+    assert!(
+        find(target_id).executed,
+        "on_workflow_start schedule_nodes action should be marked executed"
+    );
+    assert!(
+        !find(run_cmd_id).executed,
+        "run_commands action should be left untouched"
+    );
+    assert!(
+        !find(other_trigger_id).executed,
+        "on_jobs_ready schedule_nodes action should be left untouched"
+    );
+    assert!(
+        !find(recovery_id).executed,
+        "recovery schedule_nodes action should be left untouched"
+    );
+}


### PR DESCRIPTION
## Problem

A user reported that `torc recover`'s interactive wizard does not respect the number of Slurm allocations they enter — instead it submits the count defined by the workflow's existing action.

## Root cause

The wizard's execution order is `reset_failed_jobs` → `reinitialize_workflow` → submit. `reinitialize_workflow` re-arms the workflow's `on_workflow_start` `schedule_nodes` action: the server clears its `executed` flag (`reset_actions_for_reinitialize`) and re-triggers it (`check_and_trigger_actions`).

On the **reuse-existing-scheduler** path, the wizard then submits the user's chosen count via `torc slurm schedule-nodes --num-hpc-jobs N` — but leaves the re-armed action pending. When the first compute node boots, the job runner executes that pending `on_workflow_start` action at startup and submits the action's *original* `num_allocations`, overriding the user's entry.

The **regenerate** path never had this bug because `handle_regenerate` already claims/marks those actions executed "to prevent duplicate allocations."

## Fix

Add `mark_on_workflow_start_schedule_actions_executed()` and call it on the existing-scheduler path, after reinitialization and before submitting. It claims (marks executed) any non-recovery, unexecuted `on_workflow_start` `schedule_nodes` actions — mirroring `handle_regenerate`'s precedent — so only the user's chosen allocation count is submitted. Recovery actions (`is_recovery`) are left untouched; 409 conflicts (already claimed) are treated as benign.

## Test

Adds `test_mark_on_workflow_start_schedule_actions_executed`, which verifies the helper marks the matching action executed and leaves decoys untouched (wrong `action_type`, wrong `trigger_type`, and `is_recovery` actions).

## Verification

- `cargo fmt -- --check` ✅
- `cargo clippy --all --all-targets --all-features -- -D warnings` ✅ (pre-commit)
- `cargo nextest run -E 'test(test_mark_on_workflow_start_schedule_actions_executed)'` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)