### PR TITLE
Tolerate bot-blocking HTTP statuses in doc link checker

### DIFF
--- a/.github/scripts/check-doc-links.py
+++ b/.github/scripts/check-doc-links.py
@@ -24,6 +24,9 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 DOCS_ROOT = REPO_ROOT / "docs"
 DOCS_SRC = DOCS_ROOT / "src"
 LOCALHOST_NAMES = ("localhost", "127.0.0.1", "::1")
+# Statuses that indicate the server is blocking automated checkers (bot detection, auth walls, or
+# rate limiting) rather than a genuinely broken link. Treat these as reachable.
+BOT_BLOCK_STATUSES = frozenset({401, 403, 429})
 
 
 @dataclass(frozen=True)
@@ -175,6 +178,8 @@ def check_external_url(url: str, timeout: int, retries: int) -> str | None:
                 with open_url(url, method, timeout):
                     return None
             except urllib.error.HTTPError as err:
+                if err.code in BOT_BLOCK_STATUSES:
+                    return None
                 last_error = f"HTTP {err.code}"
                 if method == "HEAD":
                     continue


### PR DESCRIPTION
## Summary

CI's **Check documentation links** step failed because `zsh.sourceforge.io` returned **HTTP 403** to the automated link checker ([failing run](https://github.com/NatLabRockies/torc/actions/runs/27350552033/job/80810939751)). The page exists — sourceforge blocks non-browser requests.

This treats `401`, `403`, and `429` as reachable, since they indicate bot detection, auth walls, or rate limiting rather than a genuinely broken link.

## Changes

- Add `BOT_BLOCK_STATUSES = {401, 403, 429}` constant in `.github/scripts/check-doc-links.py`
- Return success (link reachable) when an external URL responds with one of those statuses

## Testing

`python3 .github/scripts/check-doc-links.py --external` passes locally. The CI doc-link job on this PR exercises the real sourceforge request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)