### PR TITLE
Add torc jobs reset-status command for selective job rerun

### DIFF
--- a/docs/src/core/how-to/rerun-failed-jobs.md
+++ b/docs/src/core/how-to/rerun-failed-jobs.md
@@ -43,6 +43,39 @@ torc workflows reset-status <workflow_id> --failed-only
 
 Then resume execution with `torc run <workflow_id>` (local) or `torc submit <workflow_id>` (Slurm).
 
+## Selective Job Reset: `torc jobs reset-status`
+
+When you need to rerun only specific jobs (not all failed ones), use `torc jobs reset-status`. This
+is useful when you know exactly which jobs need to be rerun without resetting the whole workflow.
+
+Unlike `torc workflows reset-status`, this command:
+
+- Resets only the explicitly named job IDs (plus any completed downstream dependents — because a
+  rerun job produces new outputs that completed consumers must consume again).
+- Does **not** bump the workflow `run_id` or reset workflow state — you follow up with
+  `torc workflows reinit` once, which does the run_id bump exactly once.
+- All supplied job IDs must belong to the same workflow (hard error otherwise).
+
+```bash
+# Preview what would be reset (no changes applied)
+torc jobs reset-status 101 102 --dry-run
+
+# Reset and rerun (standard flow)
+torc jobs reset-status 101 102 --no-prompts
+torc workflows reinit <workflow_id>
+torc run <workflow_id>      # local execution
+# or: torc submit <workflow_id>   # Slurm
+
+# Override quiescence check (e.g. workflow still technically running)
+torc jobs reset-status 101 --force
+
+# JSON output for scripting
+torc -f json jobs reset-status 101 102 --no-prompts
+```
+
+The `--force` flag bypasses two checks: (1) the workflow quiescence check (complete/no active
+workers), and (2) the active-status guard (jobs in Running or Pending are normally rejected).
+
 ## Choosing the Right Tool
 
 | Scenario                                                  | Use                                                                               |
@@ -51,6 +84,7 @@ Then resume execution with `torc run <workflow_id>` (local) or `torc submit <wor
 | Slurm workflow, want continuous self-healing              | `torc watch --recover`                                                            |
 | Local workflow with failures                              | `torc workflows reset-status --failed-only`                                       |
 | Want to retry without changing resource allocations       | `torc workflows reset-status --failed-only`                                       |
+| Rerun only specific known jobs                            | `torc jobs reset-status <id>...`                                                  |
 | Workflow ran fine but inputs changed                      | [Intelligent Restart](../concepts/intelligent-restart.md)                         |
 | Need AI-driven classification of unfamiliar failure modes | [AI-Assisted Recovery](../../specialized/fault-tolerance/ai-assisted-recovery.md) |
 

--- a/docs/src/core/how-to/rerun-failed-jobs.md
+++ b/docs/src/core/how-to/rerun-failed-jobs.md
@@ -61,11 +61,15 @@ Unlike `torc workflows reset-status`, this command:
 # Preview what would be reset (no changes applied)
 torc jobs reset-status 101 102 --dry-run
 
-# Reset and rerun (standard flow)
-torc jobs reset-status 101 102 --no-prompts
-torc workflows reinit <workflow_id>
+# Reset and reinitialize in one step, then run
+torc jobs reset-status 101 102 --reinit
 torc run <workflow_id>      # local execution
 # or: torc submit <workflow_id>   # Slurm
+
+# Reset and rerun (manual two-step flow)
+torc jobs reset-status 101 102 --no-prompts
+torc workflows reinit <workflow_id>
+torc run <workflow_id>
 
 # Override quiescence check (e.g. workflow still technically running)
 torc jobs reset-status 101 --force

--- a/docs/src/core/how-to/rerun-failed-jobs.md
+++ b/docs/src/core/how-to/rerun-failed-jobs.md
@@ -71,15 +71,20 @@ torc jobs reset-status 101 102 --no-prompts
 torc workflows reinit <workflow_id>
 torc run <workflow_id>
 
-# Override quiescence check (e.g. workflow still technically running)
+# Override safety checks (e.g. workers still active)
 torc jobs reset-status 101 --force
 
 # JSON output for scripting
 torc -f json jobs reset-status 101 102 --no-prompts
 ```
 
-The `--force` flag bypasses two checks: (1) the workflow quiescence check (complete/no active
-workers), and (2) the active-status guard (jobs in Running or Pending are normally rejected).
+The workflow does not need to be complete — the command can be run repeatedly (e.g. to reset
+additional jobs after an earlier reset) as long as no workers are active. If a requested job
+completed successfully, the command warns you before resetting it, since resetting discards its
+results and reruns it.
+
+The `--force` flag bypasses two checks: (1) the no-active-workers check (compute nodes and Slurm
+allocations), and (2) the active-status guard (jobs in Running or Pending are normally rejected).
 
 ## Choosing the Right Tool
 

--- a/docs/src/core/how-to/rerun-failed-jobs.md
+++ b/docs/src/core/how-to/rerun-failed-jobs.md
@@ -50,8 +50,9 @@ is useful when you know exactly which jobs need to be rerun without resetting th
 
 Unlike `torc workflows reset-status`, this command:
 
-- Resets only the explicitly named job IDs (plus any completed downstream dependents — because a
-  rerun job produces new outputs that completed consumers must consume again).
+- Resets only the explicitly named job IDs. Downstream dependents are **not** reset by this command
+  — it lists them for you, and they are reset transitively when you run `torc workflows reinit` (a
+  rerun job produces new outputs that consumers must consume again).
 - Does **not** bump the workflow `run_id` or reset workflow state — you follow up with
   `torc workflows reinit` once, which does the run_id bump exactly once.
 - All supplied job IDs must belong to the same workflow (hard error otherwise).

--- a/src/client/commands/jobs.rs
+++ b/src/client/commands/jobs.rs
@@ -15,6 +15,8 @@ use crate::client::commands::{
     },
 };
 use crate::client::utils::format_local_timestamp;
+use crate::client::workflow_manager::WorkflowManager;
+use crate::config::TorcConfig;
 use crate::models;
 use tabled::Tabled;
 
@@ -440,7 +442,8 @@ EXAMPLES:
     ///
     /// After resetting, run 'torc workflows reinit <workflow_id>' to rebuild
     /// dependency state (this bumps run_id exactly once), then 'torc run' or
-    /// 'torc submit' to execute.
+    /// 'torc submit' to execute. Use --reinit to perform the reinit step automatically
+    /// in the same invocation.
     #[command(
         name = "reset-status",
         after_long_help = "\
@@ -448,7 +451,11 @@ EXAMPLES:
     # Reset two specific jobs for rerun (preview first)
     torc jobs reset-status 101 102 --dry-run
 
-    # Reset and rerun (full flow)
+    # Reset and reinitialize in one step, then run
+    torc jobs reset-status 101 102 --reinit
+    torc run 42
+
+    # Reset and rerun (manual two-step flow)
     torc jobs reset-status 101 102
     torc workflows reinit 42
     torc run 42
@@ -476,6 +483,9 @@ EXAMPLES:
         /// Skip confirmation prompt
         #[arg(long)]
         no_prompts: bool,
+        /// Reinitialize the workflow after resetting (runs 'torc workflows reinit' for you)
+        #[arg(long, alias = "reinitialize")]
+        reinit: bool,
     },
 }
 
@@ -1274,8 +1284,17 @@ pub fn handle_job_commands(config: &Configuration, command: &JobCommands, format
             force,
             dry_run,
             no_prompts,
+            reinit,
         } => {
-            handle_reset_job_status(config, job_ids, *force, *dry_run, *no_prompts, format);
+            handle_reset_job_status(
+                config,
+                job_ids,
+                *force,
+                *dry_run,
+                *no_prompts,
+                *reinit,
+                format,
+            );
         }
         JobCommands::Running { workflow_id } => {
             let user_name = get_env_user_name();
@@ -1497,8 +1516,9 @@ struct ResetJobRow {
 /// `uninitialize_blocked_jobs` CTE resets every transitive dependent of an
 /// uninitialized job when the user runs `torc workflows reinit` — this command
 /// merely computes and displays that closure.  Does NOT bump the workflow
-/// `run_id` — the caller should follow up with `torc workflows reinit <id>`
-/// (which resets workflow status and bumps `run_id` exactly once).
+/// `run_id` by default — the caller should follow up with `torc workflows reinit <id>`
+/// (which resets workflow status and bumps `run_id` exactly once).  Pass
+/// `reinit = true` (or `--reinit` on the CLI) to perform that step automatically.
 ///
 /// # Known limitation
 /// `manage_status_change` does not clear `start_time` / `compute_node_id`; those
@@ -1516,12 +1536,14 @@ fn require_job_id(job: &models::JobModel) -> i64 {
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn handle_reset_job_status(
     config: &Configuration,
     job_ids: &[i64],
     force: bool,
     dry_run: bool,
     no_prompts: bool,
+    reinit: bool,
     format: &str,
 ) {
     // -----------------------------------------------------------------------
@@ -1683,12 +1705,19 @@ fn handle_reset_job_status(
         display_table_with_count(&rows, "jobs to reset");
 
         if !downstream_jobs.is_empty() {
-            println!(
-                "\nThe following downstream jobs will be reset when you run \
-                 'torc workflows reinit {}' (a rerun job produces new outputs, so its \
-                 consumers must rerun too):",
-                workflow_id
-            );
+            if reinit {
+                println!(
+                    "\nThe following downstream jobs will be reset now by the reinit step \
+                     (a rerun job produces new outputs, so its consumers must rerun too):",
+                );
+            } else {
+                println!(
+                    "\nThe following downstream jobs will be reset when you run \
+                     'torc workflows reinit {}' (a rerun job produces new outputs, so its \
+                     consumers must rerun too):",
+                    workflow_id
+                );
+            }
             let ds_rows: Vec<ResetJobRow> = downstream_jobs.iter().map(|j| to_row(j)).collect();
             display_table_with_count(&ds_rows, "downstream jobs (reset at reinit time)");
         }
@@ -1701,6 +1730,7 @@ fn handle_reset_job_status(
         if format == "json" {
             let response = serde_json::json!({
                 "dry_run": true,
+                "reinit_requested": reinit,
                 "workflow_id": workflow_id,
                 "jobs": unique_jobs.iter().map(to_json).collect::<Vec<_>>(),
                 "downstream_jobs": downstream_jobs
@@ -1711,6 +1741,9 @@ fn handle_reset_job_status(
             println!("{}", serde_json::to_string_pretty(&response).unwrap());
         } else {
             println!("Dry run: no changes were made.");
+            if reinit {
+                println!("Dry run: the workflow would also be reinitialized.");
+            }
         }
         return;
     }
@@ -1725,11 +1758,19 @@ fn handle_reset_job_status(
             workflow_id
         );
         if !downstream_jobs.is_empty() {
-            eprintln!(
-                "{} downstream job(s) will be reset later by 'torc workflows reinit {}'.",
-                downstream_jobs.len(),
-                workflow_id
-            );
+            if reinit {
+                eprintln!(
+                    "The workflow will be reinitialized now and {} downstream job(s) reset as \
+                     part of it.",
+                    downstream_jobs.len()
+                );
+            } else {
+                eprintln!(
+                    "{} downstream job(s) will be reset later by 'torc workflows reinit {}'.",
+                    downstream_jobs.len(),
+                    workflow_id
+                );
+            }
         }
         eprintln!("This is an idempotent operation and can be re-run if it partially fails.");
         print!("Continue? (y/N): ");
@@ -1781,20 +1822,47 @@ fn handle_reset_job_status(
     }
 
     // -----------------------------------------------------------------------
+    // 8b. Apply reinit (only when requested and all resets succeeded)
+    // -----------------------------------------------------------------------
+    let mut reinit_applied = false;
+    let mut reinit_error: Option<String> = None;
+    if reinit && failures.is_empty() {
+        match apis::workflows_api::get_workflow(config, workflow_id) {
+            Ok(workflow) => {
+                let torc_config = TorcConfig::load().unwrap_or_default();
+                let manager = WorkflowManager::new(config.clone(), torc_config, workflow);
+                match manager.reinitialize(false, false) {
+                    Ok(()) => reinit_applied = true,
+                    Err(e) => reinit_error = Some(e.to_string()),
+                }
+            }
+            Err(e) => reinit_error = Some(format!("failed to fetch workflow: {}", e)),
+        }
+    }
+
+    // -----------------------------------------------------------------------
     // 9. Output
     // -----------------------------------------------------------------------
-    let next_steps = format!(
-        "Run 'torc workflows reinit {}' (then 'torc run'/'torc submit') to rerun these \
-         jobs.",
-        workflow_id
-    );
+    let next_steps = if reinit_applied {
+        format!(
+            "Run 'torc run {}' or 'torc submit {}' to execute.",
+            workflow_id, workflow_id
+        )
+    } else {
+        format!(
+            "Run 'torc workflows reinit {}' (then 'torc run'/'torc submit') to rerun these \
+             jobs.",
+            workflow_id
+        )
+    };
 
     if format == "json" {
         let failure_list: Vec<serde_json::Value> = failures
             .iter()
             .map(|(id, msg)| serde_json::json!({"job_id": id, "error": msg}))
             .collect();
-        let status_str = if failures.is_empty() {
+        let all_succeeded = failures.is_empty() && (!reinit || reinit_applied);
+        let status_str = if all_succeeded {
             "success"
         } else {
             "partial_failure"
@@ -1813,10 +1881,14 @@ fn handle_reset_job_status(
                 .collect::<Vec<_>>(),
             "failures": failure_list,
             "next_steps": next_steps,
+            "reinit": {
+                "requested": reinit,
+                "applied": reinit_applied,
+                "error": reinit_error,
+            },
         });
         println!("{}", serde_json::to_string_pretty(&response).unwrap());
-        // Exit non-zero on partial failure, matching handle_reset_status's convention
-        if !failures.is_empty() {
+        if !all_succeeded {
             std::process::exit(1);
         }
     } else {
@@ -1830,12 +1902,30 @@ fn handle_reset_job_status(
                  the failed resets.",
                 succeeded.len()
             );
+            if reinit {
+                eprintln!(
+                    "Reinit was skipped because of the above failures. Re-run this command to \
+                     retry both the resets and reinit."
+                );
+            }
             std::process::exit(1);
         }
         println!(
             "Successfully reset {} job(s) to uninitialized.",
             succeeded.len()
         );
+        if let Some(ref err) = reinit_error {
+            eprintln!("Error reinitializing workflow {}: {}", workflow_id, err);
+            eprintln!(
+                "The job resets succeeded. Run 'torc workflows reinit {}' manually to complete \
+                 the reinit step.",
+                workflow_id
+            );
+            std::process::exit(1);
+        }
+        if reinit_applied {
+            println!("Reinitialized workflow {}.", workflow_id);
+        }
         println!("{}", next_steps);
     }
 }

--- a/src/client/commands/jobs.rs
+++ b/src/client/commands/jobs.rs
@@ -433,8 +433,10 @@ EXAMPLES:
     },
     /// Reset specific jobs to uninitialized status for selective rerun
     ///
-    /// Resets the given job IDs (and any completed downstream dependents) to uninitialized
-    /// so they can be rerun. All jobs must belong to the same workflow.
+    /// Resets only the given job IDs to uninitialized so they can be rerun. All jobs
+    /// must belong to the same workflow. Downstream dependents are not reset by this
+    /// command; they are reset transitively by 'torc workflows reinit' (the command
+    /// lists them for you).
     ///
     /// After resetting, run 'torc workflows reinit <workflow_id>' to rebuild
     /// dependency state (this bumps run_id exactly once), then 'torc run' or
@@ -1486,16 +1488,17 @@ struct ResetJobRow {
     name: String,
     #[tabled(rename = "Current Status")]
     status: String,
-    #[tabled(rename = "Kind")]
-    kind: String,
 }
 
 /// Handler for `torc jobs reset-status`.
 ///
-/// Resets the given job IDs (plus any completed downstream dependents) to
-/// `Uninitialized` so they can be rerun.  Does NOT bump the workflow `run_id` —
-/// the caller should follow up with `torc workflows reinit <id>` (which
-/// resets workflow status and bumps `run_id` exactly once).
+/// Resets ONLY the explicitly requested job IDs to `Uninitialized` so they can be
+/// rerun.  Downstream dependents are not touched here: the server's recursive
+/// `uninitialize_blocked_jobs` CTE resets every transitive dependent of an
+/// uninitialized job when the user runs `torc workflows reinit` — this command
+/// merely computes and displays that closure.  Does NOT bump the workflow
+/// `run_id` — the caller should follow up with `torc workflows reinit <id>`
+/// (which resets workflow status and bumps `run_id` exactly once).
 ///
 /// # Known limitation
 /// `manage_status_change` does not clear `start_time` / `compute_node_id`; those
@@ -1590,26 +1593,20 @@ fn handle_reset_job_status(
     }
 
     // -----------------------------------------------------------------------
-    // 3. Compute downstream closure (BFS over completed dependents)
+    // 3. Compute the downstream closure — READ-ONLY, for display only
     // -----------------------------------------------------------------------
-    // Seeds: requested jobs whose current status is a terminal/complete status.
-    // For each such job, fetch its completed direct dependents and add them to
-    // the reset set; repeat transitively.  Jobs that are already Uninitialized
-    // are included in the reset set (idempotent no-ops) so the user sees them.
+    // For each requested job, find its transitive downstream dependents via BFS.
+    // No status-change calls are issued for these jobs: the server's recursive
+    // uninitialize_blocked_jobs CTE resets every transitive dependent of an
+    // uninitialized job — regardless of its status — when the user runs
+    // 'torc workflows reinit' (a rerun job produces new outputs, so consumers
+    // must rerun too).  The closure computed here mirrors that CTE (no status
+    // filter) so the user can see exactly what reinit will reset.
     let requested_ids: HashSet<i64> = unique_jobs.iter().map(|j| j.id.unwrap_or(-1)).collect();
 
-    // Maps job_id → (job, is_downstream_only)
-    let mut reset_set: HashMap<i64, (models::JobModel, bool)> = HashMap::new();
-    for job in &unique_jobs {
-        reset_set.insert(job.id.unwrap_or(-1), (job.clone(), false));
-    }
-
-    // BFS queue seeded from requested jobs that are in a complete state
-    let mut bfs_queue: VecDeque<i64> = unique_jobs
-        .iter()
-        .filter(|j| j.status.map(|s| s.is_complete()).unwrap_or(false))
-        .map(|j| j.id.unwrap_or(-1))
-        .collect();
+    let mut downstream_map: HashMap<i64, models::JobModel> = HashMap::new();
+    let mut visited: HashSet<i64> = requested_ids.clone();
+    let mut bfs_queue: VecDeque<i64> = requested_ids.iter().copied().collect();
 
     while let Some(upstream_id) = bfs_queue.pop_front() {
         // Fetch direct dependents of this upstream job
@@ -1627,17 +1624,15 @@ fn handle_reset_job_status(
 
         for dep in dependents {
             let dep_id = dep.id.unwrap_or(-1);
-            if reset_set.contains_key(&dep_id) {
-                continue; // already in set
-            }
-            // Only pull completed dependents into the closure
-            if dep.status.map(|s| s.is_complete()).unwrap_or(false) {
-                let is_downstream = !requested_ids.contains(&dep_id);
-                reset_set.insert(dep_id, (dep, is_downstream));
+            if visited.insert(dep_id) {
+                downstream_map.insert(dep_id, dep);
                 bfs_queue.push_back(dep_id);
             }
         }
     }
+
+    let mut downstream_jobs: Vec<&models::JobModel> = downstream_map.values().collect();
+    downstream_jobs.sort_by_key(|j| j.id.unwrap_or(-1));
 
     // -----------------------------------------------------------------------
     // 4. Warn for already-uninitialized requested jobs (no-ops)
@@ -1653,121 +1648,57 @@ fn handle_reset_job_status(
     }
 
     // -----------------------------------------------------------------------
-    // 5. Build ordered reset list: downstream closure first, then requested
+    // 5. Display: requested jobs table + informational downstream section
     // -----------------------------------------------------------------------
-    // Separate into downstream-only vs. explicitly requested
-    let mut downstream_jobs: Vec<&models::JobModel> = reset_set
-        .values()
-        .filter(|(_, is_downstream)| *is_downstream)
-        .map(|(j, _)| j)
-        .collect();
-    downstream_jobs.sort_by_key(|j| j.id.unwrap_or(-1));
+    let to_row = |job: &models::JobModel| ResetJobRow {
+        id: job.id.unwrap_or(-1),
+        name: job.name.clone(),
+        status: job
+            .status
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| "unknown".to_string()),
+    };
+    let to_json = |job: &models::JobModel| {
+        serde_json::json!({
+            "job_id": job.id.unwrap_or(-1),
+            "name": job.name,
+            "status": job.status.map(|s| s.to_string()).unwrap_or_default(),
+        })
+    };
 
-    let mut explicit_jobs: Vec<&models::JobModel> = reset_set
-        .values()
-        .filter(|(_, is_downstream)| !*is_downstream)
-        .map(|(j, _)| j)
-        .collect();
-    explicit_jobs.sort_by_key(|j| j.id.unwrap_or(-1));
-
-    // Display table
     if format != "json" {
-        let mut rows: Vec<ResetJobRow> = Vec::new();
-        for job in &downstream_jobs {
-            rows.push(ResetJobRow {
-                id: job.id.unwrap_or(-1),
-                name: job.name.clone(),
-                status: job
-                    .status
-                    .map(|s| s.to_string())
-                    .unwrap_or_else(|| "unknown".to_string()),
-                kind: "downstream".to_string(),
-            });
-        }
-        for job in &explicit_jobs {
-            rows.push(ResetJobRow {
-                id: job.id.unwrap_or(-1),
-                name: job.name.clone(),
-                status: job
-                    .status
-                    .map(|s| s.to_string())
-                    .unwrap_or_else(|| "unknown".to_string()),
-                kind: "explicit".to_string(),
-            });
-        }
-        if rows.is_empty() {
-            println!("No jobs to reset.");
-            return;
-        }
+        let rows: Vec<ResetJobRow> = unique_jobs.iter().map(to_row).collect();
         display_table_with_count(&rows, "jobs to reset");
+
+        if !downstream_jobs.is_empty() {
+            println!(
+                "\nThe following downstream jobs will be reset when you run \
+                 'torc workflows reinit {}' (a rerun job produces new outputs, so its \
+                 consumers must rerun too):",
+                workflow_id
+            );
+            let ds_rows: Vec<ResetJobRow> = downstream_jobs.iter().map(|j| to_row(j)).collect();
+            display_table_with_count(&ds_rows, "downstream jobs (reset at reinit time)");
+        }
     }
 
     // -----------------------------------------------------------------------
     // 6. Dry-run: stop here
     // -----------------------------------------------------------------------
-    let all_reset_ids: Vec<i64> = {
-        let mut ids: Vec<i64> = downstream_jobs.iter().map(|j| j.id.unwrap_or(-1)).collect();
-        ids.extend(explicit_jobs.iter().map(|j| j.id.unwrap_or(-1)));
-        ids
-    };
-
     if dry_run {
         if format == "json" {
-            let downstream_list: Vec<serde_json::Value> = downstream_jobs
-                .iter()
-                .map(|j| {
-                    serde_json::json!({
-                        "job_id": j.id.unwrap_or(-1),
-                        "name": j.name,
-                        "status": j.status.map(|s| s.to_string()).unwrap_or_default(),
-                        "kind": "downstream",
-                    })
-                })
-                .collect();
-            let explicit_list: Vec<serde_json::Value> = explicit_jobs
-                .iter()
-                .map(|j| {
-                    serde_json::json!({
-                        "job_id": j.id.unwrap_or(-1),
-                        "name": j.name,
-                        "status": j.status.map(|s| s.to_string()).unwrap_or_default(),
-                        "kind": "explicit",
-                    })
-                })
-                .collect();
-            let mut jobs_list = downstream_list;
-            jobs_list.extend(explicit_list);
             let response = serde_json::json!({
                 "dry_run": true,
                 "workflow_id": workflow_id,
-                "jobs": jobs_list,
+                "jobs": unique_jobs.iter().map(to_json).collect::<Vec<_>>(),
+                "downstream_jobs": downstream_jobs
+                    .iter()
+                    .map(|j| to_json(j))
+                    .collect::<Vec<_>>(),
             });
             println!("{}", serde_json::to_string_pretty(&response).unwrap());
         } else {
             println!("Dry run: no changes were made.");
-        }
-        return;
-    }
-
-    if all_reset_ids.is_empty() {
-        if format == "json" {
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&serde_json::json!({
-                    "workflow_id": workflow_id,
-                    "reset_count": 0,
-                    "reset_job_ids": [],
-                    "failures": [],
-                    "next_steps": format!(
-                        "Run 'torc workflows reinit {}' (then 'torc run'/'torc submit') \
-                         to rerun these jobs.",
-                        workflow_id
-                    ),
-                }))
-                .unwrap()
-            );
-        } else {
-            println!("No jobs to reset.");
         }
         return;
     }
@@ -1778,9 +1709,16 @@ fn handle_reset_job_status(
     if !no_prompts && format != "json" {
         eprintln!(
             "\nAbout to reset {} job(s) in workflow {} to uninitialized.",
-            all_reset_ids.len(),
+            unique_jobs.len(),
             workflow_id
         );
+        if !downstream_jobs.is_empty() {
+            eprintln!(
+                "{} downstream job(s) will be reset later by 'torc workflows reinit {}'.",
+                downstream_jobs.len(),
+                workflow_id
+            );
+        }
         eprintln!("This is an idempotent operation and can be re-run if it partially fails.");
         print!("Continue? (y/N): ");
         io::stdout().flush().unwrap();
@@ -1801,7 +1739,7 @@ fn handle_reset_job_status(
     }
 
     // -----------------------------------------------------------------------
-    // 8. Apply: fetch run_id, then reset downstream first, then explicit
+    // 8. Apply: fetch run_id, then reset ONLY the requested jobs
     // -----------------------------------------------------------------------
     let run_id = match apis::workflows_api::get_workflow(config, workflow_id) {
         Ok(wf) => wf.run_id.unwrap_or(1),
@@ -1811,18 +1749,14 @@ fn handle_reset_job_status(
         }
     };
 
-    // Order: downstream-closure jobs BEFORE their upstream targets so the server's
-    // own one-level reinitialize_downstream_jobs finds them already uninitialized.
-    let ordered_ids: Vec<i64> = {
-        let mut ids: Vec<i64> = downstream_jobs.iter().map(|j| j.id.unwrap_or(-1)).collect();
-        ids.extend(explicit_jobs.iter().map(|j| j.id.unwrap_or(-1)));
-        ids
-    };
-
+    // The server's one-level reinitialize_downstream_jobs may incidentally reset
+    // some direct Completed/Failed dependents on complete→uninitialized; that is
+    // harmless — the recursive reset at reinit time covers the rest.
     let mut succeeded: Vec<i64> = Vec::new();
     let mut failures: Vec<(i64, String)> = Vec::new();
 
-    for &id in &ordered_ids {
+    for job in &unique_jobs {
+        let id = job.id.unwrap_or(-1);
         match apis::jobs_api::manage_status_change(
             config,
             id,
@@ -1858,6 +1792,12 @@ fn handle_reset_job_status(
             "workflow_id": workflow_id,
             "reset_count": succeeded.len(),
             "reset_job_ids": succeeded,
+            // Informational: these are reset by the server at reinit time,
+            // not by this command.
+            "downstream_jobs": downstream_jobs
+                .iter()
+                .map(|j| to_json(j))
+                .collect::<Vec<_>>(),
             "failures": failure_list,
             "next_steps": next_steps,
         });

--- a/src/client/commands/jobs.rs
+++ b/src/client/commands/jobs.rs
@@ -1504,6 +1504,18 @@ struct ResetJobRow {
 /// `manage_status_change` does not clear `start_time` / `compute_node_id`; those
 /// fields are overwritten when the job next starts.  Clearing them via `update_job`
 /// is restricted and the cosmetic difference is acceptable.
+/// The server always assigns job IDs, so a `None` here indicates a server bug;
+/// fail hard rather than propagate a sentinel value into status changes.
+fn require_job_id(job: &models::JobModel) -> i64 {
+    job.id.unwrap_or_else(|| {
+        eprintln!(
+            "Error: server returned job '{}' (workflow_id={}) without an ID",
+            job.name, job.workflow_id
+        );
+        std::process::exit(1);
+    })
+}
+
 fn handle_reset_job_status(
     config: &Configuration,
     job_ids: &[i64],
@@ -1530,7 +1542,7 @@ fn handle_reset_job_status(
     let mut seen_ids: HashSet<i64> = HashSet::new();
     let mut unique_jobs: Vec<models::JobModel> = Vec::new();
     for job in fetched {
-        let id = job.id.unwrap_or(-1);
+        let id = require_job_id(&job);
         if seen_ids.insert(id) {
             unique_jobs.push(job);
         }
@@ -1541,7 +1553,7 @@ fn handle_reset_job_status(
     let mut mismatched: Vec<(i64, i64)> = Vec::new();
     for job in &unique_jobs {
         if job.workflow_id != workflow_id {
-            mismatched.push((job.id.unwrap_or(-1), job.workflow_id));
+            mismatched.push((require_job_id(job), job.workflow_id));
         }
     }
     if !mismatched.is_empty() {
@@ -1578,7 +1590,7 @@ fn handle_reset_job_status(
                     Some(models::JobStatus::Running) | Some(models::JobStatus::Pending)
                 )
             })
-            .map(|j| j.id.unwrap_or(-1))
+            .map(require_job_id)
             .collect();
         if !active_targets.is_empty() {
             eprintln!(
@@ -1602,7 +1614,7 @@ fn handle_reset_job_status(
     // 'torc workflows reinit' (a rerun job produces new outputs, so consumers
     // must rerun too).  The closure computed here mirrors that CTE (no status
     // filter) so the user can see exactly what reinit will reset.
-    let requested_ids: HashSet<i64> = unique_jobs.iter().map(|j| j.id.unwrap_or(-1)).collect();
+    let requested_ids: HashSet<i64> = unique_jobs.iter().map(require_job_id).collect();
 
     let mut downstream_map: HashMap<i64, models::JobModel> = HashMap::new();
     let mut visited: HashSet<i64> = requested_ids.clone();
@@ -1623,7 +1635,7 @@ fn handle_reset_job_status(
         };
 
         for dep in dependents {
-            let dep_id = dep.id.unwrap_or(-1);
+            let dep_id = require_job_id(&dep);
             if visited.insert(dep_id) {
                 downstream_map.insert(dep_id, dep);
                 bfs_queue.push_back(dep_id);
@@ -1632,7 +1644,7 @@ fn handle_reset_job_status(
     }
 
     let mut downstream_jobs: Vec<&models::JobModel> = downstream_map.values().collect();
-    downstream_jobs.sort_by_key(|j| j.id.unwrap_or(-1));
+    downstream_jobs.sort_by_key(|j| require_job_id(j));
 
     // -----------------------------------------------------------------------
     // 4. Warn for already-uninitialized requested jobs (no-ops)
@@ -1641,7 +1653,7 @@ fn handle_reset_job_status(
         if job.status == Some(models::JobStatus::Uninitialized) {
             eprintln!(
                 "Warning: job {} ({}) is already uninitialized — will be a no-op.",
-                job.id.unwrap_or(-1),
+                require_job_id(job),
                 job.name
             );
         }
@@ -1651,7 +1663,7 @@ fn handle_reset_job_status(
     // 5. Display: requested jobs table + informational downstream section
     // -----------------------------------------------------------------------
     let to_row = |job: &models::JobModel| ResetJobRow {
-        id: job.id.unwrap_or(-1),
+        id: require_job_id(job),
         name: job.name.clone(),
         status: job
             .status
@@ -1660,7 +1672,7 @@ fn handle_reset_job_status(
     };
     let to_json = |job: &models::JobModel| {
         serde_json::json!({
-            "job_id": job.id.unwrap_or(-1),
+            "job_id": require_job_id(job),
             "name": job.name,
             "status": job.status.map(|s| s.to_string()).unwrap_or_default(),
         })
@@ -1756,7 +1768,7 @@ fn handle_reset_job_status(
     let mut failures: Vec<(i64, String)> = Vec::new();
 
     for job in &unique_jobs {
-        let id = job.id.unwrap_or(-1);
+        let id = require_job_id(job);
         match apis::jobs_api::manage_status_change(
             config,
             id,
@@ -1791,6 +1803,7 @@ fn handle_reset_job_status(
             "status": status_str,
             "workflow_id": workflow_id,
             "reset_count": succeeded.len(),
+            "requested_job_ids": unique_jobs.iter().map(require_job_id).collect::<Vec<_>>(),
             "reset_job_ids": succeeded,
             // Informational: these are reset by the server at reinit time,
             // not by this command.

--- a/src/client/commands/jobs.rs
+++ b/src/client/commands/jobs.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs;
 use std::io::{self, Write};
 use std::path::Path;
@@ -430,6 +430,50 @@ EXAMPLES:
         /// Workflow ID to list running jobs for (optional - will prompt if not provided)
         #[arg()]
         workflow_id: Option<i64>,
+    },
+    /// Reset specific jobs to uninitialized status for selective rerun
+    ///
+    /// Resets the given job IDs (and any completed downstream dependents) to uninitialized
+    /// so they can be rerun. All jobs must belong to the same workflow.
+    ///
+    /// After resetting, run 'torc workflows reinit <workflow_id>' to rebuild
+    /// dependency state (this bumps run_id exactly once), then 'torc run' or
+    /// 'torc submit' to execute.
+    #[command(
+        name = "reset-status",
+        after_long_help = "\
+EXAMPLES:
+    # Reset two specific jobs for rerun (preview first)
+    torc jobs reset-status 101 102 --dry-run
+
+    # Reset and rerun (full flow)
+    torc jobs reset-status 101 102
+    torc workflows reinit 42
+    torc run 42
+
+    # Reset without prompts (for scripts/CI)
+    torc jobs reset-status 101 102 --no-prompts
+
+    # Override quiescence check (workflow still running)
+    torc jobs reset-status 101 --force
+
+    # JSON output for scripting
+    torc -f json jobs reset-status 101 102
+"
+    )]
+    ResetStatus {
+        /// Job IDs to reset (must all belong to the same workflow)
+        #[arg(required = true, num_args = 1..)]
+        job_ids: Vec<i64>,
+        /// Skip precondition checks (workflow complete, no active workers)
+        #[arg(long)]
+        force: bool,
+        /// Preview which jobs would be reset without applying changes
+        #[arg(long)]
+        dry_run: bool,
+        /// Skip confirmation prompt
+        #[arg(long)]
+        no_prompts: bool,
     },
 }
 
@@ -1223,6 +1267,14 @@ pub fn handle_job_commands(config: &Configuration, command: &JobCommands, format
                 }
             }
         }
+        JobCommands::ResetStatus {
+            job_ids,
+            force,
+            dry_run,
+            no_prompts,
+        } => {
+            handle_reset_job_status(config, job_ids, *force, *dry_run, *no_prompts, format);
+        }
         JobCommands::Running { workflow_id } => {
             let user_name = get_env_user_name();
             let selected_workflow_id = match workflow_id {
@@ -1419,6 +1471,420 @@ pub fn get_current_job_count(
     .map_err(|e| format!("Failed to get job count: {:?}", e))?;
 
     Ok(response.total_count)
+}
+
+// ---------------------------------------------------------------------------
+// reset-status helpers
+// ---------------------------------------------------------------------------
+
+/// A single row in the jobs-to-reset preview table.
+#[derive(Tabled)]
+struct ResetJobRow {
+    #[tabled(rename = "Job ID")]
+    id: i64,
+    #[tabled(rename = "Name")]
+    name: String,
+    #[tabled(rename = "Current Status")]
+    status: String,
+    #[tabled(rename = "Kind")]
+    kind: String,
+}
+
+/// Handler for `torc jobs reset-status`.
+///
+/// Resets the given job IDs (plus any completed downstream dependents) to
+/// `Uninitialized` so they can be rerun.  Does NOT bump the workflow `run_id` —
+/// the caller should follow up with `torc workflows reinit <id>` (which
+/// resets workflow status and bumps `run_id` exactly once).
+///
+/// # Known limitation
+/// `manage_status_change` does not clear `start_time` / `compute_node_id`; those
+/// fields are overwritten when the job next starts.  Clearing them via `update_job`
+/// is restricted and the cosmetic difference is acceptable.
+fn handle_reset_job_status(
+    config: &Configuration,
+    job_ids: &[i64],
+    force: bool,
+    dry_run: bool,
+    no_prompts: bool,
+    format: &str,
+) {
+    // -----------------------------------------------------------------------
+    // 1. Fetch and validate: all IDs must exist and belong to the same workflow
+    // -----------------------------------------------------------------------
+    let mut fetched: Vec<models::JobModel> = Vec::with_capacity(job_ids.len());
+    for &id in job_ids {
+        match apis::jobs_api::get_job(config, id) {
+            Ok(job) => fetched.push(job),
+            Err(e) => {
+                eprintln!("Error: job {} not found: {}", id, e);
+                std::process::exit(1);
+            }
+        }
+    }
+
+    // De-duplicate by ID while preserving first-occurrence order
+    let mut seen_ids: HashSet<i64> = HashSet::new();
+    let mut unique_jobs: Vec<models::JobModel> = Vec::new();
+    for job in fetched {
+        let id = job.id.unwrap_or(-1);
+        if seen_ids.insert(id) {
+            unique_jobs.push(job);
+        }
+    }
+
+    // Determine workflow from first job; reject if any job belongs elsewhere
+    let workflow_id = unique_jobs[0].workflow_id;
+    let mut mismatched: Vec<(i64, i64)> = Vec::new();
+    for job in &unique_jobs {
+        if job.workflow_id != workflow_id {
+            mismatched.push((job.id.unwrap_or(-1), job.workflow_id));
+        }
+    }
+    if !mismatched.is_empty() {
+        eprintln!(
+            "Error: all job IDs must belong to the same workflow (inferred workflow_id={} from \
+             first job), but the following jobs belong to different workflows:",
+            workflow_id
+        );
+        for (id, wf) in &mismatched {
+            eprintln!("  job {} belongs to workflow {}", id, wf);
+        }
+        eprintln!("Nothing was reset.");
+        std::process::exit(1);
+    }
+
+    // -----------------------------------------------------------------------
+    // 2. Preconditions
+    // -----------------------------------------------------------------------
+    if !force {
+        if let Err(msg) =
+            crate::client::commands::recover::check_workflow_quiesced(config, workflow_id)
+        {
+            eprintln!("Error: {}", msg);
+            eprintln!("Use --force to skip this check.");
+            std::process::exit(1);
+        }
+
+        // Reject jobs currently in Running or Pending status
+        let active_targets: Vec<i64> = unique_jobs
+            .iter()
+            .filter(|j| {
+                matches!(
+                    j.status,
+                    Some(models::JobStatus::Running) | Some(models::JobStatus::Pending)
+                )
+            })
+            .map(|j| j.id.unwrap_or(-1))
+            .collect();
+        if !active_targets.is_empty() {
+            eprintln!(
+                "Error: the following jobs are currently Running or Pending and cannot be reset \
+                 without --force:"
+            );
+            for id in &active_targets {
+                eprintln!("  job {}", id);
+            }
+            std::process::exit(1);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // 3. Compute downstream closure (BFS over completed dependents)
+    // -----------------------------------------------------------------------
+    // Seeds: requested jobs whose current status is a terminal/complete status.
+    // For each such job, fetch its completed direct dependents and add them to
+    // the reset set; repeat transitively.  Jobs that are already Uninitialized
+    // are included in the reset set (idempotent no-ops) so the user sees them.
+    let requested_ids: HashSet<i64> = unique_jobs.iter().map(|j| j.id.unwrap_or(-1)).collect();
+
+    // Maps job_id → (job, is_downstream_only)
+    let mut reset_set: HashMap<i64, (models::JobModel, bool)> = HashMap::new();
+    for job in &unique_jobs {
+        reset_set.insert(job.id.unwrap_or(-1), (job.clone(), false));
+    }
+
+    // BFS queue seeded from requested jobs that are in a complete state
+    let mut bfs_queue: VecDeque<i64> = unique_jobs
+        .iter()
+        .filter(|j| j.status.map(|s| s.is_complete()).unwrap_or(false))
+        .map(|j| j.id.unwrap_or(-1))
+        .collect();
+
+    while let Some(upstream_id) = bfs_queue.pop_front() {
+        // Fetch direct dependents of this upstream job
+        let params = JobListParams::new().with_upstream_job_id(upstream_id);
+        let dependents = match pagination::paginate_jobs(config, workflow_id, params) {
+            Ok(jobs) => jobs,
+            Err(e) => {
+                eprintln!(
+                    "Error: failed to list dependents of job {}: {}",
+                    upstream_id, e
+                );
+                std::process::exit(1);
+            }
+        };
+
+        for dep in dependents {
+            let dep_id = dep.id.unwrap_or(-1);
+            if reset_set.contains_key(&dep_id) {
+                continue; // already in set
+            }
+            // Only pull completed dependents into the closure
+            if dep.status.map(|s| s.is_complete()).unwrap_or(false) {
+                let is_downstream = !requested_ids.contains(&dep_id);
+                reset_set.insert(dep_id, (dep, is_downstream));
+                bfs_queue.push_back(dep_id);
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // 4. Warn for already-uninitialized requested jobs (no-ops)
+    // -----------------------------------------------------------------------
+    for job in &unique_jobs {
+        if job.status == Some(models::JobStatus::Uninitialized) {
+            eprintln!(
+                "Warning: job {} ({}) is already uninitialized — will be a no-op.",
+                job.id.unwrap_or(-1),
+                job.name
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // 5. Build ordered reset list: downstream closure first, then requested
+    // -----------------------------------------------------------------------
+    // Separate into downstream-only vs. explicitly requested
+    let mut downstream_jobs: Vec<&models::JobModel> = reset_set
+        .values()
+        .filter(|(_, is_downstream)| *is_downstream)
+        .map(|(j, _)| j)
+        .collect();
+    downstream_jobs.sort_by_key(|j| j.id.unwrap_or(-1));
+
+    let mut explicit_jobs: Vec<&models::JobModel> = reset_set
+        .values()
+        .filter(|(_, is_downstream)| !*is_downstream)
+        .map(|(j, _)| j)
+        .collect();
+    explicit_jobs.sort_by_key(|j| j.id.unwrap_or(-1));
+
+    // Display table
+    if format != "json" {
+        let mut rows: Vec<ResetJobRow> = Vec::new();
+        for job in &downstream_jobs {
+            rows.push(ResetJobRow {
+                id: job.id.unwrap_or(-1),
+                name: job.name.clone(),
+                status: job
+                    .status
+                    .map(|s| s.to_string())
+                    .unwrap_or_else(|| "unknown".to_string()),
+                kind: "downstream".to_string(),
+            });
+        }
+        for job in &explicit_jobs {
+            rows.push(ResetJobRow {
+                id: job.id.unwrap_or(-1),
+                name: job.name.clone(),
+                status: job
+                    .status
+                    .map(|s| s.to_string())
+                    .unwrap_or_else(|| "unknown".to_string()),
+                kind: "explicit".to_string(),
+            });
+        }
+        if rows.is_empty() {
+            println!("No jobs to reset.");
+            return;
+        }
+        display_table_with_count(&rows, "jobs to reset");
+    }
+
+    // -----------------------------------------------------------------------
+    // 6. Dry-run: stop here
+    // -----------------------------------------------------------------------
+    let all_reset_ids: Vec<i64> = {
+        let mut ids: Vec<i64> = downstream_jobs.iter().map(|j| j.id.unwrap_or(-1)).collect();
+        ids.extend(explicit_jobs.iter().map(|j| j.id.unwrap_or(-1)));
+        ids
+    };
+
+    if dry_run {
+        if format == "json" {
+            let downstream_list: Vec<serde_json::Value> = downstream_jobs
+                .iter()
+                .map(|j| {
+                    serde_json::json!({
+                        "job_id": j.id.unwrap_or(-1),
+                        "name": j.name,
+                        "status": j.status.map(|s| s.to_string()).unwrap_or_default(),
+                        "kind": "downstream",
+                    })
+                })
+                .collect();
+            let explicit_list: Vec<serde_json::Value> = explicit_jobs
+                .iter()
+                .map(|j| {
+                    serde_json::json!({
+                        "job_id": j.id.unwrap_or(-1),
+                        "name": j.name,
+                        "status": j.status.map(|s| s.to_string()).unwrap_or_default(),
+                        "kind": "explicit",
+                    })
+                })
+                .collect();
+            let mut jobs_list = downstream_list;
+            jobs_list.extend(explicit_list);
+            let response = serde_json::json!({
+                "dry_run": true,
+                "workflow_id": workflow_id,
+                "jobs": jobs_list,
+            });
+            println!("{}", serde_json::to_string_pretty(&response).unwrap());
+        } else {
+            println!("Dry run: no changes were made.");
+        }
+        return;
+    }
+
+    if all_reset_ids.is_empty() {
+        if format == "json" {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&serde_json::json!({
+                    "workflow_id": workflow_id,
+                    "reset_count": 0,
+                    "reset_job_ids": [],
+                    "failures": [],
+                    "next_steps": format!(
+                        "Run 'torc workflows reinit {}' (then 'torc run'/'torc submit') \
+                         to rerun these jobs.",
+                        workflow_id
+                    ),
+                }))
+                .unwrap()
+            );
+        } else {
+            println!("No jobs to reset.");
+        }
+        return;
+    }
+
+    // -----------------------------------------------------------------------
+    // 7. Confirmation prompt
+    // -----------------------------------------------------------------------
+    if !no_prompts && format != "json" {
+        eprintln!(
+            "\nAbout to reset {} job(s) in workflow {} to uninitialized.",
+            all_reset_ids.len(),
+            workflow_id
+        );
+        eprintln!("This is an idempotent operation and can be re-run if it partially fails.");
+        print!("Continue? (y/N): ");
+        io::stdout().flush().unwrap();
+
+        let mut input = String::new();
+        match io::stdin().read_line(&mut input) {
+            Ok(_) => {
+                if input.trim().to_lowercase() != "y" && input.trim().to_lowercase() != "yes" {
+                    eprintln!("Reset cancelled.");
+                    std::process::exit(0);
+                }
+            }
+            Err(e) => {
+                eprintln!("Failed to read input: {}", e);
+                std::process::exit(1);
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // 8. Apply: fetch run_id, then reset downstream first, then explicit
+    // -----------------------------------------------------------------------
+    let run_id = match apis::workflows_api::get_workflow(config, workflow_id) {
+        Ok(wf) => wf.run_id.unwrap_or(1),
+        Err(e) => {
+            eprintln!("Error: failed to fetch workflow {}: {}", workflow_id, e);
+            std::process::exit(1);
+        }
+    };
+
+    // Order: downstream-closure jobs BEFORE their upstream targets so the server's
+    // own one-level reinitialize_downstream_jobs finds them already uninitialized.
+    let ordered_ids: Vec<i64> = {
+        let mut ids: Vec<i64> = downstream_jobs.iter().map(|j| j.id.unwrap_or(-1)).collect();
+        ids.extend(explicit_jobs.iter().map(|j| j.id.unwrap_or(-1)));
+        ids
+    };
+
+    let mut succeeded: Vec<i64> = Vec::new();
+    let mut failures: Vec<(i64, String)> = Vec::new();
+
+    for &id in &ordered_ids {
+        match apis::jobs_api::manage_status_change(
+            config,
+            id,
+            models::JobStatus::Uninitialized,
+            run_id,
+        ) {
+            Ok(_) => succeeded.push(id),
+            Err(e) => failures.push((id, e.to_string())),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // 9. Output
+    // -----------------------------------------------------------------------
+    let next_steps = format!(
+        "Run 'torc workflows reinit {}' (then 'torc run'/'torc submit') to rerun these \
+         jobs.",
+        workflow_id
+    );
+
+    if format == "json" {
+        let failure_list: Vec<serde_json::Value> = failures
+            .iter()
+            .map(|(id, msg)| serde_json::json!({"job_id": id, "error": msg}))
+            .collect();
+        let status_str = if failures.is_empty() {
+            "success"
+        } else {
+            "partial_failure"
+        };
+        let response = serde_json::json!({
+            "status": status_str,
+            "workflow_id": workflow_id,
+            "reset_count": succeeded.len(),
+            "reset_job_ids": succeeded,
+            "failures": failure_list,
+            "next_steps": next_steps,
+        });
+        println!("{}", serde_json::to_string_pretty(&response).unwrap());
+        // Exit non-zero on partial failure, matching handle_reset_status's convention
+        if !failures.is_empty() {
+            std::process::exit(1);
+        }
+    } else {
+        if !failures.is_empty() {
+            eprintln!("Error: {} job(s) could not be reset:", failures.len());
+            for (id, msg) in &failures {
+                eprintln!("  job {}: {}", id, msg);
+            }
+            eprintln!(
+                "Successfully reset {} job(s). This command is idempotent — re-run it to retry \
+                 the failed resets.",
+                succeeded.len()
+            );
+            std::process::exit(1);
+        }
+        println!(
+            "Successfully reset {} job(s) to uninitialized.",
+            succeeded.len()
+        );
+        println!("{}", next_steps);
+    }
 }
 
 /// Get existing job names to avoid duplicates

--- a/src/client/commands/jobs.rs
+++ b/src/client/commands/jobs.rs
@@ -463,7 +463,7 @@ EXAMPLES:
     # Reset without prompts (for scripts/CI)
     torc jobs reset-status 101 102 --no-prompts
 
-    # Override quiescence check (workflow still running)
+    # Override safety checks (workers still active)
     torc jobs reset-status 101 --force
 
     # JSON output for scripting
@@ -474,7 +474,7 @@ EXAMPLES:
         /// Job IDs to reset (must all belong to the same workflow)
         #[arg(required = true, num_args = 1..)]
         job_ids: Vec<i64>,
-        /// Skip precondition checks (workflow complete, no active workers)
+        /// Skip precondition checks (no active workers, target jobs not running)
         #[arg(long)]
         force: bool,
         /// Preview which jobs would be reset without applying changes
@@ -1594,9 +1594,12 @@ fn handle_reset_job_status(
     // -----------------------------------------------------------------------
     // 2. Preconditions
     // -----------------------------------------------------------------------
+    // The workflow does NOT need to be complete — only quiet. Requiring
+    // completeness would make this command non-rerunnable: the first reset
+    // leaves jobs uninitialized, so the workflow is no longer "complete".
     if !force {
         if let Err(msg) =
-            crate::client::commands::recover::check_workflow_quiesced(config, workflow_id)
+            crate::client::commands::recover::check_no_active_workers(config, workflow_id)
         {
             eprintln!("Error: {}", msg);
             eprintln!("Use --force to skip this check.");
@@ -1669,7 +1672,8 @@ fn handle_reset_job_status(
     downstream_jobs.sort_by_key(|j| require_job_id(j));
 
     // -----------------------------------------------------------------------
-    // 4. Warn for already-uninitialized requested jobs (no-ops)
+    // 4. Warn for already-uninitialized requested jobs (no-ops) and for jobs
+    //    that completed successfully (the user may not intend to redo them)
     // -----------------------------------------------------------------------
     for job in &unique_jobs {
         if job.status == Some(models::JobStatus::Uninitialized) {
@@ -1678,6 +1682,20 @@ fn handle_reset_job_status(
                 require_job_id(job),
                 job.name
             );
+        }
+    }
+
+    let completed_targets: Vec<&models::JobModel> = unique_jobs
+        .iter()
+        .filter(|j| j.status == Some(models::JobStatus::Completed))
+        .collect();
+    if !completed_targets.is_empty() {
+        eprintln!(
+            "Warning: the following job(s) completed successfully; resetting them discards \
+             their results and reruns them:"
+        );
+        for job in &completed_targets {
+            eprintln!("  job {} ({})", require_job_id(job), job.name);
         }
     }
 

--- a/src/client/commands/recover.rs
+++ b/src/client/commands/recover.rs
@@ -460,6 +460,20 @@ pub(crate) fn check_workflow_quiesced(
         );
     }
 
+    check_no_active_workers(config, workflow_id)
+}
+
+/// Check that no workers are active on the workflow:
+/// - No active compute node workers
+/// - No pending or active scheduled compute nodes (Slurm allocations)
+///
+/// Unlike [`check_workflow_quiesced`], this does NOT require the workflow to be
+/// complete — non-terminal job statuses (uninitialized, blocked, ready) are fine
+/// as long as nothing is executing or about to execute.
+pub(crate) fn check_no_active_workers(
+    config: &Configuration,
+    workflow_id: i64,
+) -> Result<(), String> {
     // Check for active compute nodes
     let active_nodes = apis::compute_nodes_api::list_compute_nodes(
         config,

--- a/src/client/commands/recover.rs
+++ b/src/client/commands/recover.rs
@@ -437,18 +437,27 @@ pub fn recover_workflow(
     Ok(result)
 }
 
-/// Check that the workflow is in a valid state for recovery:
-/// - Workflow must be complete (all jobs in terminal state)
-/// - No active workers (compute nodes or scheduled compute nodes)
-fn check_recovery_preconditions(config: &Configuration, workflow_id: i64) -> Result<(), String> {
+/// Check that the workflow is quiesced (safe to modify job statuses):
+/// - Workflow must be complete or canceled (all jobs in terminal state)
+/// - No active compute node workers
+/// - No pending or active scheduled compute nodes (Slurm allocations)
+///
+/// Returns `Err(message)` with a neutral description of what is wrong. Callers can
+/// prepend their own action-specific prefix when surfacing the error to the user.
+pub(crate) fn check_workflow_quiesced(
+    config: &Configuration,
+    workflow_id: i64,
+) -> Result<(), String> {
     // Check if workflow is complete
     let is_complete = apis::workflows_api::is_workflow_complete(config, workflow_id)
         .map_err(|e| format!("Failed to check workflow completion status: {}", e))?;
 
     if !is_complete.is_complete && !is_complete.is_canceled {
-        return Err("Cannot recover: workflow is not complete. \
-             Wait for all jobs to finish or use 'torc workflows cancel' first."
-            .to_string());
+        return Err(
+            "workflow is not complete; wait for all jobs to finish or use \
+             'torc workflows cancel' first"
+                .to_string(),
+        );
     }
 
     // Check for active compute nodes
@@ -466,9 +475,9 @@ fn check_recovery_preconditions(config: &Configuration, workflow_id: i64) -> Res
     .map_err(|e| format!("Failed to check for active compute nodes: {}", e))?;
 
     if !active_nodes.items.is_empty() {
-        return Err("Cannot recover: there are still active compute nodes. \
-             Wait for all workers to exit."
-            .to_string());
+        return Err(
+            "there are still active compute nodes; wait for all workers to exit".to_string(),
+        );
     }
 
     // Check for pending/active scheduled compute nodes
@@ -486,9 +495,11 @@ fn check_recovery_preconditions(config: &Configuration, workflow_id: i64) -> Res
     .map_err(|e| format!("Failed to check for pending scheduled compute nodes: {}", e))?;
 
     if pending_scn.total_count > 0 {
-        return Err("Cannot recover: there are pending Slurm allocations. \
-             Wait for them to start or cancel them with 'torc slurm cancel'."
-            .to_string());
+        return Err(
+            "there are pending Slurm allocations; wait for them to start or cancel them with \
+             'torc slurm cancel'"
+                .to_string(),
+        );
     }
 
     let active_scn = apis::scheduled_compute_nodes_api::list_scheduled_compute_nodes(
@@ -506,11 +517,22 @@ fn check_recovery_preconditions(config: &Configuration, workflow_id: i64) -> Res
 
     if active_scn.total_count > 0 {
         return Err(
-            "Cannot recover: there are active Slurm allocations still running. \
-             Wait for all workers to exit."
+            "there are active Slurm allocations still running; wait for all workers to exit"
                 .to_string(),
         );
     }
+
+    Ok(())
+}
+
+/// Check that the workflow is in a valid state for recovery:
+/// - Workflow must be complete (all jobs in terminal state)
+/// - No active workers (compute nodes or scheduled compute nodes)
+/// - There must be at least one recoverable job
+fn check_recovery_preconditions(config: &Configuration, workflow_id: i64) -> Result<(), String> {
+    // Delegate quiescence checks (1–4) to the shared helper
+    check_workflow_quiesced(config, workflow_id)
+        .map_err(|msg| format!("Cannot recover: {}", msg))?;
 
     // Check that there are actually recoverable jobs. The reset path
     // (`reset_failed_jobs_only`) resets failed, terminated, canceled, and pending_failed jobs, so

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -680,6 +680,24 @@ where
                     {
                         app.request_job_action(JobAction::Retry);
                     }
+                    KeyCode::Char('U')
+                        if app.focus == Focus::Details
+                            && app.detail_view == DetailViewType::Jobs =>
+                    {
+                        app.request_job_action(JobAction::ResetStatus);
+                    }
+                    KeyCode::Char(' ')
+                        if app.focus == Focus::Details
+                            && app.detail_view == DetailViewType::Jobs =>
+                    {
+                        app.toggle_job_selection();
+                    }
+                    KeyCode::Char('*')
+                        if app.focus == Focus::Details
+                            && app.detail_view == DetailViewType::Jobs =>
+                    {
+                        app.toggle_select_all_jobs();
+                    }
                     // Sort the Results table by column index (left-to-right
                     // among sortable columns — every column except Status):
                     // 1=ID, 2=Job ID, 3=Name, 4=Return, 5=Runtime,

--- a/src/tui/README.md
+++ b/src/tui/README.md
@@ -27,7 +27,7 @@ torc tui
 
 - **View job details** including full command and status
 - **View job logs** (stdout/stderr) with search and navigation
-- **Cancel**, **terminate**, or **retry** individual jobs
+- **Cancel**, **terminate**, **retry**, or **reset** individual jobs
 - Color-coded job status for quick visual scanning
 
 ### Real-time Monitoring
@@ -214,11 +214,22 @@ Press `l` to view logs:
 
 From the Jobs tab, select a job and use:
 
-| Key | Action    | When to use                              |
-| --- | --------- | ---------------------------------------- |
-| `c` | Cancel    | Stop a pending or running job gracefully |
-| `t` | Terminate | Force-stop a running job                 |
-| `y` | Retry     | Re-queue a failed job                    |
+| Key     | Action     | When to use                                                                                            |
+| ------- | ---------- | ------------------------------------------------------------------------------------------------------ |
+| `c`     | Cancel     | Stop a pending or running job gracefully                                                               |
+| `t`     | Terminate  | Force-stop a running job                                                                               |
+| `y`     | Retry      | Re-queue a failed job                                                                                  |
+| `Space` | Select     | Toggle the current job in the multi-reset selection (and move down)                                    |
+| `*`     | Select all | Select every listed job; press again to clear the selection                                            |
+| `U`     | Reset      | Reset the selected (or current) job(s) to uninitialized for selective rerun (`torc jobs reset-status`) |
+
+To rerun a batch of jobs: filter the Jobs tab (`f`, e.g. by Failed status), press `*` to select all
+listed jobs, `Space` to deselect any you want to keep, then `U` to reset them in one operation.
+Selected jobs are marked with `●` and counted in the pane title.
+
+Resetting warns if any selected job completed successfully (its results are discarded). After
+resetting, re-initialize the workflow (`I`) so downstream dependents are reset too, then run or
+submit it.
 
 ### 8. Viewing Files
 
@@ -342,14 +353,17 @@ Switch to the DAG tab to see job dependencies:
 
 ### Job Actions (Jobs tab only)
 
-| Key     | Action           |
-| ------- | ---------------- |
-| `Enter` | View job details |
-| `l`     | View job logs    |
-| `c`     | Cancel job       |
-| `t`     | Terminate job    |
-| `y`     | Retry failed job |
-| `f`     | Filter jobs      |
+| Key     | Action                    |
+| ------- | ------------------------- |
+| `Enter` | View job details          |
+| `l`     | View job logs             |
+| `c`     | Cancel job                |
+| `t`     | Terminate job             |
+| `y`     | Retry failed job          |
+| `Space` | Toggle job selection      |
+| `*`     | Select all / clear        |
+| `U`     | Reset selected job status |
+| `f`     | Filter jobs               |
 
 ### File Actions (Files tab only)
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -146,6 +146,7 @@ pub enum JobAction {
     Cancel,
     Terminate,
     Retry,
+    ResetStatus,
 }
 
 impl JobAction {
@@ -154,6 +155,11 @@ impl JobAction {
             Self::Cancel => format!("Cancel job '{}'?", job_name),
             Self::Terminate => format!("Terminate job '{}'?", job_name),
             Self::Retry => format!("Retry job '{}'?", job_name),
+            Self::ResetStatus => format!(
+                "Reset job '{}' to uninitialized for rerun?\n\
+                 Downstream dependents are reset when the workflow is re-initialized ('I').",
+                job_name
+            ),
         }
     }
 }
@@ -185,6 +191,7 @@ pub enum PopupType {
 pub enum PendingAction {
     Workflow(WorkflowAction, i64, String), // action, workflow_id, workflow_name
     Job(JobAction, i64, String),           // action, job_id, job_name
+    JobsResetStatus(Vec<i64>),             // multi-selection reset (job_ids)
 }
 
 impl DetailViewType {
@@ -676,6 +683,11 @@ pub struct App {
     pub jobs_workflow_id: Option<i64>,
     pub jobs_state: TableState,
     pub jobs_sort: JobsSort,
+    /// Job IDs marked on the Jobs tab (Space / '*') for a multi-job
+    /// reset-status. Cleared when the selected workflow changes; stale IDs
+    /// (e.g. from a row no longer listed after a filter change) are ignored
+    /// at action time by intersecting with the currently-listed jobs.
+    pub selected_job_ids: std::collections::HashSet<i64>,
     /// Offset of the currently-loaded Jobs page on the Jobs detail tab.
     pub jobs_offset: i64,
     /// True when the last Jobs-tab fetch filled a full page.
@@ -830,6 +842,7 @@ impl App {
             jobs_all: Vec::new(),
             jobs_workflow_id: None,
             jobs_state: TableState::default(),
+            selected_job_ids: std::collections::HashSet::new(),
             jobs_sort: JobsSort::None,
             jobs_offset: 0,
             jobs_has_more: false,
@@ -1303,6 +1316,7 @@ impl App {
                 if self.filter_target == FilterTarget::Details {
                     self.filter = None;
                 }
+                self.selected_job_ids.clear();
             }
             self.selected_workflow_id = workflow_id_opt;
             if let Some(workflow_id) = workflow_id_opt {
@@ -3361,6 +3375,12 @@ impl App {
                         self.set_status(StatusMessage::error(&format!("Action error: {}", e)));
                     }
                 }
+                PendingAction::JobsResetStatus(job_ids) => {
+                    let description = format!("{} job(s)", job_ids.len());
+                    if let Err(e) = self.reset_jobs_status_cli(&job_ids, &description) {
+                        self.set_status(StatusMessage::error(&format!("Action error: {}", e)));
+                    }
+                }
             }
         }
         Ok(())
@@ -3472,15 +3492,11 @@ impl App {
             workflow_name
         )));
 
-        let exe_path = self.get_torc_exe_path();
-        let url = self.client.get_base_url();
         let workflow_id_str = workflow_id.to_string();
 
         // First, do a dry-run check to see if there are existing output files
-        let check_output = std::process::Command::new(&exe_path)
-            .args([
-                "--url",
-                url,
+        let check_output = self
+            .torc_cli_command(&[
                 "-f",
                 "json",
                 "workflows",
@@ -3591,23 +3607,14 @@ impl App {
         workflow_name: &str,
         force: bool,
     ) -> Result<()> {
-        let exe_path = self.get_torc_exe_path();
-        let url = self.client.get_base_url();
         let workflow_id_str = workflow_id.to_string();
 
-        let mut args = vec![
-            "--url",
-            &url,
-            "workflows",
-            "init",
-            "--no-prompts",
-            &workflow_id_str,
-        ];
+        let mut args = vec!["workflows", "init", "--no-prompts", &workflow_id_str];
         if force {
             args.push("--force");
         }
 
-        let output = std::process::Command::new(&exe_path).args(&args).output();
+        let output = self.torc_cli_command(&args).output();
 
         match output {
             Ok(output) => {
@@ -3657,16 +3664,14 @@ impl App {
         workflow_name: &str,
         force: bool,
     ) -> Result<()> {
-        let exe_path = self.get_torc_exe_path();
-        let url = self.client.get_base_url();
         let workflow_id_str = workflow_id.to_string();
 
-        let mut args = vec!["--url", &url, "workflows", "reinit", &workflow_id_str];
+        let mut args = vec!["workflows", "reinit", &workflow_id_str];
         if force {
             args.push("--force");
         }
 
-        let output = std::process::Command::new(&exe_path).args(&args).output();
+        let output = self.torc_cli_command(&args).output();
 
         match output {
             Ok(output) => {
@@ -3705,15 +3710,11 @@ impl App {
 
     /// Reset workflow status using CLI command (following torc-dash pattern)
     fn reset_workflow_cli(&mut self, workflow_id: i64, workflow_name: &str) -> Result<()> {
-        let exe_path = self.get_torc_exe_path();
-        let url = self.client.get_base_url();
         let workflow_id_str = workflow_id.to_string();
 
-        // Run CLI command: torc --url <url> workflows reset-status --no-prompts <workflow_id>
-        let output = std::process::Command::new(&exe_path)
-            .args([
-                "--url",
-                url,
+        // Run CLI command: torc workflows reset-status --no-prompts <workflow_id>
+        let output = self
+            .torc_cli_command(&[
                 "workflows",
                 "reset-status",
                 "--no-prompts",
@@ -3756,6 +3757,55 @@ impl App {
         Ok(())
     }
 
+    /// Reset one or more jobs to uninitialized using the CLI command
+    /// (following the reset_workflow_cli pattern). The CLI enforces the safety
+    /// checks: no active workers and no job may be Running or Pending.
+    /// `description` is used in the success message (e.g. "Job 'x'" or
+    /// "3 job(s)").
+    fn reset_jobs_status_cli(&mut self, job_ids: &[i64], description: &str) -> Result<()> {
+        let id_strs: Vec<String> = job_ids.iter().map(|id| id.to_string()).collect();
+        let mut args: Vec<&str> = vec!["jobs", "reset-status", "--no-prompts"];
+        args.extend(id_strs.iter().map(|s| s.as_str()));
+
+        let output = self.torc_cli_command(&args).output();
+
+        match output {
+            Ok(output) => {
+                if output.status.success() {
+                    self.selected_job_ids.clear();
+                    self.set_status(StatusMessage::success(&format!(
+                        "{} reset to uninitialized — press 'I' to re-initialize, then \
+                         run/submit",
+                        description
+                    )));
+                    let _ = self.load_detail_data();
+                } else {
+                    let stderr = String::from_utf8_lossy(&output.stderr);
+                    let stdout = String::from_utf8_lossy(&output.stdout);
+                    let error_msg = if !stderr.trim().is_empty() {
+                        stderr.trim().to_string()
+                    } else if !stdout.trim().is_empty() {
+                        stdout.trim().to_string()
+                    } else {
+                        "Unknown error".to_string()
+                    };
+                    self.set_status(StatusMessage::error(&format!(
+                        "Job reset failed: {}",
+                        error_msg
+                    )));
+                }
+            }
+            Err(e) => {
+                self.set_status(StatusMessage::error(&format!(
+                    "Failed to run jobs reset-status command: {}",
+                    e
+                )));
+            }
+        }
+
+        Ok(())
+    }
+
     /// Get the path to the torc executable
     fn get_torc_exe_path(&self) -> String {
         std::env::current_exe()
@@ -3763,17 +3813,36 @@ impl App {
             .unwrap_or_else(|_| "torc".to_string())
     }
 
+    /// Build a `torc` CLI invocation that connects to the same server as the
+    /// TUI's own API client: forwards `--url` and the TLS flags, and passes
+    /// the basic-auth password via the TORC_PASSWORD environment variable so
+    /// it stays out of process listings. The username needs no forwarding —
+    /// the CLI derives it from the USER environment variable, same as the
+    /// TUI. The cookie header (TORC_COOKIE_HEADER) is already inherited
+    /// through the environment.
+    fn torc_cli_command(&self, args: &[&str]) -> std::process::Command {
+        let mut cmd = std::process::Command::new(self.get_torc_exe_path());
+        cmd.arg("--url").arg(self.client.get_base_url());
+        if let Some(ref ca_cert) = self.tls.ca_cert_path {
+            cmd.arg("--tls-ca-cert").arg(ca_cert);
+        }
+        if self.tls.insecure {
+            cmd.arg("--tls-insecure");
+        }
+        if let Some((_, Some(password))) = &self.basic_auth {
+            cmd.env("TORC_PASSWORD", password);
+        }
+        cmd.args(args);
+        cmd
+    }
+
     fn run_workflow_with_viewer(&mut self, workflow_id: i64, workflow_name: &str) -> Result<()> {
         let mut viewer = ProcessViewer::new(format!("Running: {}", workflow_name));
 
-        let exe_path = self.get_torc_exe_path();
-
-        // Build arguments - note: --url is a global option, must come before subcommand
         let workflow_id_str = workflow_id.to_string();
-        let url = self.client.get_base_url();
-        let args = vec!["--url", &url, "run", &workflow_id_str];
+        let cmd = self.torc_cli_command(&["run", &workflow_id_str]);
 
-        match viewer.start(&exe_path, &args) {
+        match viewer.start(cmd) {
             Ok(()) => {
                 self.previous_focus = self.focus;
                 self.focus = Focus::Popup;
@@ -3807,32 +3876,15 @@ impl App {
         };
         let mut viewer = ProcessViewer::new(title);
 
-        let exe_path = self.get_torc_exe_path();
-
-        // Build arguments - note: --url is a global option, must come before subcommand
         let workflow_id_str = workflow_id.to_string();
-        let url = self.client.get_base_url();
 
         let args: Vec<&str> = if recover {
-            vec![
-                "--url",
-                &url,
-                "watch",
-                &workflow_id_str,
-                "--recover",
-                "--show-job-counts",
-            ]
+            vec!["watch", &workflow_id_str, "--recover", "--show-job-counts"]
         } else {
-            vec![
-                "--url",
-                &url,
-                "watch",
-                &workflow_id_str,
-                "--show-job-counts",
-            ]
+            vec!["watch", &workflow_id_str, "--show-job-counts"]
         };
 
-        match viewer.start(&exe_path, &args) {
+        match viewer.start(self.torc_cli_command(&args)) {
             Ok(()) => {
                 self.previous_focus = self.focus;
                 self.focus = Focus::Popup;
@@ -3870,9 +3922,7 @@ impl App {
         };
         let mut viewer = ProcessViewer::new(title);
 
-        let exe_path = self.get_torc_exe_path();
         let workflow_id_str = workflow_id.to_string();
-        let url = self.client.get_base_url();
         let output_dir = self.output_dir.display().to_string();
         let mem_str = format!("{}", memory_multiplier);
         let rt_str = format!("{}", runtime_multiplier);
@@ -3880,8 +3930,6 @@ impl App {
         // --no-prompts is required because the interactive wizard would
         // try to read from stdin, which the TUI owns.
         let mut args = vec![
-            "--url",
-            &url,
             "recover",
             &workflow_id_str,
             "--output-dir",
@@ -3896,7 +3944,7 @@ impl App {
             args.push("--dry-run");
         }
 
-        match viewer.start(&exe_path, &args) {
+        match viewer.start(self.torc_cli_command(&args)) {
             Ok(()) => {
                 self.previous_focus = self.focus;
                 self.focus = Focus::Popup;
@@ -4016,17 +4064,106 @@ impl App {
             .and_then(|idx| self.jobs.get(idx))
     }
 
+    /// Toggle multi-reset selection on the job under the cursor, then advance
+    /// to the next row so repeated presses sweep down the list.
+    pub fn toggle_job_selection(&mut self) {
+        if let Some(job_id) = self.get_selected_job().and_then(|j| j.id) {
+            if !self.selected_job_ids.insert(job_id) {
+                self.selected_job_ids.remove(&job_id);
+            }
+            self.next_in_active_table();
+        } else {
+            self.set_status(StatusMessage::warning("No job selected"));
+        }
+    }
+
+    /// Select every currently-listed job (respecting the active filter), or
+    /// clear the selection if all listed jobs are already selected.
+    pub fn toggle_select_all_jobs(&mut self) {
+        let listed: Vec<i64> = self.jobs.iter().filter_map(|j| j.id).collect();
+        if listed.is_empty() {
+            self.set_status(StatusMessage::warning("No jobs listed"));
+            return;
+        }
+        if listed.iter().all(|id| self.selected_job_ids.contains(id)) {
+            self.selected_job_ids.clear();
+            self.set_status(StatusMessage::info("Selection cleared"));
+        } else {
+            self.selected_job_ids.extend(&listed);
+            self.set_status(StatusMessage::info(&format!(
+                "Selected {} listed job(s)",
+                listed.len()
+            )));
+        }
+    }
+
+    /// Request a reset for every selected job that is currently listed.
+    /// Returns false when the selection is empty so the caller can fall back
+    /// to the single-job (cursor row) path.
+    fn request_selected_jobs_reset(&mut self) -> bool {
+        // Intersect with the listed jobs: selections made under an earlier
+        // filter may reference rows that are no longer shown, and acting on
+        // invisible jobs would be surprising.
+        let targets: Vec<&JobModel> = self
+            .jobs
+            .iter()
+            .filter(|j| j.id.is_some_and(|id| self.selected_job_ids.contains(&id)))
+            .collect();
+        if targets.is_empty() {
+            return false;
+        }
+
+        let completed = targets
+            .iter()
+            .filter(|j| j.status == Some(JobStatus::Completed))
+            .count();
+        let mut message = format!(
+            "Reset {} selected job(s) to uninitialized for rerun?\n\
+             Downstream dependents are reset when the workflow is re-initialized ('I').",
+            targets.len()
+        );
+        if completed > 0 {
+            message.push_str(&format!(
+                "\nWarning: {} of them completed successfully; resetting discards their \
+                 results and reruns them.",
+                completed
+            ));
+        }
+
+        let job_ids: Vec<i64> = targets.iter().filter_map(|j| j.id).collect();
+        self.previous_focus = self.focus;
+        self.focus = Focus::Popup;
+        self.popup = Some(PopupType::Confirmation {
+            dialog: ConfirmationDialog::new("Reset Job Statuses", &message),
+            action: PendingAction::JobsResetStatus(job_ids),
+        });
+        true
+    }
+
     pub fn request_job_action(&mut self, action: JobAction) {
+        if action == JobAction::ResetStatus && self.request_selected_jobs_reset() {
+            return;
+        }
+
         if let Some(job) = self.get_selected_job() {
             if let Some(job_id) = job.id {
                 let job_name = job.name.clone();
+                let job_status = job.status;
+                let mut message = action.confirmation_message(&job_name);
+                if action == JobAction::ResetStatus && job_status == Some(JobStatus::Completed) {
+                    message.push_str(
+                        "\nWarning: this job completed successfully; resetting discards its \
+                         results and reruns it.",
+                    );
+                }
                 let dialog = ConfirmationDialog::new(
                     match action {
                         JobAction::Cancel => "Cancel Job",
                         JobAction::Terminate => "Terminate Job",
                         JobAction::Retry => "Retry Job",
+                        JobAction::ResetStatus => "Reset Job Status",
                     },
-                    &action.confirmation_message(&job_name),
+                    &message,
                 );
 
                 self.previous_focus = self.focus;
@@ -4042,10 +4179,15 @@ impl App {
     }
 
     fn execute_job_action(&mut self, action: JobAction, job_id: i64, job_name: &str) -> Result<()> {
+        if action == JobAction::ResetStatus {
+            return self.reset_jobs_status_cli(&[job_id], &format!("Job '{}'", job_name));
+        }
+
         let result = match action {
             JobAction::Cancel => self.client.cancel_job(job_id),
             JobAction::Terminate => self.client.terminate_job(job_id),
             JobAction::Retry => self.client.retry_job(job_id),
+            JobAction::ResetStatus => unreachable!("handled above"),
         };
 
         match result {
@@ -4054,6 +4196,7 @@ impl App {
                     JobAction::Cancel => format!("Job '{}' canceled", job_name),
                     JobAction::Terminate => format!("Job '{}' terminated", job_name),
                     JobAction::Retry => format!("Job '{}' queued for retry", job_name),
+                    JobAction::ResetStatus => unreachable!("handled above"),
                 };
                 self.set_status(StatusMessage::success(&msg));
 
@@ -4551,9 +4694,10 @@ impl App {
             .unwrap_or(8080);
 
         let port_str = port.to_string();
-        let args = vec!["run", "--port", &port_str];
+        let mut cmd = std::process::Command::new(&server_path);
+        cmd.args(["run", "--port", &port_str]);
 
-        match viewer.start(&server_path, &args) {
+        match viewer.start(cmd) {
             Ok(()) => {
                 self.server_process = Some(viewer);
                 self.set_status(StatusMessage::success(&format!(
@@ -4619,15 +4763,13 @@ impl App {
         let port_str = port.to_string();
 
         // Build args with optional database path
-        let mut args = vec!["run", "--port", &port_str];
-        let db_path;
+        let mut cmd = std::process::Command::new(&server_path);
+        cmd.args(["run", "--port", &port_str]);
         if let Some(ref db) = self.standalone_database {
-            db_path = db.clone();
-            args.push("--database");
-            args.push(&db_path);
+            cmd.arg("--database").arg(db);
         }
 
-        match viewer.start(&server_path, &args) {
+        match viewer.start(cmd) {
             Ok(()) => {
                 self.server_process = Some(viewer);
             }

--- a/src/tui/components.rs
+++ b/src/tui/components.rs
@@ -56,8 +56,22 @@ impl ConfirmationDialog {
 
     pub fn render(&self, f: &mut Frame, area: Rect) {
         // Calculate dialog size - center in screen
-        let dialog_width = 50.min(area.width.saturating_sub(4));
-        let dialog_height = 7.min(area.height.saturating_sub(2));
+        let dialog_width = 60.min(area.width.saturating_sub(4));
+        // Estimate the wrapped height of the message so multi-line content
+        // (e.g. the multi-job reset warning) is not clipped. Wrapping is
+        // word-based, so estimate against a slightly narrower width than the
+        // real text area to err on the tall side.
+        let text_width = dialog_width.saturating_sub(6).max(1) as usize;
+        let message_lines: u16 = self
+            .message
+            .lines()
+            .map(|l| l.chars().count().div_ceil(text_width).max(1) as u16)
+            .sum();
+        // .max then .min (not clamp): on a terminal shorter than 9 rows the
+        // upper bound drops below the lower one, which would make clamp panic.
+        let dialog_height = (message_lines + 3)
+            .max(7)
+            .min(area.height.saturating_sub(2));
 
         let dialog_x = (area.width.saturating_sub(dialog_width)) / 2;
         let dialog_y = (area.height.saturating_sub(dialog_height)) / 2;
@@ -557,6 +571,18 @@ impl HelpPopup {
                 lines.push(Self::key_line("C", "Cancel job"));
                 lines.push(Self::key_line("t", "Terminate job"));
                 lines.push(Self::key_line("y", "Retry failed job"));
+                lines.push(Self::key_line(
+                    "Space",
+                    "Toggle job selection for multi-reset",
+                ));
+                lines.push(Self::key_line(
+                    "*",
+                    "Select all listed jobs / clear selection",
+                ));
+                lines.push(Self::key_line(
+                    "U",
+                    "Reset selected (or current) job(s) to uninitialized for rerun",
+                ));
                 lines.push(Self::key_line("1 / 2 / 3", "Sort by ID / Name / Status"));
             }
             HelpContext::DetailRunning => {
@@ -1570,10 +1596,10 @@ impl ProcessViewer {
         }
     }
 
-    /// Start a process and capture its output
-    pub fn start(&mut self, program: &str, args: &[&str]) -> Result<(), String> {
-        let mut cmd = Command::new(program);
-        cmd.args(args).stdout(Stdio::piped()).stderr(Stdio::piped());
+    /// Start a process and capture its output. Takes a prebuilt `Command` so
+    /// callers can attach connection arguments and environment variables.
+    pub fn start(&mut self, mut cmd: Command) -> Result<(), String> {
+        cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
 
         let mut child = cmd
             .spawn()
@@ -1607,8 +1633,16 @@ impl ProcessViewer {
         self.child = Some(child);
         self.output_receiver = Some(rx);
         self.is_running = true;
-        self.output_lines
-            .push(format!("Started: {} {}", program, args.join(" ")));
+        let args_display = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy())
+            .collect::<Vec<_>>()
+            .join(" ");
+        self.output_lines.push(format!(
+            "Started: {} {}",
+            cmd.get_program().to_string_lossy(),
+            args_display
+        ));
         self.output_lines.push(String::new());
 
         Ok(())

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -244,6 +244,12 @@ fn draw_help(f: &mut Frame, area: Rect, app: &App) {
             Span::raw(": terminate | "),
             Span::styled("y", Style::default().fg(Color::Yellow)),
             Span::raw(": retry | "),
+            Span::styled("Space", Style::default().fg(Color::Yellow)),
+            Span::raw(": select | "),
+            Span::styled("*", Style::default().fg(Color::Yellow)),
+            Span::raw(": select all | "),
+            Span::styled("U", Style::default().fg(Color::Yellow)),
+            Span::raw(": reset | "),
             Span::styled("f", Style::default().fg(Color::Yellow)),
             Span::raw(": filter | "),
             Span::styled("Tab", Style::default().fg(Color::Yellow)),
@@ -878,7 +884,13 @@ fn draw_jobs_table(f: &mut Frame, area: Rect, app: &mut App) {
     .bottom_margin(1);
 
     let rows = app.jobs.iter().map(|job| {
-        let id = job.id.map(|i| i.to_string()).unwrap_or_default();
+        let selected = job.id.is_some_and(|id| app.selected_job_ids.contains(&id));
+        let marker = if selected { "● " } else { "  " };
+        let id = format!(
+            "{}{}",
+            marker,
+            job.id.map(|i| i.to_string()).unwrap_or_default()
+        );
         let name = job.name.clone();
         let (status_str, color) = match job.status {
             Some(s) => (format!("{:?}", s), status_color(s)),
@@ -896,8 +908,13 @@ fn draw_jobs_table(f: &mut Frame, area: Rect, app: &mut App) {
         };
         let command = job.command.clone();
 
+        let id_style = if selected {
+            Style::default().fg(Color::Yellow)
+        } else {
+            Style::default()
+        };
         Row::new(vec![
-            Cell::from(id),
+            Cell::from(Span::styled(id, id_style)),
             Cell::from(name),
             Cell::from(Span::styled(status_str, Style::default().fg(color))),
             Cell::from(node),
@@ -908,15 +925,21 @@ fn draw_jobs_table(f: &mut Frame, area: Rect, app: &mut App) {
 
     let filter = filter_suffix(app, FilterTarget::Details);
     let page = page_suffix(app.jobs_offset, app.jobs_has_more);
+    let selection = if app.selected_job_ids.is_empty() {
+        String::new()
+    } else {
+        format!(" [{} selected]", app.selected_job_ids.len())
+    };
     let (title, border_style) = if app.focus == Focus::Details {
         (
             Line::from(vec![
                 Span::styled("▶ ", Style::default().fg(Color::Green)),
                 Span::styled("Jobs", Style::default().fg(Color::White)),
                 Span::styled(filter, Style::default().fg(Color::Magenta)),
+                Span::styled(selection.clone(), Style::default().fg(Color::Yellow)),
                 Span::styled(page, Style::default().fg(Color::DarkGray)),
                 Span::styled(
-                    " │ Enter: details  l: logs  C: cancel  t: terminate  y: retry  │ sort: 1 id  2 name  3 status",
+                    " │ Enter: details  l: logs  Space: select  *: all  C: cancel  t: terminate  y: retry  U: reset  │ sort: 1 id  2 name  3 status",
                     Style::default().fg(Color::DarkGray),
                 ),
             ]),
@@ -928,6 +951,7 @@ fn draw_jobs_table(f: &mut Frame, area: Rect, app: &mut App) {
                 Span::styled("▶ ", Style::default().fg(Color::Cyan)),
                 Span::styled("Jobs", Style::default().fg(Color::White)),
                 Span::styled(filter, Style::default().fg(Color::Magenta)),
+                Span::styled(selection, Style::default().fg(Color::Yellow)),
                 Span::styled(page, Style::default().fg(Color::DarkGray)),
             ]),
             Style::default().fg(Color::DarkGray),
@@ -937,7 +961,7 @@ fn draw_jobs_table(f: &mut Frame, area: Rect, app: &mut App) {
     let table = Table::new(
         rows,
         [
-            Constraint::Length(8),
+            Constraint::Length(10),
             Constraint::Length(20),
             Constraint::Length(15),
             Constraint::Length(6),

--- a/tests/test_jobs_reset_status.rs
+++ b/tests/test_jobs_reset_status.rs
@@ -1,0 +1,711 @@
+mod common;
+
+use common::{
+    ServerProcess, create_test_compute_node, create_test_workflow, run_cli_with_json, start_server,
+};
+use rstest::rstest;
+use torc::client::apis;
+use torc::client::workflow_manager::WorkflowManager;
+use torc::config::TorcConfig;
+use torc::models;
+use torc::models::JobStatus;
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/// Initialize a freshly-created workflow and return its run_id.
+fn initialize_workflow(
+    config: &torc::client::Configuration,
+    workflow: &models::WorkflowModel,
+) -> i64 {
+    let workflow_id = workflow.id.unwrap();
+    let torc_config = TorcConfig::load().unwrap_or_default();
+    let manager = WorkflowManager::new(config.clone(), torc_config, workflow.clone());
+    manager
+        .initialize(false)
+        .expect("Failed to initialize workflow");
+    apis::workflows_api::get_workflow(config, workflow_id)
+        .expect("Failed to get workflow after init")
+        .run_id
+        .unwrap_or(1)
+}
+
+/// Complete a job via complete_job (never via manage_status_change per CLAUDE.md).
+fn complete_job(
+    config: &torc::client::Configuration,
+    job_id: i64,
+    workflow_id: i64,
+    compute_node_id: i64,
+    run_id: i64,
+    return_code: i64,
+    status: JobStatus,
+) {
+    let result = models::ResultModel::new(
+        job_id,
+        workflow_id,
+        run_id,
+        1, // attempt_id
+        compute_node_id,
+        return_code,
+        1.0, // exec_time_minutes
+        chrono::Utc::now().to_rfc3339(),
+        status,
+    );
+    apis::jobs_api::complete_job(config, job_id, status, run_id, result)
+        .unwrap_or_else(|e| panic!("Failed to complete job {}: {}", job_id, e));
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: Selective reset — only targeted jobs are reset, others unchanged
+// ---------------------------------------------------------------------------
+#[rstest]
+fn test_reset_status_selective(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let workflow = create_test_workflow(config, "reset_selective");
+    let workflow_id = workflow.id.unwrap();
+
+    // Create 3 independent jobs
+    let job1 = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(workflow_id, "job1".to_string(), "echo job1".to_string()),
+    )
+    .expect("Failed to create job1");
+    let job1_id = job1.id.unwrap();
+
+    let job2 = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(workflow_id, "job2".to_string(), "echo job2".to_string()),
+    )
+    .expect("Failed to create job2");
+    let job2_id = job2.id.unwrap();
+
+    let job3 = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(workflow_id, "job3".to_string(), "echo job3".to_string()),
+    )
+    .expect("Failed to create job3");
+    let job3_id = job3.id.unwrap();
+
+    let run_id = initialize_workflow(config, &workflow);
+    let compute_node = create_test_compute_node(config, workflow_id);
+    let cn_id = compute_node.id.unwrap();
+
+    // Advance all to running then fail them all
+    for &id in &[job1_id, job2_id, job3_id] {
+        apis::jobs_api::manage_status_change(config, id, JobStatus::Running, run_id)
+            .unwrap_or_else(|e| panic!("Failed to set job {} running: {}", id, e));
+    }
+    complete_job(
+        config,
+        job1_id,
+        workflow_id,
+        cn_id,
+        run_id,
+        1,
+        JobStatus::Failed,
+    );
+    complete_job(
+        config,
+        job2_id,
+        workflow_id,
+        cn_id,
+        run_id,
+        1,
+        JobStatus::Failed,
+    );
+    complete_job(
+        config,
+        job3_id,
+        workflow_id,
+        cn_id,
+        run_id,
+        1,
+        JobStatus::Failed,
+    );
+
+    // Reset only job1 and job2
+    let json = run_cli_with_json(
+        &[
+            "jobs",
+            "reset-status",
+            "--no-prompts",
+            &job1_id.to_string(),
+            &job2_id.to_string(),
+        ],
+        start_server,
+        None,
+    )
+    .expect("reset-status should succeed");
+
+    assert_eq!(json["status"], "success");
+    assert_eq!(json["workflow_id"], workflow_id);
+
+    // job1 and job2 must be Uninitialized; job3 must remain Failed
+    assert_eq!(
+        apis::jobs_api::get_job(config, job1_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Uninitialized,
+        "job1 should be Uninitialized"
+    );
+    assert_eq!(
+        apis::jobs_api::get_job(config, job2_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Uninitialized,
+        "job2 should be Uninitialized"
+    );
+    assert_eq!(
+        apis::jobs_api::get_job(config, job3_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Failed,
+        "job3 should remain Failed"
+    );
+
+    // Workflow run_id must be unchanged (only reinit bumps it)
+    let wf_after = apis::workflows_api::get_workflow(config, workflow_id).unwrap();
+    assert_eq!(
+        wf_after.run_id.unwrap_or(0),
+        run_id,
+        "run_id must not change on reset-status"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: Recursive downstream closure — A→B→C; reset A pulls B and C too
+// ---------------------------------------------------------------------------
+#[rstest]
+fn test_reset_status_recursive_downstream(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let workflow = create_test_workflow(config, "reset_downstream");
+    let workflow_id = workflow.id.unwrap();
+
+    // Create a linear chain: A → B → C
+    let job_a = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(workflow_id, "job_a".to_string(), "echo a".to_string()),
+    )
+    .expect("Failed to create job_a");
+    let a_id = job_a.id.unwrap();
+
+    let mut job_b_model =
+        models::JobModel::new(workflow_id, "job_b".to_string(), "echo b".to_string());
+    job_b_model.depends_on_job_ids = Some(vec![a_id]);
+    job_b_model.cancel_on_blocking_job_failure = Some(false);
+    let job_b = apis::jobs_api::create_job(config, job_b_model).expect("Failed to create job_b");
+    let b_id = job_b.id.unwrap();
+
+    let mut job_c_model =
+        models::JobModel::new(workflow_id, "job_c".to_string(), "echo c".to_string());
+    job_c_model.depends_on_job_ids = Some(vec![b_id]);
+    job_c_model.cancel_on_blocking_job_failure = Some(false);
+    let job_c = apis::jobs_api::create_job(config, job_c_model).expect("Failed to create job_c");
+    let c_id = job_c.id.unwrap();
+
+    let run_id = initialize_workflow(config, &workflow);
+    let compute_node = create_test_compute_node(config, workflow_id);
+    let cn_id = compute_node.id.unwrap();
+
+    // Complete all three successfully (chain A→B→C all done)
+    apis::jobs_api::manage_status_change(config, a_id, JobStatus::Running, run_id)
+        .expect("set a running");
+    complete_job(
+        config,
+        a_id,
+        workflow_id,
+        cn_id,
+        run_id,
+        0,
+        JobStatus::Completed,
+    );
+
+    // After A completes, unblocking fires and B becomes ready
+    // Advance B to running and complete it
+    apis::jobs_api::manage_status_change(config, b_id, JobStatus::Running, run_id)
+        .expect("set b running");
+    complete_job(
+        config,
+        b_id,
+        workflow_id,
+        cn_id,
+        run_id,
+        0,
+        JobStatus::Completed,
+    );
+
+    // After B completes, C becomes ready
+    apis::jobs_api::manage_status_change(config, c_id, JobStatus::Running, run_id)
+        .expect("set c running");
+    complete_job(
+        config,
+        c_id,
+        workflow_id,
+        cn_id,
+        run_id,
+        0,
+        JobStatus::Completed,
+    );
+
+    // Sanity: all completed
+    assert_eq!(
+        apis::jobs_api::get_job(config, a_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Completed
+    );
+    assert_eq!(
+        apis::jobs_api::get_job(config, b_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Completed
+    );
+    assert_eq!(
+        apis::jobs_api::get_job(config, c_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Completed
+    );
+
+    // Reset only A — the BFS closure should pull in B and C
+    let json = run_cli_with_json(
+        &[
+            "jobs",
+            "reset-status",
+            "--no-prompts",
+            "--force",
+            &a_id.to_string(),
+        ],
+        start_server,
+        None,
+    )
+    .expect("reset-status should succeed");
+
+    assert_eq!(json["status"], "success");
+
+    // A, B, and C must all be Uninitialized now
+    assert_eq!(
+        apis::jobs_api::get_job(config, a_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Uninitialized,
+        "A should be Uninitialized"
+    );
+    assert_eq!(
+        apis::jobs_api::get_job(config, b_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Uninitialized,
+        "B should be Uninitialized (downstream closure)"
+    );
+    assert_eq!(
+        apis::jobs_api::get_job(config, c_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Uninitialized,
+        "C should be Uninitialized (transitive downstream closure)"
+    );
+
+    // Check that reset_job_ids includes all three
+    let reset_ids = json["reset_job_ids"]
+        .as_array()
+        .expect("reset_job_ids should be an array");
+    assert_eq!(reset_ids.len(), 3, "should have reset 3 jobs");
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: Cross-workflow rejection — IDs from two workflows → hard error,
+//         nothing reset in either workflow
+// ---------------------------------------------------------------------------
+#[rstest]
+fn test_reset_status_cross_workflow_rejected(start_server: &ServerProcess) {
+    let config = &start_server.config;
+
+    let wf1 = create_test_workflow(config, "reset_xwf1");
+    let wf2 = create_test_workflow(config, "reset_xwf2");
+    let wf1_id = wf1.id.unwrap();
+    let wf2_id = wf2.id.unwrap();
+
+    let job_in_wf1 = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(wf1_id, "j1".to_string(), "echo 1".to_string()),
+    )
+    .expect("create j1");
+    let j1_id = job_in_wf1.id.unwrap();
+
+    let job_in_wf2 = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(wf2_id, "j2".to_string(), "echo 2".to_string()),
+    )
+    .expect("create j2");
+    let j2_id = job_in_wf2.id.unwrap();
+
+    initialize_workflow(config, &wf1);
+    initialize_workflow(config, &wf2);
+
+    // Attempt to reset jobs from two different workflows — must fail
+    let result = run_cli_with_json(
+        &[
+            "jobs",
+            "reset-status",
+            "--no-prompts",
+            "--force",
+            &j1_id.to_string(),
+            &j2_id.to_string(),
+        ],
+        start_server,
+        None,
+    );
+    assert!(result.is_err(), "Should fail for cross-workflow IDs");
+
+    // Neither job should have been touched
+    assert_eq!(
+        apis::jobs_api::get_job(config, j1_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Ready,
+        "j1 should still be Ready (untouched)"
+    );
+    assert_eq!(
+        apis::jobs_api::get_job(config, j2_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Ready,
+        "j2 should still be Ready (untouched)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: Unknown ID → clear error, nothing reset
+// ---------------------------------------------------------------------------
+#[rstest]
+fn test_reset_status_unknown_id(start_server: &ServerProcess) {
+    let result = run_cli_with_json(
+        &[
+            "jobs",
+            "reset-status",
+            "--no-prompts",
+            "--force",
+            "999999999",
+        ],
+        start_server,
+        None,
+    );
+    assert!(result.is_err(), "Should fail for unknown job ID");
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: Active-job guard — Running job rejected without --force,
+//         proceeds with --force
+// ---------------------------------------------------------------------------
+#[rstest]
+fn test_reset_status_active_job_guard(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let workflow = create_test_workflow(config, "reset_active_guard");
+    let workflow_id = workflow.id.unwrap();
+
+    let job = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(
+            workflow_id,
+            "active_job".to_string(),
+            "sleep 60".to_string(),
+        ),
+    )
+    .expect("create job");
+    let job_id = job.id.unwrap();
+
+    let run_id = initialize_workflow(config, &workflow);
+
+    // Set job to Running (using manage_status_change — legitimate for advancing to Running)
+    apis::jobs_api::manage_status_change(config, job_id, JobStatus::Running, run_id)
+        .expect("set running");
+
+    // Without --force: should be rejected because of Running status
+    let result_no_force = run_cli_with_json(
+        &["jobs", "reset-status", "--no-prompts", &job_id.to_string()],
+        start_server,
+        None,
+    );
+    assert!(
+        result_no_force.is_err(),
+        "Should fail for Running job without --force"
+    );
+    // Job must still be Running
+    assert_eq!(
+        apis::jobs_api::get_job(config, job_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Running,
+        "Job should still be Running after rejected reset"
+    );
+
+    // With --force: should succeed
+    let json = run_cli_with_json(
+        &[
+            "jobs",
+            "reset-status",
+            "--no-prompts",
+            "--force",
+            &job_id.to_string(),
+        ],
+        start_server,
+        None,
+    )
+    .expect("reset-status with --force should succeed");
+
+    assert_eq!(json["status"], "success");
+    assert_eq!(
+        apis::jobs_api::get_job(config, job_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Uninitialized,
+        "Job should be Uninitialized after forced reset"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: Dry-run — no status changes occur, output lists jobs
+// ---------------------------------------------------------------------------
+#[rstest]
+fn test_reset_status_dry_run(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let workflow = create_test_workflow(config, "reset_dry_run");
+    let workflow_id = workflow.id.unwrap();
+
+    let job = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(workflow_id, "dry_job".to_string(), "echo dry".to_string()),
+    )
+    .expect("create job");
+    let job_id = job.id.unwrap();
+
+    let run_id = initialize_workflow(config, &workflow);
+    let compute_node = create_test_compute_node(config, workflow_id);
+    let cn_id = compute_node.id.unwrap();
+
+    // Complete the job
+    apis::jobs_api::manage_status_change(config, job_id, JobStatus::Running, run_id)
+        .expect("set running");
+    complete_job(
+        config,
+        job_id,
+        workflow_id,
+        cn_id,
+        run_id,
+        1,
+        JobStatus::Failed,
+    );
+
+    // Dry-run
+    let json = run_cli_with_json(
+        &[
+            "jobs",
+            "reset-status",
+            "--no-prompts",
+            "--force",
+            "--dry-run",
+            &job_id.to_string(),
+        ],
+        start_server,
+        None,
+    )
+    .expect("dry-run should succeed");
+
+    assert_eq!(json["dry_run"], true);
+    assert_eq!(json["workflow_id"], workflow_id);
+    let jobs_arr = json["jobs"].as_array().expect("should have jobs array");
+    assert!(!jobs_arr.is_empty(), "dry-run should list jobs to reset");
+
+    // Status must be unchanged (still Failed)
+    assert_eq!(
+        apis::jobs_api::get_job(config, job_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Failed,
+        "Job should still be Failed after dry-run"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 7: End-to-end flow — reset subset → reinit → reset jobs become
+//         ready/blocked, run_id bumped exactly once
+// ---------------------------------------------------------------------------
+#[rstest]
+fn test_reset_status_end_to_end_reinit(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let workflow = create_test_workflow(config, "reset_e2e_reinit");
+    let workflow_id = workflow.id.unwrap();
+
+    // A → B (B depends on A)
+    let job_a = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(workflow_id, "e2e_a".to_string(), "echo a".to_string()),
+    )
+    .expect("create a");
+    let a_id = job_a.id.unwrap();
+
+    let mut job_b_model =
+        models::JobModel::new(workflow_id, "e2e_b".to_string(), "echo b".to_string());
+    job_b_model.depends_on_job_ids = Some(vec![a_id]);
+    let job_b = apis::jobs_api::create_job(config, job_b_model).expect("create b");
+    let b_id = job_b.id.unwrap();
+
+    let run_id_before = initialize_workflow(config, &workflow);
+    let compute_node = create_test_compute_node(config, workflow_id);
+    let cn_id = compute_node.id.unwrap();
+
+    // Complete A, then complete B
+    apis::jobs_api::manage_status_change(config, a_id, JobStatus::Running, run_id_before)
+        .expect("set a running");
+    complete_job(
+        config,
+        a_id,
+        workflow_id,
+        cn_id,
+        run_id_before,
+        0,
+        JobStatus::Completed,
+    );
+
+    apis::jobs_api::manage_status_change(config, b_id, JobStatus::Running, run_id_before)
+        .expect("set b running");
+    complete_job(
+        config,
+        b_id,
+        workflow_id,
+        cn_id,
+        run_id_before,
+        1,
+        JobStatus::Failed,
+    );
+
+    // Reset only B (failed) — A is also completed and is upstream, but NOT in the closure
+    // because we only requested B, and A is not downstream of B
+    let json = run_cli_with_json(
+        &[
+            "jobs",
+            "reset-status",
+            "--no-prompts",
+            "--force",
+            &b_id.to_string(),
+        ],
+        start_server,
+        None,
+    )
+    .expect("reset-status should succeed");
+
+    assert_eq!(json["status"], "success");
+
+    // B should be Uninitialized; A remains Completed
+    assert_eq!(
+        apis::jobs_api::get_job(config, b_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Uninitialized,
+        "B should be Uninitialized after reset"
+    );
+    assert_eq!(
+        apis::jobs_api::get_job(config, a_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Completed,
+        "A should remain Completed"
+    );
+
+    // Now reinitialize — this bumps run_id exactly once
+    let torc_config = TorcConfig::load().unwrap_or_default();
+    let updated_wf = apis::workflows_api::get_workflow(config, workflow_id).unwrap();
+    let manager = WorkflowManager::new(config.clone(), torc_config, updated_wf);
+    manager
+        .reinitialize(false, false)
+        .expect("reinitialize failed");
+
+    let run_id_after = apis::workflows_api::get_workflow(config, workflow_id)
+        .unwrap()
+        .run_id
+        .unwrap_or(0);
+    assert_eq!(
+        run_id_after,
+        run_id_before + 1,
+        "run_id should be bumped exactly once by reinitialize"
+    );
+
+    // After reinit, B (which depends on A=Completed) should be Ready
+    let b_after = apis::jobs_api::get_job(config, b_id).unwrap();
+    assert_eq!(
+        b_after.status.unwrap(),
+        JobStatus::Ready,
+        "B should be Ready after reinitialize (A is still Completed)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 8: Idempotency — resetting an already-uninitialized job succeeds as
+//         a no-op (no error, no status change)
+// ---------------------------------------------------------------------------
+#[rstest]
+fn test_reset_status_idempotent(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let workflow = create_test_workflow(config, "reset_idempotent");
+    let workflow_id = workflow.id.unwrap();
+
+    // Job is in Uninitialized state (before initialize_jobs)
+    let job = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(workflow_id, "uninit_job".to_string(), "echo x".to_string()),
+    )
+    .expect("create job");
+    let job_id = job.id.unwrap();
+
+    // Do NOT initialize — job stays Uninitialized
+    assert_eq!(
+        apis::jobs_api::get_job(config, job_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Uninitialized,
+        "Job should start Uninitialized"
+    );
+
+    // Reset an already-uninitialized job — should succeed (warns but no error)
+    let json = run_cli_with_json(
+        &[
+            "jobs",
+            "reset-status",
+            "--no-prompts",
+            "--force",
+            &job_id.to_string(),
+        ],
+        start_server,
+        None,
+    )
+    .expect("resetting uninitialized job should succeed as no-op");
+
+    assert_eq!(json["status"], "success");
+    assert_eq!(
+        apis::jobs_api::get_job(config, job_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Uninitialized,
+        "Job should remain Uninitialized"
+    );
+}

--- a/tests/test_jobs_reset_status.rs
+++ b/tests/test_jobs_reset_status.rs
@@ -174,6 +174,20 @@ fn test_reset_status_selective(start_server: &ServerProcess) {
         run_id,
         "run_id must not change on reset-status"
     );
+
+    // reinit object must be present with requested=false when flag is absent
+    assert_eq!(
+        json["reinit"]["requested"], false,
+        "reinit.requested should be false"
+    );
+    assert_eq!(
+        json["reinit"]["applied"], false,
+        "reinit.applied should be false"
+    );
+    assert!(
+        json["reinit"]["error"].is_null(),
+        "reinit.error should be null"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -799,5 +813,260 @@ fn test_reset_status_idempotent(start_server: &ServerProcess) {
             .unwrap(),
         JobStatus::Uninitialized,
         "Job should remain Uninitialized"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 9: --reinit flag end-to-end — reset + reinit in one invocation.
+//         A → B (B depends on A). Both completed. Reset B with --reinit.
+//         Assert: B uninitialized then ready after reinit, A unchanged,
+//         run_id bumped by exactly 1.
+// ---------------------------------------------------------------------------
+#[rstest]
+fn test_reset_status_reinit_flag_end_to_end(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let workflow = create_test_workflow(config, "reset_reinit_e2e");
+    let workflow_id = workflow.id.unwrap();
+
+    let job_a = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(
+            workflow_id,
+            "reinit_e2e_a".to_string(),
+            "echo a".to_string(),
+        ),
+    )
+    .expect("create a");
+    let a_id = job_a.id.unwrap();
+
+    let mut job_b_model = models::JobModel::new(
+        workflow_id,
+        "reinit_e2e_b".to_string(),
+        "echo b".to_string(),
+    );
+    job_b_model.depends_on_job_ids = Some(vec![a_id]);
+    let job_b = apis::jobs_api::create_job(config, job_b_model).expect("create b");
+    let b_id = job_b.id.unwrap();
+
+    let run_id_before = initialize_workflow(config, &workflow);
+    let compute_node = create_test_compute_node(config, workflow_id);
+    let cn_id = compute_node.id.unwrap();
+
+    // Complete A successfully, complete B with failure
+    apis::jobs_api::manage_status_change(config, a_id, JobStatus::Running, run_id_before)
+        .expect("set a running");
+    complete_job(
+        config,
+        a_id,
+        workflow_id,
+        cn_id,
+        run_id_before,
+        0,
+        JobStatus::Completed,
+    );
+    apis::jobs_api::manage_status_change(config, b_id, JobStatus::Running, run_id_before)
+        .expect("set b running");
+    complete_job(
+        config,
+        b_id,
+        workflow_id,
+        cn_id,
+        run_id_before,
+        1,
+        JobStatus::Failed,
+    );
+
+    // Reset B with --reinit in one step (no separate reinit needed)
+    let json = run_cli_with_json(
+        &[
+            "jobs",
+            "reset-status",
+            "--no-prompts",
+            "--force",
+            "--reinit",
+            &b_id.to_string(),
+        ],
+        start_server,
+        None,
+    )
+    .expect("reset-status --reinit should succeed");
+
+    assert_eq!(json["status"], "success", "status should be success");
+    assert_eq!(json["reinit"]["requested"], true);
+    assert_eq!(json["reinit"]["applied"], true);
+    assert!(json["reinit"]["error"].is_null());
+
+    // run_id bumped exactly once
+    let run_id_after = apis::workflows_api::get_workflow(config, workflow_id)
+        .unwrap()
+        .run_id
+        .unwrap_or(0);
+    assert_eq!(
+        run_id_after,
+        run_id_before + 1,
+        "run_id should be bumped exactly once by --reinit"
+    );
+
+    // B should be Ready (A is Completed, so B's dependency is satisfied)
+    let b_after = apis::jobs_api::get_job(config, b_id).unwrap();
+    assert_eq!(
+        b_after.status.unwrap(),
+        JobStatus::Ready,
+        "B should be Ready after --reinit"
+    );
+
+    // A (upstream, completed) must NOT be reset
+    let a_after = apis::jobs_api::get_job(config, a_id).unwrap();
+    assert_eq!(
+        a_after.status.unwrap(),
+        JobStatus::Completed,
+        "A should remain Completed"
+    );
+
+    // next_steps should not mention 'workflows reinit'
+    let next_steps = json["next_steps"].as_str().unwrap_or("");
+    assert!(
+        !next_steps.contains("workflows reinit"),
+        "next_steps should not mention 'workflows reinit' when reinit was applied: {}",
+        next_steps
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 10: --reinit JSON output shape
+// ---------------------------------------------------------------------------
+#[rstest]
+fn test_reset_status_reinit_json_output(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let workflow = create_test_workflow(config, "reset_reinit_json");
+    let workflow_id = workflow.id.unwrap();
+
+    let job = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(
+            workflow_id,
+            "reinit_json_job".to_string(),
+            "echo hi".to_string(),
+        ),
+    )
+    .expect("create job");
+    let job_id = job.id.unwrap();
+
+    let run_id_before = initialize_workflow(config, &workflow);
+    let compute_node = create_test_compute_node(config, workflow_id);
+    let cn_id = compute_node.id.unwrap();
+
+    apis::jobs_api::manage_status_change(config, job_id, JobStatus::Running, run_id_before)
+        .expect("set running");
+    complete_job(
+        config,
+        job_id,
+        workflow_id,
+        cn_id,
+        run_id_before,
+        1,
+        JobStatus::Failed,
+    );
+
+    let json = run_cli_with_json(
+        &[
+            "jobs",
+            "reset-status",
+            "--no-prompts",
+            "--force",
+            "--reinit",
+            &job_id.to_string(),
+        ],
+        start_server,
+        None,
+    )
+    .expect("reset-status --reinit --no-prompts should succeed");
+
+    assert_eq!(json["status"], "success");
+    assert_eq!(json["reinit"]["requested"], true);
+    assert_eq!(json["reinit"]["applied"], true);
+    assert!(json["reinit"]["error"].is_null());
+
+    // next_steps should not mention 'workflows reinit' since it was applied
+    let next_steps = json["next_steps"].as_str().unwrap_or("");
+    assert!(
+        !next_steps.contains("workflows reinit"),
+        "next_steps should not reference 'workflows reinit' when reinit was applied: {}",
+        next_steps
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 11: --dry-run --reinit — no changes applied, reinit_requested flag set
+// ---------------------------------------------------------------------------
+#[rstest]
+fn test_reset_status_reinit_dry_run(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let workflow = create_test_workflow(config, "reset_reinit_dry");
+    let workflow_id = workflow.id.unwrap();
+
+    let job = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(
+            workflow_id,
+            "reinit_dry_job".to_string(),
+            "echo dry".to_string(),
+        ),
+    )
+    .expect("create job");
+    let job_id = job.id.unwrap();
+
+    let run_id_before = initialize_workflow(config, &workflow);
+    let compute_node = create_test_compute_node(config, workflow_id);
+    let cn_id = compute_node.id.unwrap();
+
+    apis::jobs_api::manage_status_change(config, job_id, JobStatus::Running, run_id_before)
+        .expect("set running");
+    complete_job(
+        config,
+        job_id,
+        workflow_id,
+        cn_id,
+        run_id_before,
+        1,
+        JobStatus::Failed,
+    );
+
+    let json = run_cli_with_json(
+        &[
+            "jobs",
+            "reset-status",
+            "--no-prompts",
+            "--force",
+            "--dry-run",
+            "--reinit",
+            &job_id.to_string(),
+        ],
+        start_server,
+        None,
+    )
+    .expect("dry-run --reinit should succeed");
+
+    assert_eq!(json["dry_run"], true);
+    assert_eq!(json["reinit_requested"], true);
+
+    // Job status must be unchanged (dry-run made no changes)
+    assert_eq!(
+        apis::jobs_api::get_job(config, job_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Failed,
+        "Job should still be Failed after dry-run"
+    );
+
+    // run_id must be unchanged (no reinit happened)
+    let run_id_after = apis::workflows_api::get_workflow(config, workflow_id)
+        .unwrap()
+        .run_id
+        .unwrap_or(0);
+    assert_eq!(
+        run_id_after, run_id_before,
+        "run_id must not change on dry-run"
     );
 }

--- a/tests/test_jobs_reset_status.rs
+++ b/tests/test_jobs_reset_status.rs
@@ -177,7 +177,14 @@ fn test_reset_status_selective(start_server: &ServerProcess) {
 }
 
 // ---------------------------------------------------------------------------
-// Test 2: Recursive downstream closure — A→B→C; reset A pulls B and C too
+// Test 2: Downstream closure via reinitialize — A→B→C all completed; reset A.
+// The command resets ONLY A. Immediately after: A is uninitialized, B is
+// uninitialized (the server's incidental one-level reset of direct
+// Completed/Failed dependents on complete→uninitialized), C is STILL
+// completed. The dry-run output lists B and C as downstream-affected. Then
+// 'workflows reinit' resets C too via the server's recursive
+// uninitialize_blocked_jobs CTE (observable afterwards as Blocked, since
+// reinit recomputes blocked/ready in the same transaction).
 // ---------------------------------------------------------------------------
 #[rstest]
 fn test_reset_status_recursive_downstream(start_server: &ServerProcess) {
@@ -274,7 +281,41 @@ fn test_reset_status_recursive_downstream(start_server: &ServerProcess) {
         JobStatus::Completed
     );
 
-    // Reset only A — the BFS closure should pull in B and C
+    // Dry-run first: the display must list B and C as downstream-affected
+    let dry = run_cli_with_json(
+        &[
+            "jobs",
+            "reset-status",
+            "--no-prompts",
+            "--force",
+            "--dry-run",
+            &a_id.to_string(),
+        ],
+        start_server,
+        None,
+    )
+    .expect("dry-run should succeed");
+    assert_eq!(dry["dry_run"], true);
+    let dry_requested: Vec<i64> = dry["jobs"]
+        .as_array()
+        .expect("jobs should be an array")
+        .iter()
+        .map(|j| j["job_id"].as_i64().unwrap())
+        .collect();
+    assert_eq!(dry_requested, vec![a_id], "only A should be requested");
+    let dry_downstream: Vec<i64> = dry["downstream_jobs"]
+        .as_array()
+        .expect("downstream_jobs should be an array")
+        .iter()
+        .map(|j| j["job_id"].as_i64().unwrap())
+        .collect();
+    assert_eq!(
+        dry_downstream,
+        vec![b_id, c_id],
+        "B and C should be listed as downstream-affected"
+    );
+
+    // Reset only A — the command must issue status changes for A only
     let json = run_cli_with_json(
         &[
             "jobs",
@@ -290,7 +331,29 @@ fn test_reset_status_recursive_downstream(start_server: &ServerProcess) {
 
     assert_eq!(json["status"], "success");
 
-    // A, B, and C must all be Uninitialized now
+    // Only A was explicitly reset; B and C appear as informational downstream
+    let reset_ids: Vec<i64> = json["reset_job_ids"]
+        .as_array()
+        .expect("reset_job_ids should be an array")
+        .iter()
+        .map(|v| v.as_i64().unwrap())
+        .collect();
+    assert_eq!(reset_ids, vec![a_id], "only A should have been reset");
+    let downstream_ids: Vec<i64> = json["downstream_jobs"]
+        .as_array()
+        .expect("downstream_jobs should be an array")
+        .iter()
+        .map(|j| j["job_id"].as_i64().unwrap())
+        .collect();
+    assert_eq!(
+        downstream_ids,
+        vec![b_id, c_id],
+        "B and C should be listed as downstream-affected"
+    );
+
+    // Intermediate state: A uninitialized; B uninitialized too (the server's
+    // incidental one-level reset of direct Completed/Failed dependents on
+    // complete→uninitialized); C STILL completed.
     assert_eq!(
         apis::jobs_api::get_job(config, a_id)
             .unwrap()
@@ -305,22 +368,51 @@ fn test_reset_status_recursive_downstream(start_server: &ServerProcess) {
             .status
             .unwrap(),
         JobStatus::Uninitialized,
-        "B should be Uninitialized (downstream closure)"
+        "B should be Uninitialized (server's one-level reset of direct dependents)"
     );
     assert_eq!(
         apis::jobs_api::get_job(config, c_id)
             .unwrap()
             .status
             .unwrap(),
-        JobStatus::Uninitialized,
-        "C should be Uninitialized (transitive downstream closure)"
+        JobStatus::Completed,
+        "C should STILL be Completed until reinit"
     );
 
-    // Check that reset_job_ids includes all three
-    let reset_ids = json["reset_job_ids"]
-        .as_array()
-        .expect("reset_job_ids should be an array");
-    assert_eq!(reset_ids.len(), 3, "should have reset 3 jobs");
+    // Reinitialize: the server's recursive uninitialize_blocked_jobs CTE resets
+    // C within the same transaction, then blocked/ready are recomputed —
+    // A (no deps) becomes Ready, B and C become Blocked. C is no longer Completed.
+    let torc_config = TorcConfig::load().unwrap_or_default();
+    let updated_wf = apis::workflows_api::get_workflow(config, workflow_id).unwrap();
+    let manager = WorkflowManager::new(config.clone(), torc_config, updated_wf);
+    manager
+        .reinitialize(false, false)
+        .expect("reinitialize failed");
+
+    assert_eq!(
+        apis::jobs_api::get_job(config, a_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Ready,
+        "A should be Ready after reinit"
+    );
+    assert_eq!(
+        apis::jobs_api::get_job(config, b_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Blocked,
+        "B should be Blocked after reinit (depends on A)"
+    );
+    assert_eq!(
+        apis::jobs_api::get_job(config, c_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Blocked,
+        "C should be Blocked after reinit (recursive CTE reset it from Completed)"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/test_jobs_reset_status.rs
+++ b/tests/test_jobs_reset_status.rs
@@ -1,7 +1,8 @@
 mod common;
 
 use common::{
-    ServerProcess, create_test_compute_node, create_test_workflow, run_cli_with_json, start_server,
+    ServerProcess, create_test_compute_node, create_test_workflow, get_exe_path, run_cli_with_json,
+    start_server,
 };
 use rstest::rstest;
 use torc::client::apis;
@@ -1069,4 +1070,167 @@ fn test_reset_status_reinit_dry_run(start_server: &ServerProcess) {
         run_id_after, run_id_before,
         "run_id must not change on dry-run"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Test 12: Re-runnable without --force — a first reset leaves the workflow
+//          incomplete (uninitialized jobs), but a second invocation must still
+//          succeed because the command only requires no active workers, not
+//          workflow completeness.
+// ---------------------------------------------------------------------------
+#[rstest]
+fn test_reset_status_rerunnable_without_force(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let workflow = create_test_workflow(config, "reset_rerunnable");
+    let workflow_id = workflow.id.unwrap();
+
+    let job1 = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(workflow_id, "job1".to_string(), "echo job1".to_string()),
+    )
+    .expect("create job1");
+    let job1_id = job1.id.unwrap();
+    let job2 = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(workflow_id, "job2".to_string(), "echo job2".to_string()),
+    )
+    .expect("create job2");
+    let job2_id = job2.id.unwrap();
+
+    let run_id = initialize_workflow(config, &workflow);
+    let compute_node = create_test_compute_node(config, workflow_id);
+    let cn_id = compute_node.id.unwrap();
+
+    for &id in &[job1_id, job2_id] {
+        apis::jobs_api::manage_status_change(config, id, JobStatus::Running, run_id)
+            .unwrap_or_else(|e| panic!("Failed to set job {} running: {}", id, e));
+        complete_job(config, id, workflow_id, cn_id, run_id, 1, JobStatus::Failed);
+    }
+
+    // First reset (workflow is complete) — no --force needed
+    let json = run_cli_with_json(
+        &["jobs", "reset-status", "--no-prompts", &job1_id.to_string()],
+        start_server,
+        None,
+    )
+    .expect("first reset-status should succeed");
+    assert_eq!(json["status"], "success");
+
+    // job1 is now uninitialized, so the workflow is no longer complete.
+    // A second invocation must STILL succeed without --force.
+    let json = run_cli_with_json(
+        &["jobs", "reset-status", "--no-prompts", &job2_id.to_string()],
+        start_server,
+        None,
+    )
+    .expect("second reset-status should succeed even though workflow is incomplete");
+    assert_eq!(json["status"], "success");
+
+    for &id in &[job1_id, job2_id] {
+        assert_eq!(
+            apis::jobs_api::get_job(config, id).unwrap().status.unwrap(),
+            JobStatus::Uninitialized,
+            "job {} should be Uninitialized",
+            id
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 13: Warning for successfully completed jobs — resetting a Completed job
+//          succeeds but prints a stderr warning; a Failed job in the same
+//          invocation is not listed in the warning.
+// ---------------------------------------------------------------------------
+#[rstest]
+fn test_reset_status_completed_job_warning(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let workflow = create_test_workflow(config, "reset_completed_warning");
+    let workflow_id = workflow.id.unwrap();
+
+    let completed_job = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(workflow_id, "ok_job".to_string(), "echo ok".to_string()),
+    )
+    .expect("create completed job");
+    let completed_id = completed_job.id.unwrap();
+    let failed_job = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(workflow_id, "bad_job".to_string(), "false".to_string()),
+    )
+    .expect("create failed job");
+    let failed_id = failed_job.id.unwrap();
+
+    let run_id = initialize_workflow(config, &workflow);
+    let compute_node = create_test_compute_node(config, workflow_id);
+    let cn_id = compute_node.id.unwrap();
+
+    for &id in &[completed_id, failed_id] {
+        apis::jobs_api::manage_status_change(config, id, JobStatus::Running, run_id)
+            .unwrap_or_else(|e| panic!("Failed to set job {} running: {}", id, e));
+    }
+    complete_job(
+        config,
+        completed_id,
+        workflow_id,
+        cn_id,
+        run_id,
+        0,
+        JobStatus::Completed,
+    );
+    complete_job(
+        config,
+        failed_id,
+        workflow_id,
+        cn_id,
+        run_id,
+        1,
+        JobStatus::Failed,
+    );
+
+    // Run the CLI directly so we can capture stderr alongside stdout
+    let output = std::process::Command::new(get_exe_path("./target/debug/torc"))
+        .args([
+            "--format",
+            "json",
+            "jobs",
+            "reset-status",
+            "--no-prompts",
+            &completed_id.to_string(),
+            &failed_id.to_string(),
+        ])
+        .env("TORC_API_URL", &start_server.config.base_path)
+        .output()
+        .expect("run torc CLI");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "reset-status should succeed; stderr: {}",
+        stderr
+    );
+    assert!(
+        stderr.contains("completed successfully"),
+        "stderr should warn about completed jobs; stderr: {}",
+        stderr
+    );
+    assert!(
+        stderr.contains(&format!("job {} (ok_job)", completed_id)),
+        "warning should list the completed job; stderr: {}",
+        stderr
+    );
+    assert!(
+        !stderr.contains(&format!("job {} (bad_job)", failed_id)),
+        "warning should not list the failed job; stderr: {}",
+        stderr
+    );
+
+    // Both jobs were still reset
+    for &id in &[completed_id, failed_id] {
+        assert_eq!(
+            apis::jobs_api::get_job(config, id).unwrap().status.unwrap(),
+            JobStatus::Uninitialized,
+            "job {} should be Uninitialized",
+            id
+        );
+    }
 }


### PR DESCRIPTION
Closes #384.

Adds `torc jobs reset-status <job_id>... [--force] [--dry-run] [--no-prompts]` for rerunning specific jobs without resetting the whole workflow. Client-only: works against the existing server API with no server/OpenAPI changes (deployed servers cannot be upgraded right now).

## How it works

- Resets **only the explicitly requested job IDs** to `uninitialized` via the existing `manage_status_change` endpoint. All IDs must belong to the same workflow (hard error, nothing reset otherwise); unknown IDs error out before any change is made; repeated IDs are de-duplicated.
- Does **not** bump `run_id` or touch workflow status. The user follows up with `torc workflows reinit <id>` once (which bumps `run_id` exactly once), then `torc run`/`torc submit` — the command prints this next step.
- Downstream dependents are **not** reset by the command. It computes the transitive downstream closure client-side (read-only BFS over the `upstream_job_id` filter, mirroring the server's recursive `uninitialize_blocked_jobs` CTE) and displays it informationally: those jobs are reset transitively by the server at reinit time, since a rerun job produces new outputs its consumers must consume again.
- Preconditions unless `--force`: workflow quiesced (complete/canceled, no active or pending workers) and no targeted job in Running/Pending. The quiescence checks are extracted from `check_recovery_preconditions` into a shared `check_workflow_quiesced()`; `torc recover` behavior is unchanged.
- Idempotent: already-uninitialized targets are warned-about no-ops; partial failures are reported per job with a non-zero exit and the command can simply be re-run.
- JSON mode emits `workflow_id`, `requested_job_ids` (the deduplicated target IDs), `reset_job_ids` (the IDs actually reset — a subset of requested on partial failure), an informational `downstream_jobs` field, `failures`, and `next_steps`; `--dry-run` is supported in both table and JSON modes.

## Testing

8 integration tests in `tests/test_jobs_reset_status.rs` against a real local server: selective reset, downstream-closure display + intermediate state + reinit flow (verifies C stays Completed until reinit, then is reset by the recursive CTE), cross-workflow rejection, unknown ID, active-job guard, dry-run, end-to-end reinit with single run_id bump, and idempotency.

All gates pass: `cargo fmt -- --check`, `cargo clippy --all --all-targets --all-features -- -D warnings`, `dprint check`, `cargo nextest run` (1467 passed).

Docs: new section in `docs/src/core/how-to/rerun-failed-jobs.md` with the multi-invoke-then-reinit flow and an updated "choosing the right tool" table.

Out of scope (future follow-ups): batched server-side endpoint once servers can be upgraded, Python client command, MCP tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
