### PR TITLE
Release v0.34.1: backport client-only fixes for v0.34.0 servers

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - main
+      - 'release/**'
   push:
     branches:
       - main
+      - 'release/**'
 
 jobs:
   lint:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - main
+      - 'release/**'
   push:
     branches:
       - main
+      - 'release/**'
   # Run weekly to catch newly published advisories
   schedule:
     - cron: '0 6 * * 1'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - main
+      - 'release/**'
   push:
     branches:
       - main
+      - 'release/**'
 
 jobs:
   test:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5125,7 +5125,7 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "torc"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.34.0"
+version = "0.34.1"
 authors = [
   "Daniel Thom",
   "Joseph McKinsey",
@@ -20,7 +20,7 @@ description = "Workflow management system"
 
 [workspace.dependencies]
 # Self-reference for sub-crates (version only specified here)
-torc = { version = "0.34.0", path = "." }
+torc = { version = "0.34.1", path = "." }
 
 # Shared dependencies
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Usage:
 #   # Download and extract release binaries
-#   VERSION=0.34.0
+#   VERSION=0.34.1
 #   mkdir -p artifact
 #   curl -fsSL "https://github.com/NatLabRockies/torc/releases/download/v${VERSION}/torc-x86_64-unknown-linux-musl.tar.gz" \
 #     | tar xz -C artifact/

--- a/deny.toml
+++ b/deny.toml
@@ -10,6 +10,7 @@ ignore = [
     # Transitive deps we can't directly upgrade
     { id = "RUSTSEC-2025-0069", reason = "daemonize - no alternative available yet" },
     { id = "RUSTSEC-2025-0057", reason = "fxhash via tracing-timing - needs upstream update" },
+    { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 via tabled and validator - no safe upgrade available yet" },
 ]
 
 # License compliance - permissive allow-list

--- a/docs/src/core/how-to/rerun-failed-jobs.md
+++ b/docs/src/core/how-to/rerun-failed-jobs.md
@@ -43,6 +43,49 @@ torc workflows reset-status <workflow_id> --failed-only
 
 Then resume execution with `torc run <workflow_id>` (local) or `torc submit <workflow_id>` (Slurm).
 
+## Selective Job Reset: `torc jobs reset-status`
+
+When you need to rerun only specific jobs (not all failed ones), use `torc jobs reset-status`. This
+is useful when you know exactly which jobs need to be rerun without resetting the whole workflow.
+
+Unlike `torc workflows reset-status`, this command:
+
+- Resets only the explicitly named job IDs. Downstream dependents are **not** reset by this command
+  — it lists them for you, and they are reset transitively when you run `torc workflows reinit` (a
+  rerun job produces new outputs that consumers must consume again).
+- Does **not** bump the workflow `run_id` or reset workflow state — you follow up with
+  `torc workflows reinit` once, which does the run_id bump exactly once.
+- All supplied job IDs must belong to the same workflow (hard error otherwise).
+
+```bash
+# Preview what would be reset (no changes applied)
+torc jobs reset-status 101 102 --dry-run
+
+# Reset and reinitialize in one step, then run
+torc jobs reset-status 101 102 --reinit
+torc run <workflow_id>      # local execution
+# or: torc submit <workflow_id>   # Slurm
+
+# Reset and rerun (manual two-step flow)
+torc jobs reset-status 101 102 --no-prompts
+torc workflows reinit <workflow_id>
+torc run <workflow_id>
+
+# Override safety checks (e.g. workers still active)
+torc jobs reset-status 101 --force
+
+# JSON output for scripting
+torc -f json jobs reset-status 101 102 --no-prompts
+```
+
+The workflow does not need to be complete — the command can be run repeatedly (e.g. to reset
+additional jobs after an earlier reset) as long as no workers are active. If a requested job
+completed successfully, the command warns you before resetting it, since resetting discards its
+results and reruns it.
+
+The `--force` flag bypasses two checks: (1) the no-active-workers check (compute nodes and Slurm
+allocations), and (2) the active-status guard (jobs in Running or Pending are normally rejected).
+
 ## Choosing the Right Tool
 
 | Scenario                                                  | Use                                                                               |
@@ -51,6 +94,7 @@ Then resume execution with `torc run <workflow_id>` (local) or `torc submit <wor
 | Slurm workflow, want continuous self-healing              | `torc watch --recover`                                                            |
 | Local workflow with failures                              | `torc workflows reset-status --failed-only`                                       |
 | Want to retry without changing resource allocations       | `torc workflows reset-status --failed-only`                                       |
+| Rerun only specific known jobs                            | `torc jobs reset-status <id>...`                                                  |
 | Workflow ran fine but inputs changed                      | [Intelligent Restart](../concepts/intelligent-restart.md)                         |
 | Need AI-driven classification of unfamiliar failure modes | [AI-Assisted Recovery](../../specialized/fault-tolerance/ai-assisted-recovery.md) |
 

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -53,9 +53,9 @@ listed below.
 
 ```
 /scratch/dthom/torc/
-├── 0.34.0/
+├── 0.34.1/
 ├── ...
-└── latest -> 0.34.0  (symlink to current version)
+└── latest -> 0.34.1  (symlink to current version)
 ```
 
 > **Recommended**: Use the `latest` directory. Torc maintains backwards compatibility, so you'll

--- a/python_client/pyproject.toml
+++ b/python_client/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "torc-client"
 # Note: Do not update manually. Use cargo-release from the repo root, such as
 # $ cargo release minor --execute
-version = "0.34.0"
+version = "0.34.1"
 description = "Workflow management system"
 requires-python = ">=3.11,<3.14"
 license = "BSD-3-Clause"

--- a/src/client/commands/jobs.rs
+++ b/src/client/commands/jobs.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs;
 use std::io::{self, Write};
 use std::path::Path;
@@ -15,6 +15,8 @@ use crate::client::commands::{
     },
 };
 use crate::client::utils::format_local_timestamp;
+use crate::client::workflow_manager::WorkflowManager;
+use crate::config::TorcConfig;
 use crate::models;
 use tabled::Tabled;
 
@@ -397,6 +399,60 @@ EXAMPLES:
         /// Filter by specific job ID
         #[arg(short, long)]
         job_id: Option<i64>,
+    },
+    /// Reset specific jobs to uninitialized status for selective rerun
+    ///
+    /// Resets only the given job IDs to uninitialized so they can be rerun. All jobs
+    /// must belong to the same workflow. Downstream dependents are not reset by this
+    /// command; they are reset transitively by 'torc workflows reinit' (the command
+    /// lists them for you).
+    ///
+    /// After resetting, run 'torc workflows reinit <workflow_id>' to rebuild
+    /// dependency state (this bumps run_id exactly once), then 'torc run' or
+    /// 'torc submit' to execute. Use --reinit to perform the reinit step automatically
+    /// in the same invocation.
+    #[command(
+        name = "reset-status",
+        after_long_help = "\
+EXAMPLES:
+    # Reset two specific jobs for rerun (preview first)
+    torc jobs reset-status 101 102 --dry-run
+
+    # Reset and reinitialize in one step, then run
+    torc jobs reset-status 101 102 --reinit
+    torc run 42
+
+    # Reset and rerun (manual two-step flow)
+    torc jobs reset-status 101 102
+    torc workflows reinit 42
+    torc run 42
+
+    # Reset without prompts (for scripts/CI)
+    torc jobs reset-status 101 102 --no-prompts
+
+    # Override safety checks (workers still active)
+    torc jobs reset-status 101 --force
+
+    # JSON output for scripting
+    torc -f json jobs reset-status 101 102
+"
+    )]
+    ResetStatus {
+        /// Job IDs to reset (must all belong to the same workflow)
+        #[arg(required = true, num_args = 1..)]
+        job_ids: Vec<i64>,
+        /// Skip precondition checks (no active workers, target jobs not running)
+        #[arg(long)]
+        force: bool,
+        /// Preview which jobs would be reset without applying changes
+        #[arg(long)]
+        dry_run: bool,
+        /// Skip confirmation prompt
+        #[arg(long)]
+        no_prompts: bool,
+        /// Reinitialize the workflow after resetting (runs 'torc workflows reinit' for you)
+        #[arg(long, alias = "reinitialize")]
+        reinit: bool,
     },
 }
 
@@ -1190,6 +1246,23 @@ pub fn handle_job_commands(config: &Configuration, command: &JobCommands, format
                 }
             }
         }
+        JobCommands::ResetStatus {
+            job_ids,
+            force,
+            dry_run,
+            no_prompts,
+            reinit,
+        } => {
+            handle_reset_job_status(
+                config,
+                job_ids,
+                *force,
+                *dry_run,
+                *no_prompts,
+                *reinit,
+                format,
+            );
+        }
     }
 }
 
@@ -1323,6 +1396,460 @@ pub fn get_current_job_count(
     .map_err(|e| format!("Failed to get job count: {:?}", e))?;
 
     Ok(response.total_count)
+}
+
+// ---------------------------------------------------------------------------
+// reset-status helpers
+// ---------------------------------------------------------------------------
+
+/// A single row in the jobs-to-reset preview table.
+#[derive(Tabled)]
+struct ResetJobRow {
+    #[tabled(rename = "Job ID")]
+    id: i64,
+    #[tabled(rename = "Name")]
+    name: String,
+    #[tabled(rename = "Current Status")]
+    status: String,
+}
+
+/// Handler for `torc jobs reset-status`.
+///
+/// Resets ONLY the explicitly requested job IDs to `Uninitialized` so they can be
+/// rerun.  Downstream dependents are not touched here: the server's recursive
+/// `uninitialize_blocked_jobs` CTE resets every transitive dependent of an
+/// uninitialized job when the user runs `torc workflows reinit` — this command
+/// merely computes and displays that closure.  Does NOT bump the workflow
+/// `run_id` by default — the caller should follow up with `torc workflows reinit <id>`
+/// (which resets workflow status and bumps `run_id` exactly once).  Pass
+/// `reinit = true` (or `--reinit` on the CLI) to perform that step automatically.
+///
+/// # Known limitation
+/// `manage_status_change` does not clear `start_time` / `compute_node_id`; those
+/// fields are overwritten when the job next starts.  Clearing them via `update_job`
+/// is restricted and the cosmetic difference is acceptable.
+/// The server always assigns job IDs, so a `None` here indicates a server bug;
+/// fail hard rather than propagate a sentinel value into status changes.
+fn require_job_id(job: &models::JobModel) -> i64 {
+    job.id.unwrap_or_else(|| {
+        eprintln!(
+            "Error: server returned job '{}' (workflow_id={}) without an ID",
+            job.name, job.workflow_id
+        );
+        std::process::exit(1);
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn handle_reset_job_status(
+    config: &Configuration,
+    job_ids: &[i64],
+    force: bool,
+    dry_run: bool,
+    no_prompts: bool,
+    reinit: bool,
+    format: &str,
+) {
+    // -----------------------------------------------------------------------
+    // 1. Fetch and validate: all IDs must exist and belong to the same workflow
+    // -----------------------------------------------------------------------
+    let mut fetched: Vec<models::JobModel> = Vec::with_capacity(job_ids.len());
+    for &id in job_ids {
+        match apis::jobs_api::get_job(config, id) {
+            Ok(job) => fetched.push(job),
+            Err(e) => {
+                eprintln!("Error: job {} not found: {}", id, e);
+                std::process::exit(1);
+            }
+        }
+    }
+
+    // De-duplicate by ID while preserving first-occurrence order
+    let mut seen_ids: HashSet<i64> = HashSet::new();
+    let mut unique_jobs: Vec<models::JobModel> = Vec::new();
+    for job in fetched {
+        let id = require_job_id(&job);
+        if seen_ids.insert(id) {
+            unique_jobs.push(job);
+        }
+    }
+
+    // Determine workflow from first job; reject if any job belongs elsewhere
+    let workflow_id = unique_jobs[0].workflow_id;
+    let mut mismatched: Vec<(i64, i64)> = Vec::new();
+    for job in &unique_jobs {
+        if job.workflow_id != workflow_id {
+            mismatched.push((require_job_id(job), job.workflow_id));
+        }
+    }
+    if !mismatched.is_empty() {
+        eprintln!(
+            "Error: all job IDs must belong to the same workflow (inferred workflow_id={} from \
+             first job), but the following jobs belong to different workflows:",
+            workflow_id
+        );
+        for (id, wf) in &mismatched {
+            eprintln!("  job {} belongs to workflow {}", id, wf);
+        }
+        eprintln!("Nothing was reset.");
+        std::process::exit(1);
+    }
+
+    // -----------------------------------------------------------------------
+    // 2. Preconditions
+    // -----------------------------------------------------------------------
+    // The workflow does NOT need to be complete — only quiet. Requiring
+    // completeness would make this command non-rerunnable: the first reset
+    // leaves jobs uninitialized, so the workflow is no longer "complete".
+    if !force {
+        if let Err(msg) =
+            crate::client::commands::recover::check_no_active_workers(config, workflow_id)
+        {
+            eprintln!("Error: {}", msg);
+            eprintln!("Use --force to skip this check.");
+            std::process::exit(1);
+        }
+
+        // Reject jobs currently in Running or Pending status
+        let active_targets: Vec<i64> = unique_jobs
+            .iter()
+            .filter(|j| {
+                matches!(
+                    j.status,
+                    Some(models::JobStatus::Running) | Some(models::JobStatus::Pending)
+                )
+            })
+            .map(require_job_id)
+            .collect();
+        if !active_targets.is_empty() {
+            eprintln!(
+                "Error: the following jobs are currently Running or Pending and cannot be reset \
+                 without --force:"
+            );
+            for id in &active_targets {
+                eprintln!("  job {}", id);
+            }
+            std::process::exit(1);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // 3. Compute the downstream closure — READ-ONLY, for display only
+    // -----------------------------------------------------------------------
+    // For each requested job, find its transitive downstream dependents via BFS.
+    // No status-change calls are issued for these jobs: the server's recursive
+    // uninitialize_blocked_jobs CTE resets every transitive dependent of an
+    // uninitialized job — regardless of its status — when the user runs
+    // 'torc workflows reinit' (a rerun job produces new outputs, so consumers
+    // must rerun too).  The closure computed here mirrors that CTE (no status
+    // filter) so the user can see exactly what reinit will reset.
+    let requested_ids: HashSet<i64> = unique_jobs.iter().map(require_job_id).collect();
+
+    let mut downstream_map: HashMap<i64, models::JobModel> = HashMap::new();
+    let mut visited: HashSet<i64> = requested_ids.clone();
+    let mut bfs_queue: VecDeque<i64> = requested_ids.iter().copied().collect();
+
+    while let Some(upstream_id) = bfs_queue.pop_front() {
+        // Fetch direct dependents of this upstream job
+        let params = JobListParams::new().with_upstream_job_id(upstream_id);
+        let dependents = match pagination::paginate_jobs(config, workflow_id, params) {
+            Ok(jobs) => jobs,
+            Err(e) => {
+                eprintln!(
+                    "Error: failed to list dependents of job {}: {}",
+                    upstream_id, e
+                );
+                std::process::exit(1);
+            }
+        };
+
+        for dep in dependents {
+            let dep_id = require_job_id(&dep);
+            if visited.insert(dep_id) {
+                downstream_map.insert(dep_id, dep);
+                bfs_queue.push_back(dep_id);
+            }
+        }
+    }
+
+    let mut downstream_jobs: Vec<&models::JobModel> = downstream_map.values().collect();
+    downstream_jobs.sort_by_key(|j| require_job_id(j));
+
+    // -----------------------------------------------------------------------
+    // 4. Warn for already-uninitialized requested jobs (no-ops) and for jobs
+    //    that completed successfully (the user may not intend to redo them)
+    // -----------------------------------------------------------------------
+    for job in &unique_jobs {
+        if job.status == Some(models::JobStatus::Uninitialized) {
+            eprintln!(
+                "Warning: job {} ({}) is already uninitialized — will be a no-op.",
+                require_job_id(job),
+                job.name
+            );
+        }
+    }
+
+    let completed_targets: Vec<&models::JobModel> = unique_jobs
+        .iter()
+        .filter(|j| j.status == Some(models::JobStatus::Completed))
+        .collect();
+    if !completed_targets.is_empty() {
+        eprintln!(
+            "Warning: the following job(s) completed successfully; resetting them discards \
+             their results and reruns them:"
+        );
+        for job in &completed_targets {
+            eprintln!("  job {} ({})", require_job_id(job), job.name);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // 5. Display: requested jobs table + informational downstream section
+    // -----------------------------------------------------------------------
+    let to_row = |job: &models::JobModel| ResetJobRow {
+        id: require_job_id(job),
+        name: job.name.clone(),
+        status: job
+            .status
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| "unknown".to_string()),
+    };
+    let to_json = |job: &models::JobModel| {
+        serde_json::json!({
+            "job_id": require_job_id(job),
+            "name": job.name,
+            "status": job.status.map(|s| s.to_string()).unwrap_or_default(),
+        })
+    };
+
+    if format != "json" {
+        let rows: Vec<ResetJobRow> = unique_jobs.iter().map(to_row).collect();
+        display_table_with_count(&rows, "jobs to reset");
+
+        if !downstream_jobs.is_empty() {
+            if reinit {
+                println!(
+                    "\nThe following downstream jobs will be reset now by the reinit step \
+                     (a rerun job produces new outputs, so its consumers must rerun too):",
+                );
+            } else {
+                println!(
+                    "\nThe following downstream jobs will be reset when you run \
+                     'torc workflows reinit {}' (a rerun job produces new outputs, so its \
+                     consumers must rerun too):",
+                    workflow_id
+                );
+            }
+            let ds_rows: Vec<ResetJobRow> = downstream_jobs.iter().map(|j| to_row(j)).collect();
+            display_table_with_count(&ds_rows, "downstream jobs (reset at reinit time)");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // 6. Dry-run: stop here
+    // -----------------------------------------------------------------------
+    if dry_run {
+        if format == "json" {
+            let response = serde_json::json!({
+                "dry_run": true,
+                "reinit_requested": reinit,
+                "workflow_id": workflow_id,
+                "jobs": unique_jobs.iter().map(to_json).collect::<Vec<_>>(),
+                "downstream_jobs": downstream_jobs
+                    .iter()
+                    .map(|j| to_json(j))
+                    .collect::<Vec<_>>(),
+            });
+            println!("{}", serde_json::to_string_pretty(&response).unwrap());
+        } else {
+            println!("Dry run: no changes were made.");
+            if reinit {
+                println!("Dry run: the workflow would also be reinitialized.");
+            }
+        }
+        return;
+    }
+
+    // -----------------------------------------------------------------------
+    // 7. Confirmation prompt
+    // -----------------------------------------------------------------------
+    if !no_prompts && format != "json" {
+        eprintln!(
+            "\nAbout to reset {} job(s) in workflow {} to uninitialized.",
+            unique_jobs.len(),
+            workflow_id
+        );
+        if !downstream_jobs.is_empty() {
+            if reinit {
+                eprintln!(
+                    "The workflow will be reinitialized now and {} downstream job(s) reset as \
+                     part of it.",
+                    downstream_jobs.len()
+                );
+            } else {
+                eprintln!(
+                    "{} downstream job(s) will be reset later by 'torc workflows reinit {}'.",
+                    downstream_jobs.len(),
+                    workflow_id
+                );
+            }
+        }
+        eprintln!("This is an idempotent operation and can be re-run if it partially fails.");
+        print!("Continue? (y/N): ");
+        io::stdout().flush().unwrap();
+
+        let mut input = String::new();
+        match io::stdin().read_line(&mut input) {
+            Ok(_) => {
+                if input.trim().to_lowercase() != "y" && input.trim().to_lowercase() != "yes" {
+                    eprintln!("Reset cancelled.");
+                    std::process::exit(0);
+                }
+            }
+            Err(e) => {
+                eprintln!("Failed to read input: {}", e);
+                std::process::exit(1);
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // 8. Apply: fetch run_id, then reset ONLY the requested jobs
+    // -----------------------------------------------------------------------
+    let run_id = match apis::workflows_api::get_workflow(config, workflow_id) {
+        Ok(wf) => wf.run_id.unwrap_or(1),
+        Err(e) => {
+            eprintln!("Error: failed to fetch workflow {}: {}", workflow_id, e);
+            std::process::exit(1);
+        }
+    };
+
+    // The server's one-level reinitialize_downstream_jobs may incidentally reset
+    // some direct Completed/Failed dependents on complete→uninitialized; that is
+    // harmless — the recursive reset at reinit time covers the rest.
+    let mut succeeded: Vec<i64> = Vec::new();
+    let mut failures: Vec<(i64, String)> = Vec::new();
+
+    for job in &unique_jobs {
+        let id = require_job_id(job);
+        match apis::jobs_api::manage_status_change(
+            config,
+            id,
+            models::JobStatus::Uninitialized,
+            run_id,
+        ) {
+            Ok(_) => succeeded.push(id),
+            Err(e) => failures.push((id, e.to_string())),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // 8b. Apply reinit (only when requested and all resets succeeded)
+    // -----------------------------------------------------------------------
+    let mut reinit_applied = false;
+    let mut reinit_error: Option<String> = None;
+    if reinit && failures.is_empty() {
+        match apis::workflows_api::get_workflow(config, workflow_id) {
+            Ok(workflow) => {
+                let torc_config = TorcConfig::load().unwrap_or_default();
+                let manager = WorkflowManager::new(config.clone(), torc_config, workflow);
+                match manager.reinitialize(false, false) {
+                    Ok(()) => reinit_applied = true,
+                    Err(e) => reinit_error = Some(e.to_string()),
+                }
+            }
+            Err(e) => reinit_error = Some(format!("failed to fetch workflow: {}", e)),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // 9. Output
+    // -----------------------------------------------------------------------
+    let next_steps = if reinit_applied {
+        format!(
+            "Run 'torc run {}' or 'torc submit {}' to execute.",
+            workflow_id, workflow_id
+        )
+    } else {
+        format!(
+            "Run 'torc workflows reinit {}' (then 'torc run'/'torc submit') to rerun these \
+             jobs.",
+            workflow_id
+        )
+    };
+
+    if format == "json" {
+        let failure_list: Vec<serde_json::Value> = failures
+            .iter()
+            .map(|(id, msg)| serde_json::json!({"job_id": id, "error": msg}))
+            .collect();
+        let all_succeeded = failures.is_empty() && (!reinit || reinit_applied);
+        let status_str = if all_succeeded {
+            "success"
+        } else {
+            "partial_failure"
+        };
+        let response = serde_json::json!({
+            "status": status_str,
+            "workflow_id": workflow_id,
+            "reset_count": succeeded.len(),
+            "requested_job_ids": unique_jobs.iter().map(require_job_id).collect::<Vec<_>>(),
+            "reset_job_ids": succeeded,
+            // Informational: these are reset by the server at reinit time,
+            // not by this command.
+            "downstream_jobs": downstream_jobs
+                .iter()
+                .map(|j| to_json(j))
+                .collect::<Vec<_>>(),
+            "failures": failure_list,
+            "next_steps": next_steps,
+            "reinit": {
+                "requested": reinit,
+                "applied": reinit_applied,
+                "error": reinit_error,
+            },
+        });
+        println!("{}", serde_json::to_string_pretty(&response).unwrap());
+        if !all_succeeded {
+            std::process::exit(1);
+        }
+    } else {
+        if !failures.is_empty() {
+            eprintln!("Error: {} job(s) could not be reset:", failures.len());
+            for (id, msg) in &failures {
+                eprintln!("  job {}: {}", id, msg);
+            }
+            eprintln!(
+                "Successfully reset {} job(s). This command is idempotent — re-run it to retry \
+                 the failed resets.",
+                succeeded.len()
+            );
+            if reinit {
+                eprintln!(
+                    "Reinit was skipped because of the above failures. Re-run this command to \
+                     retry both the resets and reinit."
+                );
+            }
+            std::process::exit(1);
+        }
+        println!(
+            "Successfully reset {} job(s) to uninitialized.",
+            succeeded.len()
+        );
+        if let Some(ref err) = reinit_error {
+            eprintln!("Error reinitializing workflow {}: {}", workflow_id, err);
+            eprintln!(
+                "The job resets succeeded. Run 'torc workflows reinit {}' manually to complete \
+                 the reinit step.",
+                workflow_id
+            );
+            std::process::exit(1);
+        }
+        if reinit_applied {
+            println!("Reinitialized workflow {}.", workflow_id);
+        }
+        println!("{}", next_steps);
+    }
 }
 
 /// Get existing job names to avoid duplicates

--- a/src/client/commands/recover.rs
+++ b/src/client/commands/recover.rs
@@ -27,16 +27,48 @@ use crate::models::JobStatus;
 /// Maximum time to wait for the server's database to become healthy when claiming actions.
 const WAIT_FOR_HEALTHY_DATABASE_MINUTES: u64 = 20;
 
-fn torc_command() -> Result<Command, String> {
-    if let Ok(path) = std::env::var("TORC_BIN")
+fn torc_command(config: &Configuration) -> Result<Command, String> {
+    let mut cmd = if let Ok(path) = std::env::var("TORC_BIN")
         && !path.trim().is_empty()
     {
-        return Ok(Command::new(path));
+        // Use the trimmed value: a TORC_BIN with surrounding whitespace passes the emptiness
+        // check above but would fail to spawn if passed verbatim.
+        Command::new(path.trim())
+    } else {
+        let current_exe = std::env::current_exe()
+            .map_err(|e| format!("Failed to determine current torc executable: {}", e))?;
+        Command::new(current_exe)
+    };
+
+    // Forward the resolved server connection settings so the spawned `torc` talks to the same
+    // server with the same TLS/auth. The child reads these from env-mapped CLI args, and it
+    // inherits our environment — but only ambient env vars, not values the parent received via
+    // CLI flags (`--url`, `--tls-*`, `--password`) or `--standalone` (whose ephemeral URL is
+    // deliberately kept out of the environment). Setting them explicitly covers both cases.
+    cmd.env("TORC_API_URL", &config.base_path);
+    if let Some(ref ca_cert) = config.tls.ca_cert_path {
+        cmd.env("TORC_TLS_CA_CERT", ca_cert);
+    }
+    if config.tls.insecure {
+        cmd.env("TORC_TLS_INSECURE", "true");
+    }
+    if let Some(ref cookie_header) = config.cookie_header {
+        cmd.env("TORC_COOKIE_HEADER", cookie_header);
+    }
+    if let Some((_, Some(ref password))) = config.basic_auth {
+        cmd.env("TORC_PASSWORD", password);
     }
 
-    let current_exe = std::env::current_exe()
-        .map_err(|e| format!("Failed to determine current torc executable: {}", e))?;
-    Ok(Command::new(current_exe))
+    Ok(cmd)
+}
+
+/// Render an output directory as a `-o` argument, erroring on non-UTF-8 paths instead of silently
+/// substituting a different directory.
+fn output_dir_arg(output_dir: &Path) -> Result<String, String> {
+    output_dir
+        .to_str()
+        .map(|s| s.to_string())
+        .ok_or_else(|| format!("Output directory path is not valid UTF-8: {:?}", output_dir))
 }
 
 /// Arguments for workflow recovery
@@ -283,7 +315,12 @@ pub fn recover_workflow(
 
             // Get the real scheduler plan using slurm regenerate --dry-run --include-job-ids
             info!("[DRY RUN] Slurm schedulers that would be created:");
-            match get_scheduler_dry_run(args.workflow_id, &args.output_dir, &result.jobs_to_retry) {
+            match get_scheduler_dry_run(
+                config,
+                args.workflow_id,
+                &args.output_dir,
+                &result.jobs_to_retry,
+            ) {
                 Ok(mut dry_run_result) => {
                     // Apply the adjusted memory/runtime values to the scheduler info.
                     // slurm regenerate reads from the database, but in dry-run mode
@@ -395,7 +432,7 @@ pub fn recover_workflow(
 
     // Step 7: Regenerate Slurm schedulers and submit
     info!("Schedulers regenerating workflow_id={}", args.workflow_id);
-    regenerate_and_submit(args.workflow_id, &args.output_dir, None, None)?;
+    regenerate_and_submit(config, args.workflow_id, &args.output_dir, None, None)?;
 
     Ok(result)
 }
@@ -475,47 +512,48 @@ fn check_recovery_preconditions(config: &Configuration, workflow_id: i64) -> Res
         );
     }
 
-    // Check that there are actually failed/terminated/canceled jobs to recover
-    let failed_jobs = apis::jobs_api::list_jobs(
-        config,
-        workflow_id,
-        Some(crate::models::JobStatus::Failed), // status
-        None,                                   // needs_file_id
-        None,                                   // upstream_job_id
-        None,                                   // offset
-        Some(1),                                // limit
-        None,                                   // sort_by
-        None,                                   // reverse_sort
-        None,                                   // include_relationships
-        None,                                   // active_compute_node_id
-        None,                                   // origin_is_set
-        None,                                   // name
-        None,                                   // command
-    )
-    .map_err(|e| format!("Failed to list failed jobs: {}", e))?;
+    // Check that there are actually recoverable jobs. The reset path
+    // (`reset_failed_jobs_only`) resets failed, terminated, canceled, and pending_failed jobs, so
+    // accept any of those here — otherwise a workflow whose jobs are only canceled or pending_failed
+    // (which passes the completeness/cancellation gate above) would be rejected even though recovery
+    // can act on it.
+    let recoverable_statuses = [
+        crate::models::JobStatus::Failed,
+        crate::models::JobStatus::Terminated,
+        crate::models::JobStatus::Canceled,
+        crate::models::JobStatus::PendingFailed,
+    ];
+    let mut has_recoverable_jobs = false;
+    for status in recoverable_statuses {
+        let jobs = apis::jobs_api::list_jobs(
+            config,
+            workflow_id,
+            Some(status), // status
+            None,         // needs_file_id
+            None,         // upstream_job_id
+            None,         // offset
+            Some(1),      // limit - just need to know if any exist
+            None,         // sort_by
+            None,         // reverse_sort
+            None,         // include_relationships
+            None,         // active_compute_node_id
+            None,         // origin_is_set
+            None,         // name
+            None,         // command
+        )
+        .map_err(|e| format!("Failed to list {:?} jobs: {}", status, e))?;
+        if jobs.total_count > 0 {
+            has_recoverable_jobs = true;
+            break;
+        }
+    }
 
-    let terminated_jobs = apis::jobs_api::list_jobs(
-        config,
-        workflow_id,
-        Some(crate::models::JobStatus::Terminated), // status
-        None,                                       // needs_file_id
-        None,                                       // upstream_job_id
-        None,                                       // offset
-        Some(1),                                    // limit
-        None,                                       // sort_by
-        None,                                       // reverse_sort
-        None,                                       // include_relationships
-        None,                                       // active_compute_node_id
-        None,                                       // origin_is_set
-        None,                                       // name
-        None,                                       // command
-    )
-    .map_err(|e| format!("Failed to list terminated jobs: {}", e))?;
-
-    if failed_jobs.total_count == 0 && terminated_jobs.total_count == 0 {
-        return Err("No failed or terminated jobs to recover. \
+    if !has_recoverable_jobs {
+        return Err(
+            "No failed, terminated, canceled, or pending_failed jobs to recover. \
              Workflow may have completed successfully."
-            .to_string());
+                .to_string(),
+        );
     }
 
     Ok(())
@@ -947,6 +985,7 @@ pub fn run_recovery_hook(
 
 /// Regenerate Slurm schedulers and submit allocations
 pub fn regenerate_and_submit(
+    config: &Configuration,
     workflow_id: i64,
     output_dir: &Path,
     partition: Option<&str>,
@@ -958,7 +997,7 @@ pub fn regenerate_and_submit(
         workflow_id.to_string(),
         "--submit".to_string(),
         "-o".to_string(),
-        output_dir.to_str().unwrap_or("torc_output").to_string(),
+        output_dir_arg(output_dir)?,
     ];
     if let Some(p) = partition {
         args.push("--partition".to_string());
@@ -968,7 +1007,7 @@ pub fn regenerate_and_submit(
         args.push("--walltime".to_string());
         args.push(w.to_string());
     }
-    let mut cmd = torc_command()?;
+    let mut cmd = torc_command(config)?;
     let output = cmd
         .args(&args)
         .output()
@@ -992,6 +1031,7 @@ pub fn regenerate_and_submit(
 
 /// Get a dry-run preview of what schedulers would be created, including specific job IDs
 fn get_scheduler_dry_run(
+    config: &Configuration,
     workflow_id: i64,
     output_dir: &Path,
     job_ids: &[i64],
@@ -1003,7 +1043,8 @@ fn get_scheduler_dry_run(
         .collect::<Vec<_>>()
         .join(",");
 
-    let mut cmd = torc_command()?;
+    let output_dir_str = output_dir_arg(output_dir)?;
+    let mut cmd = torc_command(config)?;
     let output = cmd
         .args([
             "-f",
@@ -1015,7 +1056,7 @@ fn get_scheduler_dry_run(
             "--include-job-ids",
             &job_ids_str,
             "-o",
-            output_dir.to_str().unwrap_or("torc_output"),
+            &output_dir_str,
         ])
         .output()
         .map_err(|e| format!("Failed to run slurm regenerate --dry-run: {}", e))?;
@@ -1411,28 +1452,32 @@ fn recover_workflow_interactive(
 
     if args.dry_run {
         eprintln!("\n[DRY RUN] No changes applied.");
-        let slurm_dry_run =
-            match get_scheduler_dry_run(args.workflow_id, &args.output_dir, &all_jobs_to_retry) {
-                Ok(mut dr) => {
-                    dr.would_submit = true;
-                    for sched in &dr.planned_schedulers {
-                        let deps = if sched.has_dependencies {
-                            " (deferred)"
-                        } else {
-                            ""
-                        };
-                        eprintln!(
-                            "  {} - {} job(s), {} allocation(s){}",
-                            sched.name, sched.job_count, sched.num_allocations, deps
-                        );
-                    }
-                    Some(dr)
+        let slurm_dry_run = match get_scheduler_dry_run(
+            config,
+            args.workflow_id,
+            &args.output_dir,
+            &all_jobs_to_retry,
+        ) {
+            Ok(mut dr) => {
+                dr.would_submit = true;
+                for sched in &dr.planned_schedulers {
+                    let deps = if sched.has_dependencies {
+                        " (deferred)"
+                    } else {
+                        ""
+                    };
+                    eprintln!(
+                        "  {} - {} job(s), {} allocation(s){}",
+                        sched.name, sched.job_count, sched.num_allocations, deps
+                    );
                 }
-                Err(e) => {
-                    warn!("Could not get scheduler preview: {}", e);
-                    None
-                }
-            };
+                Some(dr)
+            }
+            Err(e) => {
+                warn!("Could not get scheduler preview: {}", e);
+                None
+            }
+        };
 
         return Ok(RecoveryResult {
             oom_fixed: correction_result.memory_corrections,
@@ -1527,6 +1572,7 @@ fn recover_workflow_interactive(
         } => {
             info!("Regenerating and submitting Slurm schedulers...");
             regenerate_and_submit(
+                config,
                 args.workflow_id,
                 &args.output_dir,
                 partition.as_deref(),
@@ -1549,6 +1595,7 @@ fn recover_workflow_interactive(
                 num_allocations, scheduler_id
             );
             submit_existing_scheduler(
+                config,
                 args.workflow_id,
                 *scheduler_id,
                 *num_allocations,
@@ -1815,13 +1862,14 @@ pub fn mark_on_workflow_start_schedule_actions_executed(
 
 /// Submit allocations using an existing scheduler config via `torc slurm schedule-nodes`.
 fn submit_existing_scheduler(
+    config: &Configuration,
     workflow_id: i64,
     scheduler_id: i64,
     num_allocations: i32,
     start_one_worker_per_node: bool,
     output_dir: &Path,
 ) -> Result<(), String> {
-    let mut cmd = torc_command()?;
+    let mut cmd = torc_command(config)?;
     let mut args = vec![
         "slurm".to_string(),
         "schedule-nodes".to_string(),
@@ -1831,7 +1879,7 @@ fn submit_existing_scheduler(
         "--num-hpc-jobs".to_string(),
         num_allocations.to_string(),
         "-o".to_string(),
-        output_dir.to_str().unwrap_or("torc_output").to_string(),
+        output_dir_arg(output_dir)?,
     ];
     if start_one_worker_per_node {
         args.push("--start-one-worker-per-node".to_string());
@@ -1866,5 +1914,95 @@ fn truncate(s: &str, max: usize) -> String {
     } else {
         let prefix: String = s.chars().take(max - 3).collect();
         format!("{}...", prefix)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::apis::configuration::TlsConfig;
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    /// Collect the env overrides explicitly set on a `Command` (not inherited parent env).
+    fn env_overrides(cmd: &Command) -> HashMap<String, String> {
+        cmd.get_envs()
+            .filter_map(|(k, v)| Some((k.to_str()?.to_string(), v?.to_str()?.to_string())))
+            .collect()
+    }
+
+    #[test]
+    fn torc_command_forwards_connection_settings() {
+        let mut config = Configuration::new();
+        config.base_path = "https://example.test:9000/torc-service/v1".to_string();
+        config.tls = TlsConfig {
+            ca_cert_path: Some(PathBuf::from("/tmp/ca.pem")),
+            insecure: false,
+        };
+        config.cookie_header = Some("session=abc".to_string());
+        config.basic_auth = Some(("alice".to_string(), Some("s3cret".to_string())));
+
+        let cmd = torc_command(&config).expect("torc_command");
+        let envs = env_overrides(&cmd);
+
+        // URL, TLS CA, cookie, and password are forwarded so the child resolves the same server
+        // even when the parent received these via CLI flags rather than the environment.
+        assert_eq!(
+            envs.get("TORC_API_URL").map(String::as_str),
+            Some("https://example.test:9000/torc-service/v1")
+        );
+        assert_eq!(
+            envs.get("TORC_TLS_CA_CERT").map(String::as_str),
+            Some("/tmp/ca.pem")
+        );
+        assert_eq!(
+            envs.get("TORC_COOKIE_HEADER").map(String::as_str),
+            Some("session=abc")
+        );
+        assert_eq!(
+            envs.get("TORC_PASSWORD").map(String::as_str),
+            Some("s3cret")
+        );
+        // insecure=false must not set the flag (clap would parse it as true).
+        assert!(!envs.contains_key("TORC_TLS_INSECURE"));
+    }
+
+    #[test]
+    fn torc_command_sets_tls_insecure_only_when_enabled() {
+        let mut config = Configuration::new();
+        config.tls = TlsConfig {
+            ca_cert_path: None,
+            insecure: true,
+        };
+
+        let cmd = torc_command(&config).expect("torc_command");
+        let envs = env_overrides(&cmd);
+
+        assert_eq!(
+            envs.get("TORC_TLS_INSECURE").map(String::as_str),
+            Some("true")
+        );
+        // Nothing else should be forwarded when not configured.
+        assert!(!envs.contains_key("TORC_TLS_CA_CERT"));
+        assert!(!envs.contains_key("TORC_PASSWORD"));
+        assert!(!envs.contains_key("TORC_COOKIE_HEADER"));
+    }
+
+    #[test]
+    fn output_dir_arg_accepts_utf8_path() {
+        assert_eq!(
+            output_dir_arg(Path::new("torc_output")).unwrap(),
+            "torc_output"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn output_dir_arg_rejects_non_utf8_path() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        let bad = OsStr::from_bytes(b"out\xffput");
+        assert!(output_dir_arg(Path::new(bad)).is_err());
     }
 }

--- a/src/client/commands/recover.rs
+++ b/src/client/commands/recover.rs
@@ -18,7 +18,7 @@ use crate::client::commands::slurm::RegenerateDryRunResult;
 use crate::client::report_models::{ResourceUtilizationReport, ResultsReport};
 use crate::client::resource_correction::{
     ResourceAdjustmentReport, ResourceCorrectionContext, ResourceCorrectionOptions,
-    apply_resource_corrections,
+    ResourceCorrectionResult, apply_resource_corrections,
 };
 use crate::client::workflow_manager::WorkflowManager;
 use crate::config::TorcConfig;
@@ -1341,7 +1341,11 @@ fn recover_workflow_interactive(
         dry_run: true, // always preview first in interactive mode
         no_downsize: true,
     };
-    let correction_result = apply_resource_corrections(&correction_ctx, &correction_opts)?;
+    let correction_result = if !correction_opts.include_jobs.is_empty() {
+        apply_resource_corrections(&correction_ctx, &correction_opts)?
+    } else {
+        ResourceCorrectionResult::default()
+    };
 
     // --- Show proposed changes and confirm ------------------------------------
     eprintln!("\n--- Recovery Plan ---\n");
@@ -1490,7 +1494,11 @@ fn recover_workflow_interactive(
         dry_run: false,
         no_downsize: true,
     };
-    let real_result = apply_resource_corrections(&correction_ctx, &real_opts)?;
+    let real_result = if !real_opts.include_jobs.is_empty() {
+        apply_resource_corrections(&correction_ctx, &real_opts)?
+    } else {
+        ResourceCorrectionResult::default()
+    };
 
     // Run recovery hook if applicable
     if !unknown_job_ids.is_empty()

--- a/src/client/commands/recover.rs
+++ b/src/client/commands/recover.rs
@@ -437,20 +437,43 @@ pub fn recover_workflow(
     Ok(result)
 }
 
-/// Check that the workflow is in a valid state for recovery:
-/// - Workflow must be complete (all jobs in terminal state)
-/// - No active workers (compute nodes or scheduled compute nodes)
-fn check_recovery_preconditions(config: &Configuration, workflow_id: i64) -> Result<(), String> {
+/// Check that the workflow is quiesced (safe to modify job statuses):
+/// - Workflow must be complete or canceled (all jobs in terminal state)
+/// - No active compute node workers
+/// - No pending or active scheduled compute nodes (Slurm allocations)
+///
+/// Returns `Err(message)` with a neutral description of what is wrong. Callers can
+/// prepend their own action-specific prefix when surfacing the error to the user.
+pub(crate) fn check_workflow_quiesced(
+    config: &Configuration,
+    workflow_id: i64,
+) -> Result<(), String> {
     // Check if workflow is complete
     let is_complete = apis::workflows_api::is_workflow_complete(config, workflow_id)
         .map_err(|e| format!("Failed to check workflow completion status: {}", e))?;
 
     if !is_complete.is_complete && !is_complete.is_canceled {
-        return Err("Cannot recover: workflow is not complete. \
-             Wait for all jobs to finish or use 'torc workflows cancel' first."
-            .to_string());
+        return Err(
+            "workflow is not complete; wait for all jobs to finish or use \
+             'torc workflows cancel' first"
+                .to_string(),
+        );
     }
 
+    check_no_active_workers(config, workflow_id)
+}
+
+/// Check that no workers are active on the workflow:
+/// - No active compute node workers
+/// - No pending or active scheduled compute nodes (Slurm allocations)
+///
+/// Unlike [`check_workflow_quiesced`], this does NOT require the workflow to be
+/// complete — non-terminal job statuses (uninitialized, blocked, ready) are fine
+/// as long as nothing is executing or about to execute.
+pub(crate) fn check_no_active_workers(
+    config: &Configuration,
+    workflow_id: i64,
+) -> Result<(), String> {
     // Check for active compute nodes
     let active_nodes = apis::compute_nodes_api::list_compute_nodes(
         config,
@@ -466,9 +489,9 @@ fn check_recovery_preconditions(config: &Configuration, workflow_id: i64) -> Res
     .map_err(|e| format!("Failed to check for active compute nodes: {}", e))?;
 
     if !active_nodes.items.is_empty() {
-        return Err("Cannot recover: there are still active compute nodes. \
-             Wait for all workers to exit."
-            .to_string());
+        return Err(
+            "there are still active compute nodes; wait for all workers to exit".to_string(),
+        );
     }
 
     // Check for pending/active scheduled compute nodes
@@ -486,9 +509,11 @@ fn check_recovery_preconditions(config: &Configuration, workflow_id: i64) -> Res
     .map_err(|e| format!("Failed to check for pending scheduled compute nodes: {}", e))?;
 
     if pending_scn.total_count > 0 {
-        return Err("Cannot recover: there are pending Slurm allocations. \
-             Wait for them to start or cancel them with 'torc slurm cancel'."
-            .to_string());
+        return Err(
+            "there are pending Slurm allocations; wait for them to start or cancel them with \
+             'torc slurm cancel'"
+                .to_string(),
+        );
     }
 
     let active_scn = apis::scheduled_compute_nodes_api::list_scheduled_compute_nodes(
@@ -506,11 +531,22 @@ fn check_recovery_preconditions(config: &Configuration, workflow_id: i64) -> Res
 
     if active_scn.total_count > 0 {
         return Err(
-            "Cannot recover: there are active Slurm allocations still running. \
-             Wait for all workers to exit."
+            "there are active Slurm allocations still running; wait for all workers to exit"
                 .to_string(),
         );
     }
+
+    Ok(())
+}
+
+/// Check that the workflow is in a valid state for recovery:
+/// - Workflow must be complete (all jobs in terminal state)
+/// - No active workers (compute nodes or scheduled compute nodes)
+/// - There must be at least one recoverable job
+fn check_recovery_preconditions(config: &Configuration, workflow_id: i64) -> Result<(), String> {
+    // Delegate quiescence checks (1–4) to the shared helper
+    check_workflow_quiesced(config, workflow_id)
+        .map_err(|msg| format!("Cannot recover: {}", msg))?;
 
     // Check that there are actually recoverable jobs. The reset path
     // (`reset_failed_jobs_only`) resets failed, terminated, canceled, and pending_failed jobs, so

--- a/src/client/commands/recover.rs
+++ b/src/client/commands/recover.rs
@@ -827,17 +827,25 @@ pub fn reset_failed_jobs(
         return Ok(0);
     }
 
-    let job_count = job_ids.len();
-
-    apis::workflows_api::reset_workflow_status(config, workflow_id, None)
-        .map_err(|e| format!("Failed to reset workflow status: {}", e))?;
-    info!("  Reset workflow status for workflow {}", workflow_id);
-
-    apis::workflows_api::reset_job_status(config, workflow_id, Some(true))
+    // NOTE: do not reset workflow status here. `reset_workflow_status` bumps
+    // run_id, and every caller of this function follows it with
+    // `reinitialize_workflow`, which already resets workflow status (and bumps
+    // run_id) exactly once. Resetting here too bumps run_id twice per recovery,
+    // leaving a gap (e.g. a recovered job jumping from run 1 to run 3). Reset
+    // only the failed jobs so the run_id bump stays single.
+    //
+    // `reset_job_status` resets all retryable failed jobs workflow-wide (the
+    // `job_ids` argument here only gates the no-op early return above), so use
+    // the server-reported `updated_count` for an accurate count, not job_ids.len().
+    let response = apis::workflows_api::reset_job_status(config, workflow_id, Some(true))
         .map_err(|e| format!("Failed to reset failed job status: {}", e))?;
-    info!("  Reset failed job status for workflow {}", workflow_id);
+    let reset_count = response.updated_count.max(0) as usize;
+    info!(
+        "  Reset {} failed job(s) for workflow {}",
+        reset_count, workflow_id
+    );
 
-    Ok(job_count)
+    Ok(reset_count)
 }
 
 /// Reinitialize the workflow (set up dependencies and fire on_workflow_start actions)

--- a/src/client/commands/recover.rs
+++ b/src/client/commands/recover.rs
@@ -24,6 +24,9 @@ use crate::client::workflow_manager::WorkflowManager;
 use crate::config::TorcConfig;
 use crate::models::JobStatus;
 
+/// Maximum time to wait for the server's database to become healthy when claiming actions.
+const WAIT_FOR_HEALTHY_DATABASE_MINUTES: u64 = 20;
+
 fn torc_command() -> Result<Command, String> {
     if let Ok(path) = std::env::var("TORC_BIN")
         && !path.trim().is_empty()
@@ -1536,6 +1539,11 @@ fn recover_workflow_interactive(
             start_one_worker_per_node,
             ..
         } => {
+            // Reinitialization above re-armed the workflow's on_workflow_start schedule_nodes
+            // action. Mark it executed before submitting so it doesn't re-fire on the first
+            // compute node and submit the action's original allocation count instead of the
+            // user's choice. (The Regenerate path does the equivalent inside handle_regenerate.)
+            mark_on_workflow_start_schedule_actions_executed(config, args.workflow_id)?;
             info!(
                 "Submitting {} allocation(s) with scheduler ID {}...",
                 num_allocations, scheduler_id
@@ -1746,6 +1754,63 @@ fn prompt_scheduler_choice(
             start_one_worker_per_node,
         });
     }
+}
+
+/// Mark the workflow's `on_workflow_start` `schedule_nodes` actions as executed.
+///
+/// `reinitialize_workflow` re-arms these actions (the server clears their `executed` flag and
+/// re-triggers them). When recovery reuses an existing scheduler and submits a user-chosen number
+/// of allocations directly via `torc slurm schedule-nodes`, a re-armed action would otherwise fire
+/// again on the first compute node that starts and submit the action's original `num_allocations`,
+/// ignoring the user's entry. Claiming the actions here marks them executed and prevents that
+/// duplicate, action-defined submission. The `regenerate` path performs the equivalent step inside
+/// `handle_regenerate`. Recovery actions (`is_recovery`) are left untouched.
+pub fn mark_on_workflow_start_schedule_actions_executed(
+    config: &Configuration,
+    workflow_id: i64,
+) -> Result<(), String> {
+    let actions = apis::workflow_actions_api::get_workflow_actions(config, workflow_id)
+        .map_err(|e| format!("Failed to list workflow actions: {}", e))?;
+
+    for action in actions {
+        if action.trigger_type == "on_workflow_start"
+            && action.action_type == "schedule_nodes"
+            && !action.is_recovery
+            && !action.executed
+            && let Some(action_id) = action.id
+        {
+            // Delegate to the shared helper, which treats a 409 Conflict (already claimed by
+            // another process) as `Ok(false)` and surfaces any other failure as an error. We
+            // propagate that error rather than logging and continuing: if the claim genuinely
+            // fails, the action stays armed and would re-fire on a compute node, reintroducing
+            // the duplicate-allocation bug — better to stop and report it.
+            match crate::client::utils::claim_action(
+                config,
+                workflow_id,
+                action_id,
+                None, // login-node submission, no compute node
+                WAIT_FOR_HEALTHY_DATABASE_MINUTES,
+            ) {
+                Ok(true) => {
+                    info!(
+                        "Marked on_workflow_start schedule_nodes action {} as executed to avoid duplicate allocations",
+                        action_id
+                    );
+                }
+                Ok(false) => {
+                    debug!("Action {} already claimed", action_id);
+                }
+                Err(e) => {
+                    return Err(format!(
+                        "Failed to mark on_workflow_start schedule_nodes action {} as executed: {}",
+                        action_id, e
+                    ));
+                }
+            }
+        }
+    }
+
+    Ok(())
 }
 
 /// Submit allocations using an existing scheduler config via `torc slurm schedule-nodes`.

--- a/src/client/commands/watch.rs
+++ b/src/client/commands/watch.rs
@@ -473,6 +473,7 @@ fn poll_until_complete(
                                     unplanned_ready, auto_schedule.threshold
                                 );
                                 match regenerate_and_submit(
+                                    config,
                                     workflow_id,
                                     &auto_schedule.output_dir,
                                     auto_schedule.partition.as_deref(),
@@ -496,6 +497,7 @@ fn poll_until_complete(
                                     auto_schedule.stranded_timeout.as_secs()
                                 );
                                 match regenerate_and_submit(
+                                    config,
                                     workflow_id,
                                     &auto_schedule.output_dir,
                                     auto_schedule.partition.as_deref(),
@@ -590,6 +592,7 @@ fn poll_until_complete(
                             );
                             info!("Auto-schedule: Regenerating schedulers...");
                             match regenerate_and_submit(
+                                config,
                                 workflow_id,
                                 &auto_schedule.output_dir,
                                 auto_schedule.partition.as_deref(),
@@ -1019,6 +1022,7 @@ pub fn run_watch(config: &Configuration, args: &WatchArgs) {
         // Step 5: Regenerate Slurm schedulers (this also marks old actions as executed)
         info!("Regenerating Slurm schedulers...");
         if let Err(e) = regenerate_and_submit(
+            config,
             args.workflow_id,
             &args.output_dir,
             args.partition.as_deref(),

--- a/src/client/resource_correction.rs
+++ b/src/client/resource_correction.rs
@@ -40,7 +40,7 @@ pub struct ResourceCorrectionOptions {
 }
 
 /// Result of applying resource corrections
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Default)]
 pub struct ResourceCorrectionResult {
     pub resource_requirements_updated: usize,
     pub jobs_analyzed: usize,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1011,7 +1011,10 @@ fn main() {
             ai_recovery,
             ai_agent,
         } => {
-            let interactive = !no_prompts && std::io::stdin().is_terminal();
+            // The interactive wizard prints prompts to stderr and reads stdin; that would block
+            // and corrupt `-f json` output, which is meant for scripting. Force non-interactive
+            // whenever JSON output is requested.
+            let interactive = !no_prompts && format != "json" && std::io::stdin().is_terminal();
             let args = RecoverArgs {
                 workflow_id: *workflow_id,
                 output_dir: output_dir.clone(),

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -698,15 +698,48 @@ where
                     {
                         app.toggle_select_all_jobs();
                     }
-                    // Sort the Results table by Peak Memory / Peak CPU. Each
-                    // press cycles None → Desc → Asc → None.
-                    KeyCode::Char('m')
+                    // Sort the Results table by column index (left-to-right
+                    // among sortable columns — every column except Status):
+                    // 1=ID, 2=Job ID, 3=Return, 4=Runtime, 5=Completion,
+                    // 6=Peak Memory, 7=Peak CPU. Each press cycles
+                    // None → Desc → Asc → None.
+                    KeyCode::Char('1')
+                        if app.focus == Focus::Details
+                            && app.detail_view == DetailViewType::Results =>
+                    {
+                        app.cycle_results_sort_id();
+                    }
+                    KeyCode::Char('2')
+                        if app.focus == Focus::Details
+                            && app.detail_view == DetailViewType::Results =>
+                    {
+                        app.cycle_results_sort_job_id();
+                    }
+                    KeyCode::Char('3')
+                        if app.focus == Focus::Details
+                            && app.detail_view == DetailViewType::Results =>
+                    {
+                        app.cycle_results_sort_return();
+                    }
+                    KeyCode::Char('4')
+                        if app.focus == Focus::Details
+                            && app.detail_view == DetailViewType::Results =>
+                    {
+                        app.cycle_results_sort_runtime();
+                    }
+                    KeyCode::Char('5')
+                        if app.focus == Focus::Details
+                            && app.detail_view == DetailViewType::Results =>
+                    {
+                        app.cycle_results_sort_completion();
+                    }
+                    KeyCode::Char('6')
                         if app.focus == Focus::Details
                             && app.detail_view == DetailViewType::Results =>
                     {
                         app.cycle_results_sort_peak_memory();
                     }
-                    KeyCode::Char('p')
+                    KeyCode::Char('7')
                         if app.focus == Focus::Details
                             && app.detail_view == DetailViewType::Results =>
                     {
@@ -747,12 +780,6 @@ where
                     }
                     KeyCode::Char('3') if app.focus == Focus::Workflows => {
                         app.cycle_workflows_sort_user();
-                    }
-                    KeyCode::Char('E')
-                        if app.focus == Focus::Details
-                            && app.detail_view == DetailViewType::Results =>
-                    {
-                        app.cycle_results_sort_runtime();
                     }
                     // Sort the Jobs table by column index 1=ID, 2=Name, 3=Status.
                     KeyCode::Char('1')

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -680,6 +680,24 @@ where
                     {
                         app.request_job_action(JobAction::Retry);
                     }
+                    KeyCode::Char('U')
+                        if app.focus == Focus::Details
+                            && app.detail_view == DetailViewType::Jobs =>
+                    {
+                        app.request_job_action(JobAction::ResetStatus);
+                    }
+                    KeyCode::Char(' ')
+                        if app.focus == Focus::Details
+                            && app.detail_view == DetailViewType::Jobs =>
+                    {
+                        app.toggle_job_selection();
+                    }
+                    KeyCode::Char('*')
+                        if app.focus == Focus::Details
+                            && app.detail_view == DetailViewType::Jobs =>
+                    {
+                        app.toggle_select_all_jobs();
+                    }
                     // Sort the Results table by Peak Memory / Peak CPU. Each
                     // press cycles None → Desc → Asc → None.
                     KeyCode::Char('m')

--- a/src/tui/README.md
+++ b/src/tui/README.md
@@ -27,7 +27,7 @@ torc tui
 
 - **View job details** including full command and status
 - **View job logs** (stdout/stderr) with search and navigation
-- **Cancel**, **terminate**, or **retry** individual jobs
+- **Cancel**, **terminate**, **retry**, or **reset** individual jobs
 - Color-coded job status for quick visual scanning
 
 ### Real-time Monitoring
@@ -214,11 +214,22 @@ Press `l` to view logs:
 
 From the Jobs tab, select a job and use:
 
-| Key | Action    | When to use                              |
-| --- | --------- | ---------------------------------------- |
-| `c` | Cancel    | Stop a pending or running job gracefully |
-| `t` | Terminate | Force-stop a running job                 |
-| `y` | Retry     | Re-queue a failed job                    |
+| Key     | Action     | When to use                                                                                            |
+| ------- | ---------- | ------------------------------------------------------------------------------------------------------ |
+| `c`     | Cancel     | Stop a pending or running job gracefully                                                               |
+| `t`     | Terminate  | Force-stop a running job                                                                               |
+| `y`     | Retry      | Re-queue a failed job                                                                                  |
+| `Space` | Select     | Toggle the current job in the multi-reset selection (and move down)                                    |
+| `*`     | Select all | Select every listed job; press again to clear the selection                                            |
+| `U`     | Reset      | Reset the selected (or current) job(s) to uninitialized for selective rerun (`torc jobs reset-status`) |
+
+To rerun a batch of jobs: filter the Jobs tab (`f`, e.g. by Failed status), press `*` to select all
+listed jobs, `Space` to deselect any you want to keep, then `U` to reset them in one operation.
+Selected jobs are marked with `●` and counted in the pane title.
+
+Resetting warns if any selected job completed successfully (its results are discarded). After
+resetting, re-initialize the workflow (`I`) so downstream dependents are reset too, then run or
+submit it.
 
 ### 8. Viewing Files
 
@@ -342,14 +353,17 @@ Switch to the DAG tab to see job dependencies:
 
 ### Job Actions (Jobs tab only)
 
-| Key     | Action           |
-| ------- | ---------------- |
-| `Enter` | View job details |
-| `l`     | View job logs    |
-| `c`     | Cancel job       |
-| `t`     | Terminate job    |
-| `y`     | Retry failed job |
-| `f`     | Filter jobs      |
+| Key     | Action                    |
+| ------- | ------------------------- |
+| `Enter` | View job details          |
+| `l`     | View job logs             |
+| `c`     | Cancel job                |
+| `t`     | Terminate job             |
+| `y`     | Retry failed job          |
+| `Space` | Toggle job selection      |
+| `*`     | Select all / clear        |
+| `U`     | Reset selected job status |
+| `f`     | Filter jobs               |
 
 ### File Actions (Files tab only)
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -292,6 +292,14 @@ pub const TUI_PAGE_SIZE: i64 = 250;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ResultsSort {
     None,
+    IdDesc,
+    IdAsc,
+    JobIdDesc,
+    JobIdAsc,
+    ReturnDesc,
+    ReturnAsc,
+    CompletionDesc,
+    CompletionAsc,
     PeakMemoryDesc,
     PeakMemoryAsc,
     PeakCpuDesc,
@@ -359,6 +367,38 @@ impl JobsSort {
 }
 
 impl ResultsSort {
+    pub fn cycle_id(self) -> Self {
+        match self {
+            Self::IdDesc => Self::IdAsc,
+            Self::IdAsc => Self::None,
+            _ => Self::IdDesc,
+        }
+    }
+
+    pub fn cycle_job_id(self) -> Self {
+        match self {
+            Self::JobIdDesc => Self::JobIdAsc,
+            Self::JobIdAsc => Self::None,
+            _ => Self::JobIdDesc,
+        }
+    }
+
+    pub fn cycle_return(self) -> Self {
+        match self {
+            Self::ReturnDesc => Self::ReturnAsc,
+            Self::ReturnAsc => Self::None,
+            _ => Self::ReturnDesc,
+        }
+    }
+
+    pub fn cycle_completion(self) -> Self {
+        match self {
+            Self::CompletionDesc => Self::CompletionAsc,
+            Self::CompletionAsc => Self::None,
+            _ => Self::CompletionDesc,
+        }
+    }
+
     /// Cycle: None → Desc → Asc → None for the Peak Memory column. If currently
     /// sorting by another column, jump to PeakMemoryDesc.
     pub fn cycle_peak_memory(self) -> Self {
@@ -382,6 +422,38 @@ impl ResultsSort {
             Self::RuntimeDesc => Self::RuntimeAsc,
             Self::RuntimeAsc => Self::None,
             _ => Self::RuntimeDesc,
+        }
+    }
+
+    pub fn id_indicator(self) -> &'static str {
+        match self {
+            Self::IdDesc => " ↓",
+            Self::IdAsc => " ↑",
+            _ => "",
+        }
+    }
+
+    pub fn job_id_indicator(self) -> &'static str {
+        match self {
+            Self::JobIdDesc => " ↓",
+            Self::JobIdAsc => " ↑",
+            _ => "",
+        }
+    }
+
+    pub fn return_indicator(self) -> &'static str {
+        match self {
+            Self::ReturnDesc => " ↓",
+            Self::ReturnAsc => " ↑",
+            _ => "",
+        }
+    }
+
+    pub fn completion_indicator(self) -> &'static str {
+        match self {
+            Self::CompletionDesc => " ↓",
+            Self::CompletionAsc => " ↑",
+            _ => "",
         }
     }
 
@@ -1358,8 +1430,36 @@ impl App {
     /// missing values sort last in both directions so they don't crowd the
     /// top.
     pub fn apply_results_sort(&mut self) {
+        // RFC3339 completion_time → epoch seconds for ordering; unparseable
+        // timestamps sort last (treated as None below).
+        fn completion_secs(r: &ResultModel) -> Option<i64> {
+            chrono::DateTime::parse_from_rfc3339(&r.completion_time)
+                .ok()
+                .map(|dt| dt.timestamp())
+        }
         match self.results_sort {
             ResultsSort::None => {}
+            ResultsSort::IdDesc => self
+                .results
+                .sort_by_key(|r| (r.id.is_none(), std::cmp::Reverse(r.id.unwrap_or(i64::MIN)))),
+            ResultsSort::IdAsc => self
+                .results
+                .sort_by_key(|r| (r.id.is_none(), r.id.unwrap_or(i64::MAX))),
+            ResultsSort::JobIdDesc => self.results.sort_by_key(|r| std::cmp::Reverse(r.job_id)),
+            ResultsSort::JobIdAsc => self.results.sort_by_key(|r| r.job_id),
+            ResultsSort::ReturnDesc => self
+                .results
+                .sort_by_key(|r| std::cmp::Reverse(r.return_code)),
+            ResultsSort::ReturnAsc => self.results.sort_by_key(|r| r.return_code),
+            // Cache the parsed timestamp per row; unparseable times sort last.
+            ResultsSort::CompletionDesc => self.results.sort_by_cached_key(|r| {
+                let secs = completion_secs(r);
+                (secs.is_none(), std::cmp::Reverse(secs.unwrap_or(0)))
+            }),
+            ResultsSort::CompletionAsc => self.results.sort_by_cached_key(|r| {
+                let secs = completion_secs(r);
+                (secs.is_none(), secs.unwrap_or(0))
+            }),
             ResultsSort::PeakMemoryDesc => {
                 self.results
                     .sort_by(|a, b| match (a.peak_memory_bytes, b.peak_memory_bytes) {
@@ -1410,6 +1510,34 @@ impl App {
                     .sort_by(|a, b| a.exec_time_minutes.total_cmp(&b.exec_time_minutes));
             }
         }
+    }
+
+    pub fn cycle_results_sort_id(&mut self) {
+        let prev_id = self.selected_result_id();
+        self.results_sort = self.results_sort.cycle_id();
+        self.apply_results_sort();
+        self.restore_results_selection(prev_id);
+    }
+
+    pub fn cycle_results_sort_job_id(&mut self) {
+        let prev_id = self.selected_result_id();
+        self.results_sort = self.results_sort.cycle_job_id();
+        self.apply_results_sort();
+        self.restore_results_selection(prev_id);
+    }
+
+    pub fn cycle_results_sort_return(&mut self) {
+        let prev_id = self.selected_result_id();
+        self.results_sort = self.results_sort.cycle_return();
+        self.apply_results_sort();
+        self.restore_results_selection(prev_id);
+    }
+
+    pub fn cycle_results_sort_completion(&mut self) {
+        let prev_id = self.selected_result_id();
+        self.results_sort = self.results_sort.cycle_completion();
+        self.apply_results_sort();
+        self.restore_results_selection(prev_id);
     }
 
     pub fn cycle_results_sort_peak_memory(&mut self) {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -3660,9 +3660,16 @@ impl App {
     }
 
     /// Request a reset for every selected job that is currently listed.
-    /// Returns false when the selection is empty so the caller can fall back
-    /// to the single-job (cursor row) path.
+    /// Returns false only when the multi-select is empty, so the caller can
+    /// fall back to the single-job (cursor row) path. When a selection exists
+    /// but none of its jobs are listed (e.g., the filter changed), this warns
+    /// and returns true so the caller does NOT silently reset the cursor row.
     fn request_selected_jobs_reset(&mut self) -> bool {
+        // An empty selection is the only case where falling back to the
+        // cursor-row job is the intended behavior.
+        if self.selected_job_ids.is_empty() {
+            return false;
+        }
         // Intersect with the listed jobs: selections made under an earlier
         // filter may reference rows that are no longer shown, and acting on
         // invisible jobs would be surprising.
@@ -3672,7 +3679,14 @@ impl App {
             .filter(|j| j.id.is_some_and(|id| self.selected_job_ids.contains(&id)))
             .collect();
         if targets.is_empty() {
-            return false;
+            // A selection exists but none of its jobs are in the current view.
+            // Don't fall through to resetting the cursor row, which the user
+            // didn't pick; tell them their selection is hidden. The selection
+            // is left intact so clearing the filter restores it.
+            self.set_status(StatusMessage::warning(
+                "Selected jobs are not in the current view; clear the filter or press '*' to reselect",
+            ));
+            return true;
         }
 
         let completed = targets

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -145,6 +145,7 @@ pub enum JobAction {
     Cancel,
     Terminate,
     Retry,
+    ResetStatus,
 }
 
 impl JobAction {
@@ -153,6 +154,11 @@ impl JobAction {
             Self::Cancel => format!("Cancel job '{}'?", job_name),
             Self::Terminate => format!("Terminate job '{}'?", job_name),
             Self::Retry => format!("Retry job '{}'?", job_name),
+            Self::ResetStatus => format!(
+                "Reset job '{}' to uninitialized for rerun?\n\
+                 Downstream dependents are reset when the workflow is re-initialized ('I').",
+                job_name
+            ),
         }
     }
 }
@@ -184,6 +190,7 @@ pub enum PopupType {
 pub enum PendingAction {
     Workflow(WorkflowAction, i64, String), // action, workflow_id, workflow_name
     Job(JobAction, i64, String),           // action, job_id, job_name
+    JobsResetStatus(Vec<i64>),             // multi-selection reset (job_ids)
 }
 
 impl DetailViewType {
@@ -570,6 +577,11 @@ pub struct App {
     pub jobs_workflow_id: Option<i64>,
     pub jobs_state: TableState,
     pub jobs_sort: JobsSort,
+    /// Job IDs marked on the Jobs tab (Space / '*') for a multi-job
+    /// reset-status. Cleared when the selected workflow changes; stale IDs
+    /// (e.g. from a row no longer listed after a filter change) are ignored
+    /// at action time by intersecting with the currently-listed jobs.
+    pub selected_job_ids: std::collections::HashSet<i64>,
     /// Offset of the currently-loaded Jobs page on the Jobs detail tab.
     pub jobs_offset: i64,
     /// True when the last Jobs-tab fetch filled a full page.
@@ -711,6 +723,7 @@ impl App {
             jobs_all: Vec::new(),
             jobs_workflow_id: None,
             jobs_state: TableState::default(),
+            selected_job_ids: std::collections::HashSet::new(),
             jobs_sort: JobsSort::None,
             jobs_offset: 0,
             jobs_has_more: false,
@@ -1126,6 +1139,7 @@ impl App {
             // that may have far fewer records.
             if self.selected_workflow_id != workflow_id_opt {
                 self.reset_detail_pagination();
+                self.selected_job_ids.clear();
             }
             self.selected_workflow_id = workflow_id_opt;
             if let Some(workflow_id) = workflow_id_opt {
@@ -2795,6 +2809,12 @@ impl App {
                         self.set_status(StatusMessage::error(&format!("Action error: {}", e)));
                     }
                 }
+                PendingAction::JobsResetStatus(job_ids) => {
+                    let description = format!("{} job(s)", job_ids.len());
+                    if let Err(e) = self.reset_jobs_status_cli(&job_ids, &description) {
+                        self.set_status(StatusMessage::error(&format!("Action error: {}", e)));
+                    }
+                }
             }
         }
         Ok(())
@@ -2906,15 +2926,11 @@ impl App {
             workflow_name
         )));
 
-        let exe_path = self.get_torc_exe_path();
-        let url = self.client.get_base_url();
         let workflow_id_str = workflow_id.to_string();
 
         // First, do a dry-run check to see if there are existing output files
-        let check_output = std::process::Command::new(&exe_path)
-            .args([
-                "--url",
-                url,
+        let check_output = self
+            .torc_cli_command(&[
                 "-f",
                 "json",
                 "workflows",
@@ -3025,23 +3041,14 @@ impl App {
         workflow_name: &str,
         force: bool,
     ) -> Result<()> {
-        let exe_path = self.get_torc_exe_path();
-        let url = self.client.get_base_url();
         let workflow_id_str = workflow_id.to_string();
 
-        let mut args = vec![
-            "--url",
-            &url,
-            "workflows",
-            "init",
-            "--no-prompts",
-            &workflow_id_str,
-        ];
+        let mut args = vec!["workflows", "init", "--no-prompts", &workflow_id_str];
         if force {
             args.push("--force");
         }
 
-        let output = std::process::Command::new(&exe_path).args(&args).output();
+        let output = self.torc_cli_command(&args).output();
 
         match output {
             Ok(output) => {
@@ -3091,16 +3098,14 @@ impl App {
         workflow_name: &str,
         force: bool,
     ) -> Result<()> {
-        let exe_path = self.get_torc_exe_path();
-        let url = self.client.get_base_url();
         let workflow_id_str = workflow_id.to_string();
 
-        let mut args = vec!["--url", &url, "workflows", "reinit", &workflow_id_str];
+        let mut args = vec!["workflows", "reinit", &workflow_id_str];
         if force {
             args.push("--force");
         }
 
-        let output = std::process::Command::new(&exe_path).args(&args).output();
+        let output = self.torc_cli_command(&args).output();
 
         match output {
             Ok(output) => {
@@ -3139,15 +3144,11 @@ impl App {
 
     /// Reset workflow status using CLI command (following torc-dash pattern)
     fn reset_workflow_cli(&mut self, workflow_id: i64, workflow_name: &str) -> Result<()> {
-        let exe_path = self.get_torc_exe_path();
-        let url = self.client.get_base_url();
         let workflow_id_str = workflow_id.to_string();
 
-        // Run CLI command: torc --url <url> workflows reset-status --no-prompts <workflow_id>
-        let output = std::process::Command::new(&exe_path)
-            .args([
-                "--url",
-                url,
+        // Run CLI command: torc workflows reset-status --no-prompts <workflow_id>
+        let output = self
+            .torc_cli_command(&[
                 "workflows",
                 "reset-status",
                 "--no-prompts",
@@ -3190,6 +3191,55 @@ impl App {
         Ok(())
     }
 
+    /// Reset one or more jobs to uninitialized using the CLI command
+    /// (following the reset_workflow_cli pattern). The CLI enforces the safety
+    /// checks: no active workers and no job may be Running or Pending.
+    /// `description` is used in the success message (e.g. "Job 'x'" or
+    /// "3 job(s)").
+    fn reset_jobs_status_cli(&mut self, job_ids: &[i64], description: &str) -> Result<()> {
+        let id_strs: Vec<String> = job_ids.iter().map(|id| id.to_string()).collect();
+        let mut args: Vec<&str> = vec!["jobs", "reset-status", "--no-prompts"];
+        args.extend(id_strs.iter().map(|s| s.as_str()));
+
+        let output = self.torc_cli_command(&args).output();
+
+        match output {
+            Ok(output) => {
+                if output.status.success() {
+                    self.selected_job_ids.clear();
+                    self.set_status(StatusMessage::success(&format!(
+                        "{} reset to uninitialized — press 'I' to re-initialize, then \
+                         run/submit",
+                        description
+                    )));
+                    let _ = self.load_detail_data();
+                } else {
+                    let stderr = String::from_utf8_lossy(&output.stderr);
+                    let stdout = String::from_utf8_lossy(&output.stdout);
+                    let error_msg = if !stderr.trim().is_empty() {
+                        stderr.trim().to_string()
+                    } else if !stdout.trim().is_empty() {
+                        stdout.trim().to_string()
+                    } else {
+                        "Unknown error".to_string()
+                    };
+                    self.set_status(StatusMessage::error(&format!(
+                        "Job reset failed: {}",
+                        error_msg
+                    )));
+                }
+            }
+            Err(e) => {
+                self.set_status(StatusMessage::error(&format!(
+                    "Failed to run jobs reset-status command: {}",
+                    e
+                )));
+            }
+        }
+
+        Ok(())
+    }
+
     /// Get the path to the torc executable
     fn get_torc_exe_path(&self) -> String {
         std::env::current_exe()
@@ -3197,17 +3247,36 @@ impl App {
             .unwrap_or_else(|_| "torc".to_string())
     }
 
+    /// Build a `torc` CLI invocation that connects to the same server as the
+    /// TUI's own API client: forwards `--url` and the TLS flags, and passes
+    /// the basic-auth password via the TORC_PASSWORD environment variable so
+    /// it stays out of process listings. The username needs no forwarding —
+    /// the CLI derives it from the USER environment variable, same as the
+    /// TUI. The cookie header (TORC_COOKIE_HEADER) is already inherited
+    /// through the environment.
+    fn torc_cli_command(&self, args: &[&str]) -> std::process::Command {
+        let mut cmd = std::process::Command::new(self.get_torc_exe_path());
+        cmd.arg("--url").arg(self.client.get_base_url());
+        if let Some(ref ca_cert) = self.tls.ca_cert_path {
+            cmd.arg("--tls-ca-cert").arg(ca_cert);
+        }
+        if self.tls.insecure {
+            cmd.arg("--tls-insecure");
+        }
+        if let Some((_, Some(password))) = &self.basic_auth {
+            cmd.env("TORC_PASSWORD", password);
+        }
+        cmd.args(args);
+        cmd
+    }
+
     fn run_workflow_with_viewer(&mut self, workflow_id: i64, workflow_name: &str) -> Result<()> {
         let mut viewer = ProcessViewer::new(format!("Running: {}", workflow_name));
 
-        let exe_path = self.get_torc_exe_path();
-
-        // Build arguments - note: --url is a global option, must come before subcommand
         let workflow_id_str = workflow_id.to_string();
-        let url = self.client.get_base_url();
-        let args = vec!["--url", &url, "run", &workflow_id_str];
+        let cmd = self.torc_cli_command(&["run", &workflow_id_str]);
 
-        match viewer.start(&exe_path, &args) {
+        match viewer.start(cmd) {
             Ok(()) => {
                 self.previous_focus = self.focus;
                 self.focus = Focus::Popup;
@@ -3241,32 +3310,15 @@ impl App {
         };
         let mut viewer = ProcessViewer::new(title);
 
-        let exe_path = self.get_torc_exe_path();
-
-        // Build arguments - note: --url is a global option, must come before subcommand
         let workflow_id_str = workflow_id.to_string();
-        let url = self.client.get_base_url();
 
         let args: Vec<&str> = if recover {
-            vec![
-                "--url",
-                &url,
-                "watch",
-                &workflow_id_str,
-                "--recover",
-                "--show-job-counts",
-            ]
+            vec!["watch", &workflow_id_str, "--recover", "--show-job-counts"]
         } else {
-            vec![
-                "--url",
-                &url,
-                "watch",
-                &workflow_id_str,
-                "--show-job-counts",
-            ]
+            vec!["watch", &workflow_id_str, "--show-job-counts"]
         };
 
-        match viewer.start(&exe_path, &args) {
+        match viewer.start(self.torc_cli_command(&args)) {
             Ok(()) => {
                 self.previous_focus = self.focus;
                 self.focus = Focus::Popup;
@@ -3304,9 +3356,7 @@ impl App {
         };
         let mut viewer = ProcessViewer::new(title);
 
-        let exe_path = self.get_torc_exe_path();
         let workflow_id_str = workflow_id.to_string();
-        let url = self.client.get_base_url();
         let output_dir = self.output_dir.display().to_string();
         let mem_str = format!("{}", memory_multiplier);
         let rt_str = format!("{}", runtime_multiplier);
@@ -3314,8 +3364,6 @@ impl App {
         // --no-prompts is required because the interactive wizard would
         // try to read from stdin, which the TUI owns.
         let mut args = vec![
-            "--url",
-            &url,
             "recover",
             &workflow_id_str,
             "--output-dir",
@@ -3330,7 +3378,7 @@ impl App {
             args.push("--dry-run");
         }
 
-        match viewer.start(&exe_path, &args) {
+        match viewer.start(self.torc_cli_command(&args)) {
             Ok(()) => {
                 self.previous_focus = self.focus;
                 self.focus = Focus::Popup;
@@ -3450,17 +3498,106 @@ impl App {
             .and_then(|idx| self.jobs.get(idx))
     }
 
+    /// Toggle multi-reset selection on the job under the cursor, then advance
+    /// to the next row so repeated presses sweep down the list.
+    pub fn toggle_job_selection(&mut self) {
+        if let Some(job_id) = self.get_selected_job().and_then(|j| j.id) {
+            if !self.selected_job_ids.insert(job_id) {
+                self.selected_job_ids.remove(&job_id);
+            }
+            self.next_in_active_table();
+        } else {
+            self.set_status(StatusMessage::warning("No job selected"));
+        }
+    }
+
+    /// Select every currently-listed job (respecting the active filter), or
+    /// clear the selection if all listed jobs are already selected.
+    pub fn toggle_select_all_jobs(&mut self) {
+        let listed: Vec<i64> = self.jobs.iter().filter_map(|j| j.id).collect();
+        if listed.is_empty() {
+            self.set_status(StatusMessage::warning("No jobs listed"));
+            return;
+        }
+        if listed.iter().all(|id| self.selected_job_ids.contains(id)) {
+            self.selected_job_ids.clear();
+            self.set_status(StatusMessage::info("Selection cleared"));
+        } else {
+            self.selected_job_ids.extend(&listed);
+            self.set_status(StatusMessage::info(&format!(
+                "Selected {} listed job(s)",
+                listed.len()
+            )));
+        }
+    }
+
+    /// Request a reset for every selected job that is currently listed.
+    /// Returns false when the selection is empty so the caller can fall back
+    /// to the single-job (cursor row) path.
+    fn request_selected_jobs_reset(&mut self) -> bool {
+        // Intersect with the listed jobs: selections made under an earlier
+        // filter may reference rows that are no longer shown, and acting on
+        // invisible jobs would be surprising.
+        let targets: Vec<&JobModel> = self
+            .jobs
+            .iter()
+            .filter(|j| j.id.is_some_and(|id| self.selected_job_ids.contains(&id)))
+            .collect();
+        if targets.is_empty() {
+            return false;
+        }
+
+        let completed = targets
+            .iter()
+            .filter(|j| j.status == Some(JobStatus::Completed))
+            .count();
+        let mut message = format!(
+            "Reset {} selected job(s) to uninitialized for rerun?\n\
+             Downstream dependents are reset when the workflow is re-initialized ('I').",
+            targets.len()
+        );
+        if completed > 0 {
+            message.push_str(&format!(
+                "\nWarning: {} of them completed successfully; resetting discards their \
+                 results and reruns them.",
+                completed
+            ));
+        }
+
+        let job_ids: Vec<i64> = targets.iter().filter_map(|j| j.id).collect();
+        self.previous_focus = self.focus;
+        self.focus = Focus::Popup;
+        self.popup = Some(PopupType::Confirmation {
+            dialog: ConfirmationDialog::new("Reset Job Statuses", &message),
+            action: PendingAction::JobsResetStatus(job_ids),
+        });
+        true
+    }
+
     pub fn request_job_action(&mut self, action: JobAction) {
+        if action == JobAction::ResetStatus && self.request_selected_jobs_reset() {
+            return;
+        }
+
         if let Some(job) = self.get_selected_job() {
             if let Some(job_id) = job.id {
                 let job_name = job.name.clone();
+                let job_status = job.status;
+                let mut message = action.confirmation_message(&job_name);
+                if action == JobAction::ResetStatus && job_status == Some(JobStatus::Completed) {
+                    message.push_str(
+                        "\nWarning: this job completed successfully; resetting discards its \
+                         results and reruns it.",
+                    );
+                }
                 let dialog = ConfirmationDialog::new(
                     match action {
                         JobAction::Cancel => "Cancel Job",
                         JobAction::Terminate => "Terminate Job",
                         JobAction::Retry => "Retry Job",
+                        JobAction::ResetStatus => "Reset Job Status",
                     },
-                    &action.confirmation_message(&job_name),
+                    &message,
                 );
 
                 self.previous_focus = self.focus;
@@ -3476,10 +3613,15 @@ impl App {
     }
 
     fn execute_job_action(&mut self, action: JobAction, job_id: i64, job_name: &str) -> Result<()> {
+        if action == JobAction::ResetStatus {
+            return self.reset_jobs_status_cli(&[job_id], &format!("Job '{}'", job_name));
+        }
+
         let result = match action {
             JobAction::Cancel => self.client.cancel_job(job_id),
             JobAction::Terminate => self.client.terminate_job(job_id),
             JobAction::Retry => self.client.retry_job(job_id),
+            JobAction::ResetStatus => unreachable!("handled above"),
         };
 
         match result {
@@ -3488,6 +3630,7 @@ impl App {
                     JobAction::Cancel => format!("Job '{}' canceled", job_name),
                     JobAction::Terminate => format!("Job '{}' terminated", job_name),
                     JobAction::Retry => format!("Job '{}' queued for retry", job_name),
+                    JobAction::ResetStatus => unreachable!("handled above"),
                 };
                 self.set_status(StatusMessage::success(&msg));
 
@@ -3982,9 +4125,10 @@ impl App {
             .unwrap_or(8080);
 
         let port_str = port.to_string();
-        let args = vec!["run", "--port", &port_str];
+        let mut cmd = std::process::Command::new(&server_path);
+        cmd.args(["run", "--port", &port_str]);
 
-        match viewer.start(&server_path, &args) {
+        match viewer.start(cmd) {
             Ok(()) => {
                 self.server_process = Some(viewer);
                 self.set_status(StatusMessage::success(&format!(
@@ -4050,15 +4194,13 @@ impl App {
         let port_str = port.to_string();
 
         // Build args with optional database path
-        let mut args = vec!["run", "--port", &port_str];
-        let db_path;
+        let mut cmd = std::process::Command::new(&server_path);
+        cmd.args(["run", "--port", &port_str]);
         if let Some(ref db) = self.standalone_database {
-            db_path = db.clone();
-            args.push("--database");
-            args.push(&db_path);
+            cmd.arg("--database").arg(db);
         }
 
-        match viewer.start(&server_path, &args) {
+        match viewer.start(cmd) {
             Ok(()) => {
                 self.server_process = Some(viewer);
             }

--- a/src/tui/components.rs
+++ b/src/tui/components.rs
@@ -56,8 +56,22 @@ impl ConfirmationDialog {
 
     pub fn render(&self, f: &mut Frame, area: Rect) {
         // Calculate dialog size - center in screen
-        let dialog_width = 50.min(area.width.saturating_sub(4));
-        let dialog_height = 7.min(area.height.saturating_sub(2));
+        let dialog_width = 60.min(area.width.saturating_sub(4));
+        // Estimate the wrapped height of the message so multi-line content
+        // (e.g. the multi-job reset warning) is not clipped. Wrapping is
+        // word-based, so estimate against a slightly narrower width than the
+        // real text area to err on the tall side.
+        let text_width = dialog_width.saturating_sub(6).max(1) as usize;
+        let message_lines: u16 = self
+            .message
+            .lines()
+            .map(|l| l.chars().count().div_ceil(text_width).max(1) as u16)
+            .sum();
+        // .max then .min (not clamp): on a terminal shorter than 9 rows the
+        // upper bound drops below the lower one, which would make clamp panic.
+        let dialog_height = (message_lines + 3)
+            .max(7)
+            .min(area.height.saturating_sub(2));
 
         let dialog_x = (area.width.saturating_sub(dialog_width)) / 2;
         let dialog_y = (area.height.saturating_sub(dialog_height)) / 2;
@@ -556,6 +570,18 @@ impl HelpPopup {
                 lines.push(Self::key_line("C", "Cancel job"));
                 lines.push(Self::key_line("t", "Terminate job"));
                 lines.push(Self::key_line("y", "Retry failed job"));
+                lines.push(Self::key_line(
+                    "Space",
+                    "Toggle job selection for multi-reset",
+                ));
+                lines.push(Self::key_line(
+                    "*",
+                    "Select all listed jobs / clear selection",
+                ));
+                lines.push(Self::key_line(
+                    "U",
+                    "Reset selected (or current) job(s) to uninitialized for rerun",
+                ));
                 lines.push(Self::key_line("1 / 2 / 3", "Sort by ID / Name / Status"));
             }
             HelpContext::DetailResults => {
@@ -1567,10 +1593,10 @@ impl ProcessViewer {
         }
     }
 
-    /// Start a process and capture its output
-    pub fn start(&mut self, program: &str, args: &[&str]) -> Result<(), String> {
-        let mut cmd = Command::new(program);
-        cmd.args(args).stdout(Stdio::piped()).stderr(Stdio::piped());
+    /// Start a process and capture its output. Takes a prebuilt `Command` so
+    /// callers can attach connection arguments and environment variables.
+    pub fn start(&mut self, mut cmd: Command) -> Result<(), String> {
+        cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
 
         let mut child = cmd
             .spawn()
@@ -1604,8 +1630,16 @@ impl ProcessViewer {
         self.child = Some(child);
         self.output_receiver = Some(rx);
         self.is_running = true;
-        self.output_lines
-            .push(format!("Started: {} {}", program, args.join(" ")));
+        let args_display = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy())
+            .collect::<Vec<_>>()
+            .join(" ");
+        self.output_lines.push(format!(
+            "Started: {} {}",
+            cmd.get_program().to_string_lossy(),
+            args_display
+        ));
         self.output_lines.push(String::new());
 
         Ok(())

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1198,16 +1198,20 @@ fn draw_results_table(f: &mut Frame, area: Rect, app: &mut App) {
         .fg(Color::Yellow)
         .add_modifier(Modifier::BOLD);
 
+    let id_header = format!("ID{}", app.results_sort.id_indicator());
+    let job_id_header = format!("Job ID{}", app.results_sort.job_id_indicator());
+    let return_header = format!("Return{}", app.results_sort.return_indicator());
+    let completion_header = format!("Completion Time{}", app.results_sort.completion_indicator());
     let peak_mem_header = format!("Peak Mem{}", app.results_sort.peak_memory_indicator());
     let peak_cpu_header = format!("Peak CPU %{}", app.results_sort.peak_cpu_indicator());
     let runtime_header = format!("Runtime (m){}", app.results_sort.runtime_indicator());
     let header = Row::new(vec![
-        "ID".to_string(),
-        "Job ID".to_string(),
-        "Return".to_string(),
+        id_header,
+        job_id_header,
+        return_header,
         "Status".to_string(),
         runtime_header,
-        "Completion Time".to_string(),
+        completion_header,
         peak_mem_header,
         peak_cpu_header,
     ])
@@ -1267,7 +1271,7 @@ fn draw_results_table(f: &mut Frame, area: Rect, app: &mut App) {
                 Span::styled(filter, Style::default().fg(Color::Magenta)),
                 Span::styled(page, Style::default().fg(Color::DarkGray)),
                 Span::styled(
-                    " │ l: logs  m: peak mem  p: peak cpu",
+                    " │ l: logs  │ sort: 1 id  2 job id  3 return  4 runtime  5 completion  6 peak mem  7 peak cpu",
                     Style::default().fg(Color::DarkGray),
                 ),
             ]),

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -243,6 +243,12 @@ fn draw_help(f: &mut Frame, area: Rect, app: &App) {
             Span::raw(": terminate | "),
             Span::styled("y", Style::default().fg(Color::Yellow)),
             Span::raw(": retry | "),
+            Span::styled("Space", Style::default().fg(Color::Yellow)),
+            Span::raw(": select | "),
+            Span::styled("*", Style::default().fg(Color::Yellow)),
+            Span::raw(": select all | "),
+            Span::styled("U", Style::default().fg(Color::Yellow)),
+            Span::raw(": reset | "),
             Span::styled("f", Style::default().fg(Color::Yellow)),
             Span::raw(": filter | "),
             Span::styled("Tab", Style::default().fg(Color::Yellow)),
@@ -810,7 +816,13 @@ fn draw_jobs_table(f: &mut Frame, area: Rect, app: &mut App) {
     .bottom_margin(1);
 
     let rows = app.jobs.iter().map(|job| {
-        let id = job.id.map(|i| i.to_string()).unwrap_or_default();
+        let selected = job.id.is_some_and(|id| app.selected_job_ids.contains(&id));
+        let marker = if selected { "● " } else { "  " };
+        let id = format!(
+            "{}{}",
+            marker,
+            job.id.map(|i| i.to_string()).unwrap_or_default()
+        );
         let name = job.name.clone();
         let (status_str, color) = match job.status {
             Some(s) => (format!("{:?}", s), status_color(s)),
@@ -828,8 +840,13 @@ fn draw_jobs_table(f: &mut Frame, area: Rect, app: &mut App) {
         };
         let command = job.command.clone();
 
+        let id_style = if selected {
+            Style::default().fg(Color::Yellow)
+        } else {
+            Style::default()
+        };
         Row::new(vec![
-            Cell::from(id),
+            Cell::from(Span::styled(id, id_style)),
             Cell::from(name),
             Cell::from(Span::styled(status_str, Style::default().fg(color))),
             Cell::from(node),
@@ -840,15 +857,21 @@ fn draw_jobs_table(f: &mut Frame, area: Rect, app: &mut App) {
 
     let filter = filter_suffix(app, FilterTarget::Details);
     let page = page_suffix(app.jobs_offset, app.jobs_has_more);
+    let selection = if app.selected_job_ids.is_empty() {
+        String::new()
+    } else {
+        format!(" [{} selected]", app.selected_job_ids.len())
+    };
     let (title, border_style) = if app.focus == Focus::Details {
         (
             Line::from(vec![
                 Span::styled("▶ ", Style::default().fg(Color::Green)),
                 Span::styled("Jobs", Style::default().fg(Color::White)),
                 Span::styled(filter, Style::default().fg(Color::Magenta)),
+                Span::styled(selection.clone(), Style::default().fg(Color::Yellow)),
                 Span::styled(page, Style::default().fg(Color::DarkGray)),
                 Span::styled(
-                    " │ Enter: details  l: logs  C: cancel  t: terminate  y: retry",
+                    " │ Enter: details  l: logs  Space: select  *: all  C: cancel  t: terminate  y: retry  U: reset  │ sort: 1 id  2 name  3 status",
                     Style::default().fg(Color::DarkGray),
                 ),
             ]),
@@ -860,6 +883,7 @@ fn draw_jobs_table(f: &mut Frame, area: Rect, app: &mut App) {
                 Span::styled("▶ ", Style::default().fg(Color::Cyan)),
                 Span::styled("Jobs", Style::default().fg(Color::White)),
                 Span::styled(filter, Style::default().fg(Color::Magenta)),
+                Span::styled(selection, Style::default().fg(Color::Yellow)),
                 Span::styled(page, Style::default().fg(Color::DarkGray)),
             ]),
             Style::default().fg(Color::DarkGray),
@@ -869,7 +893,7 @@ fn draw_jobs_table(f: &mut Frame, area: Rect, app: &mut App) {
     let table = Table::new(
         rows,
         [
-            Constraint::Length(8),
+            Constraint::Length(10),
             Constraint::Length(20),
             Constraint::Length(15),
             Constraint::Length(6),

--- a/tests/test_jobs_reset_status.rs
+++ b/tests/test_jobs_reset_status.rs
@@ -1,0 +1,1236 @@
+mod common;
+
+use common::{
+    ServerProcess, create_test_compute_node, create_test_workflow, get_exe_path, run_cli_with_json,
+    start_server,
+};
+use rstest::rstest;
+use torc::client::apis;
+use torc::client::workflow_manager::WorkflowManager;
+use torc::config::TorcConfig;
+use torc::models;
+use torc::models::JobStatus;
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/// Initialize a freshly-created workflow and return its run_id.
+fn initialize_workflow(
+    config: &torc::client::Configuration,
+    workflow: &models::WorkflowModel,
+) -> i64 {
+    let workflow_id = workflow.id.unwrap();
+    let torc_config = TorcConfig::load().unwrap_or_default();
+    let manager = WorkflowManager::new(config.clone(), torc_config, workflow.clone());
+    manager
+        .initialize(false)
+        .expect("Failed to initialize workflow");
+    apis::workflows_api::get_workflow(config, workflow_id)
+        .expect("Failed to get workflow after init")
+        .run_id
+        .unwrap_or(1)
+}
+
+/// Complete a job via complete_job (never via manage_status_change per CLAUDE.md).
+fn complete_job(
+    config: &torc::client::Configuration,
+    job_id: i64,
+    workflow_id: i64,
+    compute_node_id: i64,
+    run_id: i64,
+    return_code: i64,
+    status: JobStatus,
+) {
+    let result = models::ResultModel::new(
+        job_id,
+        workflow_id,
+        run_id,
+        1, // attempt_id
+        compute_node_id,
+        return_code,
+        1.0, // exec_time_minutes
+        chrono::Utc::now().to_rfc3339(),
+        status,
+    );
+    apis::jobs_api::complete_job(config, job_id, status, run_id, result)
+        .unwrap_or_else(|e| panic!("Failed to complete job {}: {}", job_id, e));
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: Selective reset — only targeted jobs are reset, others unchanged
+// ---------------------------------------------------------------------------
+#[rstest]
+fn test_reset_status_selective(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let workflow = create_test_workflow(config, "reset_selective");
+    let workflow_id = workflow.id.unwrap();
+
+    // Create 3 independent jobs
+    let job1 = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(workflow_id, "job1".to_string(), "echo job1".to_string()),
+    )
+    .expect("Failed to create job1");
+    let job1_id = job1.id.unwrap();
+
+    let job2 = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(workflow_id, "job2".to_string(), "echo job2".to_string()),
+    )
+    .expect("Failed to create job2");
+    let job2_id = job2.id.unwrap();
+
+    let job3 = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(workflow_id, "job3".to_string(), "echo job3".to_string()),
+    )
+    .expect("Failed to create job3");
+    let job3_id = job3.id.unwrap();
+
+    let run_id = initialize_workflow(config, &workflow);
+    let compute_node = create_test_compute_node(config, workflow_id);
+    let cn_id = compute_node.id.unwrap();
+
+    // Advance all to running then fail them all
+    for &id in &[job1_id, job2_id, job3_id] {
+        apis::jobs_api::manage_status_change(config, id, JobStatus::Running, run_id)
+            .unwrap_or_else(|e| panic!("Failed to set job {} running: {}", id, e));
+    }
+    complete_job(
+        config,
+        job1_id,
+        workflow_id,
+        cn_id,
+        run_id,
+        1,
+        JobStatus::Failed,
+    );
+    complete_job(
+        config,
+        job2_id,
+        workflow_id,
+        cn_id,
+        run_id,
+        1,
+        JobStatus::Failed,
+    );
+    complete_job(
+        config,
+        job3_id,
+        workflow_id,
+        cn_id,
+        run_id,
+        1,
+        JobStatus::Failed,
+    );
+
+    // Reset only job1 and job2
+    let json = run_cli_with_json(
+        &[
+            "jobs",
+            "reset-status",
+            "--no-prompts",
+            &job1_id.to_string(),
+            &job2_id.to_string(),
+        ],
+        start_server,
+        None,
+    )
+    .expect("reset-status should succeed");
+
+    assert_eq!(json["status"], "success");
+    assert_eq!(json["workflow_id"], workflow_id);
+
+    // job1 and job2 must be Uninitialized; job3 must remain Failed
+    assert_eq!(
+        apis::jobs_api::get_job(config, job1_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Uninitialized,
+        "job1 should be Uninitialized"
+    );
+    assert_eq!(
+        apis::jobs_api::get_job(config, job2_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Uninitialized,
+        "job2 should be Uninitialized"
+    );
+    assert_eq!(
+        apis::jobs_api::get_job(config, job3_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Failed,
+        "job3 should remain Failed"
+    );
+
+    // Workflow run_id must be unchanged (only reinit bumps it)
+    let wf_after = apis::workflows_api::get_workflow(config, workflow_id).unwrap();
+    assert_eq!(
+        wf_after.run_id.unwrap_or(0),
+        run_id,
+        "run_id must not change on reset-status"
+    );
+
+    // reinit object must be present with requested=false when flag is absent
+    assert_eq!(
+        json["reinit"]["requested"], false,
+        "reinit.requested should be false"
+    );
+    assert_eq!(
+        json["reinit"]["applied"], false,
+        "reinit.applied should be false"
+    );
+    assert!(
+        json["reinit"]["error"].is_null(),
+        "reinit.error should be null"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: Downstream closure via reinitialize — A→B→C all completed; reset A.
+// The command resets ONLY A. Immediately after: A is uninitialized, B is
+// uninitialized (the server's incidental one-level reset of direct
+// Completed/Failed dependents on complete→uninitialized), C is STILL
+// completed. The dry-run output lists B and C as downstream-affected. Then
+// 'workflows reinit' resets C too via the server's recursive
+// uninitialize_blocked_jobs CTE (observable afterwards as Blocked, since
+// reinit recomputes blocked/ready in the same transaction).
+// ---------------------------------------------------------------------------
+#[rstest]
+fn test_reset_status_recursive_downstream(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let workflow = create_test_workflow(config, "reset_downstream");
+    let workflow_id = workflow.id.unwrap();
+
+    // Create a linear chain: A → B → C
+    let job_a = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(workflow_id, "job_a".to_string(), "echo a".to_string()),
+    )
+    .expect("Failed to create job_a");
+    let a_id = job_a.id.unwrap();
+
+    let mut job_b_model =
+        models::JobModel::new(workflow_id, "job_b".to_string(), "echo b".to_string());
+    job_b_model.depends_on_job_ids = Some(vec![a_id]);
+    job_b_model.cancel_on_blocking_job_failure = Some(false);
+    let job_b = apis::jobs_api::create_job(config, job_b_model).expect("Failed to create job_b");
+    let b_id = job_b.id.unwrap();
+
+    let mut job_c_model =
+        models::JobModel::new(workflow_id, "job_c".to_string(), "echo c".to_string());
+    job_c_model.depends_on_job_ids = Some(vec![b_id]);
+    job_c_model.cancel_on_blocking_job_failure = Some(false);
+    let job_c = apis::jobs_api::create_job(config, job_c_model).expect("Failed to create job_c");
+    let c_id = job_c.id.unwrap();
+
+    let run_id = initialize_workflow(config, &workflow);
+    let compute_node = create_test_compute_node(config, workflow_id);
+    let cn_id = compute_node.id.unwrap();
+
+    // Complete all three successfully (chain A→B→C all done)
+    apis::jobs_api::manage_status_change(config, a_id, JobStatus::Running, run_id)
+        .expect("set a running");
+    complete_job(
+        config,
+        a_id,
+        workflow_id,
+        cn_id,
+        run_id,
+        0,
+        JobStatus::Completed,
+    );
+
+    // After A completes, unblocking fires and B becomes ready
+    // Advance B to running and complete it
+    apis::jobs_api::manage_status_change(config, b_id, JobStatus::Running, run_id)
+        .expect("set b running");
+    complete_job(
+        config,
+        b_id,
+        workflow_id,
+        cn_id,
+        run_id,
+        0,
+        JobStatus::Completed,
+    );
+
+    // After B completes, C becomes ready
+    apis::jobs_api::manage_status_change(config, c_id, JobStatus::Running, run_id)
+        .expect("set c running");
+    complete_job(
+        config,
+        c_id,
+        workflow_id,
+        cn_id,
+        run_id,
+        0,
+        JobStatus::Completed,
+    );
+
+    // Sanity: all completed
+    assert_eq!(
+        apis::jobs_api::get_job(config, a_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Completed
+    );
+    assert_eq!(
+        apis::jobs_api::get_job(config, b_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Completed
+    );
+    assert_eq!(
+        apis::jobs_api::get_job(config, c_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Completed
+    );
+
+    // Dry-run first: the display must list B and C as downstream-affected
+    let dry = run_cli_with_json(
+        &[
+            "jobs",
+            "reset-status",
+            "--no-prompts",
+            "--force",
+            "--dry-run",
+            &a_id.to_string(),
+        ],
+        start_server,
+        None,
+    )
+    .expect("dry-run should succeed");
+    assert_eq!(dry["dry_run"], true);
+    let dry_requested: Vec<i64> = dry["jobs"]
+        .as_array()
+        .expect("jobs should be an array")
+        .iter()
+        .map(|j| j["job_id"].as_i64().unwrap())
+        .collect();
+    assert_eq!(dry_requested, vec![a_id], "only A should be requested");
+    let dry_downstream: Vec<i64> = dry["downstream_jobs"]
+        .as_array()
+        .expect("downstream_jobs should be an array")
+        .iter()
+        .map(|j| j["job_id"].as_i64().unwrap())
+        .collect();
+    assert_eq!(
+        dry_downstream,
+        vec![b_id, c_id],
+        "B and C should be listed as downstream-affected"
+    );
+
+    // Reset only A — the command must issue status changes for A only
+    let json = run_cli_with_json(
+        &[
+            "jobs",
+            "reset-status",
+            "--no-prompts",
+            "--force",
+            &a_id.to_string(),
+        ],
+        start_server,
+        None,
+    )
+    .expect("reset-status should succeed");
+
+    assert_eq!(json["status"], "success");
+
+    // Only A was explicitly reset; B and C appear as informational downstream
+    let reset_ids: Vec<i64> = json["reset_job_ids"]
+        .as_array()
+        .expect("reset_job_ids should be an array")
+        .iter()
+        .map(|v| v.as_i64().unwrap())
+        .collect();
+    assert_eq!(reset_ids, vec![a_id], "only A should have been reset");
+    let downstream_ids: Vec<i64> = json["downstream_jobs"]
+        .as_array()
+        .expect("downstream_jobs should be an array")
+        .iter()
+        .map(|j| j["job_id"].as_i64().unwrap())
+        .collect();
+    assert_eq!(
+        downstream_ids,
+        vec![b_id, c_id],
+        "B and C should be listed as downstream-affected"
+    );
+
+    // Intermediate state: A uninitialized; B uninitialized too (the server's
+    // incidental one-level reset of direct Completed/Failed dependents on
+    // complete→uninitialized); C STILL completed.
+    assert_eq!(
+        apis::jobs_api::get_job(config, a_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Uninitialized,
+        "A should be Uninitialized"
+    );
+    assert_eq!(
+        apis::jobs_api::get_job(config, b_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Uninitialized,
+        "B should be Uninitialized (server's one-level reset of direct dependents)"
+    );
+    assert_eq!(
+        apis::jobs_api::get_job(config, c_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Completed,
+        "C should STILL be Completed until reinit"
+    );
+
+    // Reinitialize: the server's recursive uninitialize_blocked_jobs CTE resets
+    // C within the same transaction, then blocked/ready are recomputed —
+    // A (no deps) becomes Ready, B and C become Blocked. C is no longer Completed.
+    let torc_config = TorcConfig::load().unwrap_or_default();
+    let updated_wf = apis::workflows_api::get_workflow(config, workflow_id).unwrap();
+    let manager = WorkflowManager::new(config.clone(), torc_config, updated_wf);
+    manager
+        .reinitialize(false, false)
+        .expect("reinitialize failed");
+
+    assert_eq!(
+        apis::jobs_api::get_job(config, a_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Ready,
+        "A should be Ready after reinit"
+    );
+    assert_eq!(
+        apis::jobs_api::get_job(config, b_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Blocked,
+        "B should be Blocked after reinit (depends on A)"
+    );
+    assert_eq!(
+        apis::jobs_api::get_job(config, c_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Blocked,
+        "C should be Blocked after reinit (recursive CTE reset it from Completed)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: Cross-workflow rejection — IDs from two workflows → hard error,
+//         nothing reset in either workflow
+// ---------------------------------------------------------------------------
+#[rstest]
+fn test_reset_status_cross_workflow_rejected(start_server: &ServerProcess) {
+    let config = &start_server.config;
+
+    let wf1 = create_test_workflow(config, "reset_xwf1");
+    let wf2 = create_test_workflow(config, "reset_xwf2");
+    let wf1_id = wf1.id.unwrap();
+    let wf2_id = wf2.id.unwrap();
+
+    let job_in_wf1 = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(wf1_id, "j1".to_string(), "echo 1".to_string()),
+    )
+    .expect("create j1");
+    let j1_id = job_in_wf1.id.unwrap();
+
+    let job_in_wf2 = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(wf2_id, "j2".to_string(), "echo 2".to_string()),
+    )
+    .expect("create j2");
+    let j2_id = job_in_wf2.id.unwrap();
+
+    initialize_workflow(config, &wf1);
+    initialize_workflow(config, &wf2);
+
+    // Attempt to reset jobs from two different workflows — must fail
+    let result = run_cli_with_json(
+        &[
+            "jobs",
+            "reset-status",
+            "--no-prompts",
+            "--force",
+            &j1_id.to_string(),
+            &j2_id.to_string(),
+        ],
+        start_server,
+        None,
+    );
+    assert!(result.is_err(), "Should fail for cross-workflow IDs");
+
+    // Neither job should have been touched
+    assert_eq!(
+        apis::jobs_api::get_job(config, j1_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Ready,
+        "j1 should still be Ready (untouched)"
+    );
+    assert_eq!(
+        apis::jobs_api::get_job(config, j2_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Ready,
+        "j2 should still be Ready (untouched)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: Unknown ID → clear error, nothing reset
+// ---------------------------------------------------------------------------
+#[rstest]
+fn test_reset_status_unknown_id(start_server: &ServerProcess) {
+    let result = run_cli_with_json(
+        &[
+            "jobs",
+            "reset-status",
+            "--no-prompts",
+            "--force",
+            "999999999",
+        ],
+        start_server,
+        None,
+    );
+    assert!(result.is_err(), "Should fail for unknown job ID");
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: Active-job guard — Running job rejected without --force,
+//         proceeds with --force
+// ---------------------------------------------------------------------------
+#[rstest]
+fn test_reset_status_active_job_guard(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let workflow = create_test_workflow(config, "reset_active_guard");
+    let workflow_id = workflow.id.unwrap();
+
+    let job = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(
+            workflow_id,
+            "active_job".to_string(),
+            "sleep 60".to_string(),
+        ),
+    )
+    .expect("create job");
+    let job_id = job.id.unwrap();
+
+    let run_id = initialize_workflow(config, &workflow);
+
+    // Set job to Running (using manage_status_change — legitimate for advancing to Running)
+    apis::jobs_api::manage_status_change(config, job_id, JobStatus::Running, run_id)
+        .expect("set running");
+
+    // Without --force: should be rejected because of Running status
+    let result_no_force = run_cli_with_json(
+        &["jobs", "reset-status", "--no-prompts", &job_id.to_string()],
+        start_server,
+        None,
+    );
+    assert!(
+        result_no_force.is_err(),
+        "Should fail for Running job without --force"
+    );
+    // Job must still be Running
+    assert_eq!(
+        apis::jobs_api::get_job(config, job_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Running,
+        "Job should still be Running after rejected reset"
+    );
+
+    // With --force: should succeed
+    let json = run_cli_with_json(
+        &[
+            "jobs",
+            "reset-status",
+            "--no-prompts",
+            "--force",
+            &job_id.to_string(),
+        ],
+        start_server,
+        None,
+    )
+    .expect("reset-status with --force should succeed");
+
+    assert_eq!(json["status"], "success");
+    assert_eq!(
+        apis::jobs_api::get_job(config, job_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Uninitialized,
+        "Job should be Uninitialized after forced reset"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: Dry-run — no status changes occur, output lists jobs
+// ---------------------------------------------------------------------------
+#[rstest]
+fn test_reset_status_dry_run(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let workflow = create_test_workflow(config, "reset_dry_run");
+    let workflow_id = workflow.id.unwrap();
+
+    let job = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(workflow_id, "dry_job".to_string(), "echo dry".to_string()),
+    )
+    .expect("create job");
+    let job_id = job.id.unwrap();
+
+    let run_id = initialize_workflow(config, &workflow);
+    let compute_node = create_test_compute_node(config, workflow_id);
+    let cn_id = compute_node.id.unwrap();
+
+    // Complete the job
+    apis::jobs_api::manage_status_change(config, job_id, JobStatus::Running, run_id)
+        .expect("set running");
+    complete_job(
+        config,
+        job_id,
+        workflow_id,
+        cn_id,
+        run_id,
+        1,
+        JobStatus::Failed,
+    );
+
+    // Dry-run
+    let json = run_cli_with_json(
+        &[
+            "jobs",
+            "reset-status",
+            "--no-prompts",
+            "--force",
+            "--dry-run",
+            &job_id.to_string(),
+        ],
+        start_server,
+        None,
+    )
+    .expect("dry-run should succeed");
+
+    assert_eq!(json["dry_run"], true);
+    assert_eq!(json["workflow_id"], workflow_id);
+    let jobs_arr = json["jobs"].as_array().expect("should have jobs array");
+    assert!(!jobs_arr.is_empty(), "dry-run should list jobs to reset");
+
+    // Status must be unchanged (still Failed)
+    assert_eq!(
+        apis::jobs_api::get_job(config, job_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Failed,
+        "Job should still be Failed after dry-run"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 7: End-to-end flow — reset subset → reinit → reset jobs become
+//         ready/blocked, run_id bumped exactly once
+// ---------------------------------------------------------------------------
+#[rstest]
+fn test_reset_status_end_to_end_reinit(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let workflow = create_test_workflow(config, "reset_e2e_reinit");
+    let workflow_id = workflow.id.unwrap();
+
+    // A → B (B depends on A)
+    let job_a = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(workflow_id, "e2e_a".to_string(), "echo a".to_string()),
+    )
+    .expect("create a");
+    let a_id = job_a.id.unwrap();
+
+    let mut job_b_model =
+        models::JobModel::new(workflow_id, "e2e_b".to_string(), "echo b".to_string());
+    job_b_model.depends_on_job_ids = Some(vec![a_id]);
+    let job_b = apis::jobs_api::create_job(config, job_b_model).expect("create b");
+    let b_id = job_b.id.unwrap();
+
+    let run_id_before = initialize_workflow(config, &workflow);
+    let compute_node = create_test_compute_node(config, workflow_id);
+    let cn_id = compute_node.id.unwrap();
+
+    // Complete A, then complete B
+    apis::jobs_api::manage_status_change(config, a_id, JobStatus::Running, run_id_before)
+        .expect("set a running");
+    complete_job(
+        config,
+        a_id,
+        workflow_id,
+        cn_id,
+        run_id_before,
+        0,
+        JobStatus::Completed,
+    );
+
+    apis::jobs_api::manage_status_change(config, b_id, JobStatus::Running, run_id_before)
+        .expect("set b running");
+    complete_job(
+        config,
+        b_id,
+        workflow_id,
+        cn_id,
+        run_id_before,
+        1,
+        JobStatus::Failed,
+    );
+
+    // Reset only B (failed) — A is also completed and is upstream, but NOT in the closure
+    // because we only requested B, and A is not downstream of B
+    let json = run_cli_with_json(
+        &[
+            "jobs",
+            "reset-status",
+            "--no-prompts",
+            "--force",
+            &b_id.to_string(),
+        ],
+        start_server,
+        None,
+    )
+    .expect("reset-status should succeed");
+
+    assert_eq!(json["status"], "success");
+
+    // B should be Uninitialized; A remains Completed
+    assert_eq!(
+        apis::jobs_api::get_job(config, b_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Uninitialized,
+        "B should be Uninitialized after reset"
+    );
+    assert_eq!(
+        apis::jobs_api::get_job(config, a_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Completed,
+        "A should remain Completed"
+    );
+
+    // Now reinitialize — this bumps run_id exactly once
+    let torc_config = TorcConfig::load().unwrap_or_default();
+    let updated_wf = apis::workflows_api::get_workflow(config, workflow_id).unwrap();
+    let manager = WorkflowManager::new(config.clone(), torc_config, updated_wf);
+    manager
+        .reinitialize(false, false)
+        .expect("reinitialize failed");
+
+    let run_id_after = apis::workflows_api::get_workflow(config, workflow_id)
+        .unwrap()
+        .run_id
+        .unwrap_or(0);
+    assert_eq!(
+        run_id_after,
+        run_id_before + 1,
+        "run_id should be bumped exactly once by reinitialize"
+    );
+
+    // After reinit, B (which depends on A=Completed) should be Ready
+    let b_after = apis::jobs_api::get_job(config, b_id).unwrap();
+    assert_eq!(
+        b_after.status.unwrap(),
+        JobStatus::Ready,
+        "B should be Ready after reinitialize (A is still Completed)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 8: Idempotency — resetting an already-uninitialized job succeeds as
+//         a no-op (no error, no status change)
+// ---------------------------------------------------------------------------
+#[rstest]
+fn test_reset_status_idempotent(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let workflow = create_test_workflow(config, "reset_idempotent");
+    let workflow_id = workflow.id.unwrap();
+
+    // Job is in Uninitialized state (before initialize_jobs)
+    let job = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(workflow_id, "uninit_job".to_string(), "echo x".to_string()),
+    )
+    .expect("create job");
+    let job_id = job.id.unwrap();
+
+    // Do NOT initialize — job stays Uninitialized
+    assert_eq!(
+        apis::jobs_api::get_job(config, job_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Uninitialized,
+        "Job should start Uninitialized"
+    );
+
+    // Reset an already-uninitialized job — should succeed (warns but no error)
+    let json = run_cli_with_json(
+        &[
+            "jobs",
+            "reset-status",
+            "--no-prompts",
+            "--force",
+            &job_id.to_string(),
+        ],
+        start_server,
+        None,
+    )
+    .expect("resetting uninitialized job should succeed as no-op");
+
+    assert_eq!(json["status"], "success");
+    assert_eq!(
+        apis::jobs_api::get_job(config, job_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Uninitialized,
+        "Job should remain Uninitialized"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 9: --reinit flag end-to-end — reset + reinit in one invocation.
+//         A → B (B depends on A). Both completed. Reset B with --reinit.
+//         Assert: B uninitialized then ready after reinit, A unchanged,
+//         run_id bumped by exactly 1.
+// ---------------------------------------------------------------------------
+#[rstest]
+fn test_reset_status_reinit_flag_end_to_end(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let workflow = create_test_workflow(config, "reset_reinit_e2e");
+    let workflow_id = workflow.id.unwrap();
+
+    let job_a = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(
+            workflow_id,
+            "reinit_e2e_a".to_string(),
+            "echo a".to_string(),
+        ),
+    )
+    .expect("create a");
+    let a_id = job_a.id.unwrap();
+
+    let mut job_b_model = models::JobModel::new(
+        workflow_id,
+        "reinit_e2e_b".to_string(),
+        "echo b".to_string(),
+    );
+    job_b_model.depends_on_job_ids = Some(vec![a_id]);
+    let job_b = apis::jobs_api::create_job(config, job_b_model).expect("create b");
+    let b_id = job_b.id.unwrap();
+
+    let run_id_before = initialize_workflow(config, &workflow);
+    let compute_node = create_test_compute_node(config, workflow_id);
+    let cn_id = compute_node.id.unwrap();
+
+    // Complete A successfully, complete B with failure
+    apis::jobs_api::manage_status_change(config, a_id, JobStatus::Running, run_id_before)
+        .expect("set a running");
+    complete_job(
+        config,
+        a_id,
+        workflow_id,
+        cn_id,
+        run_id_before,
+        0,
+        JobStatus::Completed,
+    );
+    apis::jobs_api::manage_status_change(config, b_id, JobStatus::Running, run_id_before)
+        .expect("set b running");
+    complete_job(
+        config,
+        b_id,
+        workflow_id,
+        cn_id,
+        run_id_before,
+        1,
+        JobStatus::Failed,
+    );
+
+    // Reset B with --reinit in one step (no separate reinit needed)
+    let json = run_cli_with_json(
+        &[
+            "jobs",
+            "reset-status",
+            "--no-prompts",
+            "--force",
+            "--reinit",
+            &b_id.to_string(),
+        ],
+        start_server,
+        None,
+    )
+    .expect("reset-status --reinit should succeed");
+
+    assert_eq!(json["status"], "success", "status should be success");
+    assert_eq!(json["reinit"]["requested"], true);
+    assert_eq!(json["reinit"]["applied"], true);
+    assert!(json["reinit"]["error"].is_null());
+
+    // run_id bumped exactly once
+    let run_id_after = apis::workflows_api::get_workflow(config, workflow_id)
+        .unwrap()
+        .run_id
+        .unwrap_or(0);
+    assert_eq!(
+        run_id_after,
+        run_id_before + 1,
+        "run_id should be bumped exactly once by --reinit"
+    );
+
+    // B should be Ready (A is Completed, so B's dependency is satisfied)
+    let b_after = apis::jobs_api::get_job(config, b_id).unwrap();
+    assert_eq!(
+        b_after.status.unwrap(),
+        JobStatus::Ready,
+        "B should be Ready after --reinit"
+    );
+
+    // A (upstream, completed) must NOT be reset
+    let a_after = apis::jobs_api::get_job(config, a_id).unwrap();
+    assert_eq!(
+        a_after.status.unwrap(),
+        JobStatus::Completed,
+        "A should remain Completed"
+    );
+
+    // next_steps should not mention 'workflows reinit'
+    let next_steps = json["next_steps"].as_str().unwrap_or("");
+    assert!(
+        !next_steps.contains("workflows reinit"),
+        "next_steps should not mention 'workflows reinit' when reinit was applied: {}",
+        next_steps
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 10: --reinit JSON output shape
+// ---------------------------------------------------------------------------
+#[rstest]
+fn test_reset_status_reinit_json_output(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let workflow = create_test_workflow(config, "reset_reinit_json");
+    let workflow_id = workflow.id.unwrap();
+
+    let job = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(
+            workflow_id,
+            "reinit_json_job".to_string(),
+            "echo hi".to_string(),
+        ),
+    )
+    .expect("create job");
+    let job_id = job.id.unwrap();
+
+    let run_id_before = initialize_workflow(config, &workflow);
+    let compute_node = create_test_compute_node(config, workflow_id);
+    let cn_id = compute_node.id.unwrap();
+
+    apis::jobs_api::manage_status_change(config, job_id, JobStatus::Running, run_id_before)
+        .expect("set running");
+    complete_job(
+        config,
+        job_id,
+        workflow_id,
+        cn_id,
+        run_id_before,
+        1,
+        JobStatus::Failed,
+    );
+
+    let json = run_cli_with_json(
+        &[
+            "jobs",
+            "reset-status",
+            "--no-prompts",
+            "--force",
+            "--reinit",
+            &job_id.to_string(),
+        ],
+        start_server,
+        None,
+    )
+    .expect("reset-status --reinit --no-prompts should succeed");
+
+    assert_eq!(json["status"], "success");
+    assert_eq!(json["reinit"]["requested"], true);
+    assert_eq!(json["reinit"]["applied"], true);
+    assert!(json["reinit"]["error"].is_null());
+
+    // next_steps should not mention 'workflows reinit' since it was applied
+    let next_steps = json["next_steps"].as_str().unwrap_or("");
+    assert!(
+        !next_steps.contains("workflows reinit"),
+        "next_steps should not reference 'workflows reinit' when reinit was applied: {}",
+        next_steps
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 11: --dry-run --reinit — no changes applied, reinit_requested flag set
+// ---------------------------------------------------------------------------
+#[rstest]
+fn test_reset_status_reinit_dry_run(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let workflow = create_test_workflow(config, "reset_reinit_dry");
+    let workflow_id = workflow.id.unwrap();
+
+    let job = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(
+            workflow_id,
+            "reinit_dry_job".to_string(),
+            "echo dry".to_string(),
+        ),
+    )
+    .expect("create job");
+    let job_id = job.id.unwrap();
+
+    let run_id_before = initialize_workflow(config, &workflow);
+    let compute_node = create_test_compute_node(config, workflow_id);
+    let cn_id = compute_node.id.unwrap();
+
+    apis::jobs_api::manage_status_change(config, job_id, JobStatus::Running, run_id_before)
+        .expect("set running");
+    complete_job(
+        config,
+        job_id,
+        workflow_id,
+        cn_id,
+        run_id_before,
+        1,
+        JobStatus::Failed,
+    );
+
+    let json = run_cli_with_json(
+        &[
+            "jobs",
+            "reset-status",
+            "--no-prompts",
+            "--force",
+            "--dry-run",
+            "--reinit",
+            &job_id.to_string(),
+        ],
+        start_server,
+        None,
+    )
+    .expect("dry-run --reinit should succeed");
+
+    assert_eq!(json["dry_run"], true);
+    assert_eq!(json["reinit_requested"], true);
+
+    // Job status must be unchanged (dry-run made no changes)
+    assert_eq!(
+        apis::jobs_api::get_job(config, job_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Failed,
+        "Job should still be Failed after dry-run"
+    );
+
+    // run_id must be unchanged (no reinit happened)
+    let run_id_after = apis::workflows_api::get_workflow(config, workflow_id)
+        .unwrap()
+        .run_id
+        .unwrap_or(0);
+    assert_eq!(
+        run_id_after, run_id_before,
+        "run_id must not change on dry-run"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 12: Re-runnable without --force — a first reset leaves the workflow
+//          incomplete (uninitialized jobs), but a second invocation must still
+//          succeed because the command only requires no active workers, not
+//          workflow completeness.
+// ---------------------------------------------------------------------------
+#[rstest]
+fn test_reset_status_rerunnable_without_force(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let workflow = create_test_workflow(config, "reset_rerunnable");
+    let workflow_id = workflow.id.unwrap();
+
+    let job1 = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(workflow_id, "job1".to_string(), "echo job1".to_string()),
+    )
+    .expect("create job1");
+    let job1_id = job1.id.unwrap();
+    let job2 = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(workflow_id, "job2".to_string(), "echo job2".to_string()),
+    )
+    .expect("create job2");
+    let job2_id = job2.id.unwrap();
+
+    let run_id = initialize_workflow(config, &workflow);
+    let compute_node = create_test_compute_node(config, workflow_id);
+    let cn_id = compute_node.id.unwrap();
+
+    for &id in &[job1_id, job2_id] {
+        apis::jobs_api::manage_status_change(config, id, JobStatus::Running, run_id)
+            .unwrap_or_else(|e| panic!("Failed to set job {} running: {}", id, e));
+        complete_job(config, id, workflow_id, cn_id, run_id, 1, JobStatus::Failed);
+    }
+
+    // First reset (workflow is complete) — no --force needed
+    let json = run_cli_with_json(
+        &["jobs", "reset-status", "--no-prompts", &job1_id.to_string()],
+        start_server,
+        None,
+    )
+    .expect("first reset-status should succeed");
+    assert_eq!(json["status"], "success");
+
+    // job1 is now uninitialized, so the workflow is no longer complete.
+    // A second invocation must STILL succeed without --force.
+    let json = run_cli_with_json(
+        &["jobs", "reset-status", "--no-prompts", &job2_id.to_string()],
+        start_server,
+        None,
+    )
+    .expect("second reset-status should succeed even though workflow is incomplete");
+    assert_eq!(json["status"], "success");
+
+    for &id in &[job1_id, job2_id] {
+        assert_eq!(
+            apis::jobs_api::get_job(config, id).unwrap().status.unwrap(),
+            JobStatus::Uninitialized,
+            "job {} should be Uninitialized",
+            id
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 13: Warning for successfully completed jobs — resetting a Completed job
+//          succeeds but prints a stderr warning; a Failed job in the same
+//          invocation is not listed in the warning.
+// ---------------------------------------------------------------------------
+#[rstest]
+fn test_reset_status_completed_job_warning(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let workflow = create_test_workflow(config, "reset_completed_warning");
+    let workflow_id = workflow.id.unwrap();
+
+    let completed_job = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(workflow_id, "ok_job".to_string(), "echo ok".to_string()),
+    )
+    .expect("create completed job");
+    let completed_id = completed_job.id.unwrap();
+    let failed_job = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(workflow_id, "bad_job".to_string(), "false".to_string()),
+    )
+    .expect("create failed job");
+    let failed_id = failed_job.id.unwrap();
+
+    let run_id = initialize_workflow(config, &workflow);
+    let compute_node = create_test_compute_node(config, workflow_id);
+    let cn_id = compute_node.id.unwrap();
+
+    for &id in &[completed_id, failed_id] {
+        apis::jobs_api::manage_status_change(config, id, JobStatus::Running, run_id)
+            .unwrap_or_else(|e| panic!("Failed to set job {} running: {}", id, e));
+    }
+    complete_job(
+        config,
+        completed_id,
+        workflow_id,
+        cn_id,
+        run_id,
+        0,
+        JobStatus::Completed,
+    );
+    complete_job(
+        config,
+        failed_id,
+        workflow_id,
+        cn_id,
+        run_id,
+        1,
+        JobStatus::Failed,
+    );
+
+    // Run the CLI directly so we can capture stderr alongside stdout
+    let output = std::process::Command::new(get_exe_path("./target/debug/torc"))
+        .args([
+            "--format",
+            "json",
+            "jobs",
+            "reset-status",
+            "--no-prompts",
+            &completed_id.to_string(),
+            &failed_id.to_string(),
+        ])
+        .env("TORC_API_URL", &start_server.config.base_path)
+        .output()
+        .expect("run torc CLI");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "reset-status should succeed; stderr: {}",
+        stderr
+    );
+    assert!(
+        stderr.contains("completed successfully"),
+        "stderr should warn about completed jobs; stderr: {}",
+        stderr
+    );
+    assert!(
+        stderr.contains(&format!("job {} (ok_job)", completed_id)),
+        "warning should list the completed job; stderr: {}",
+        stderr
+    );
+    assert!(
+        !stderr.contains(&format!("job {} (bad_job)", failed_id)),
+        "warning should not list the failed job; stderr: {}",
+        stderr
+    );
+
+    // Both jobs were still reset
+    for &id in &[completed_id, failed_id] {
+        assert_eq!(
+            apis::jobs_api::get_job(config, id).unwrap().status.unwrap(),
+            JobStatus::Uninitialized,
+            "job {} should be Uninitialized",
+            id
+        );
+    }
+}

--- a/tests/test_workflow_actions.rs
+++ b/tests/test_workflow_actions.rs
@@ -808,3 +808,111 @@ fn test_action_executed_flag_reset_on_reinitialize(start_server: &ServerProcess)
         "executed should be false (pending, not claimed)"
     );
 }
+
+/// Regression test for the recover wizard re-submitting the action-defined allocation count.
+///
+/// After reinitialization re-arms the workflow's `on_workflow_start` `schedule_nodes` action, the
+/// recover wizard's "reuse existing scheduler" path calls
+/// `mark_on_workflow_start_schedule_actions_executed` before submitting the user's chosen number of
+/// allocations. This prevents the re-armed action from firing again on the first compute node and
+/// submitting its own (original) `num_allocations`. The helper must mark exactly the matching
+/// actions executed and leave everything else untouched.
+#[rstest]
+fn test_mark_on_workflow_start_schedule_actions_executed(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let workflow = create_test_workflow(config, "mark_on_start_schedule_workflow");
+    let workflow_id = workflow.id.unwrap();
+
+    let schedule_config = json!({
+        "scheduler_type": "slurm",
+        "scheduler_id": 1,
+        "num_allocations": 5,
+    });
+
+    // Target: on_workflow_start + schedule_nodes (non-recovery) — should be marked executed.
+    let target = apis::workflow_actions_api::create_workflow_action(
+        config,
+        workflow_id,
+        workflow_action(
+            workflow_id,
+            "on_workflow_start",
+            "schedule_nodes",
+            schedule_config.clone(),
+            None,
+        ),
+    )
+    .expect("Failed to create target action");
+    let target_id = target.id.unwrap();
+
+    // Decoy 1: on_workflow_start + run_commands — wrong action_type, must be left alone.
+    let run_cmd = apis::workflow_actions_api::create_workflow_action(
+        config,
+        workflow_id,
+        workflow_action(
+            workflow_id,
+            "on_workflow_start",
+            "run_commands",
+            json!({ "commands": ["echo hi"] }),
+            None,
+        ),
+    )
+    .expect("Failed to create run_commands action");
+    let run_cmd_id = run_cmd.id.unwrap();
+
+    // Decoy 2: on_jobs_ready + schedule_nodes — wrong trigger_type, must be left alone.
+    let other_trigger = apis::workflow_actions_api::create_workflow_action(
+        config,
+        workflow_id,
+        workflow_action(
+            workflow_id,
+            "on_jobs_ready",
+            "schedule_nodes",
+            schedule_config.clone(),
+            None,
+        ),
+    )
+    .expect("Failed to create on_jobs_ready action");
+    let other_trigger_id = other_trigger.id.unwrap();
+
+    // Decoy 3: on_workflow_start + schedule_nodes but is_recovery=true — must be left alone.
+    let mut recovery_body = workflow_action(
+        workflow_id,
+        "on_workflow_start",
+        "schedule_nodes",
+        schedule_config,
+        None,
+    );
+    recovery_body.is_recovery = true;
+    let recovery =
+        apis::workflow_actions_api::create_workflow_action(config, workflow_id, recovery_body)
+            .expect("Failed to create recovery action");
+    let recovery_id = recovery.id.unwrap();
+
+    // Run the fix under test.
+    torc::client::commands::recover::mark_on_workflow_start_schedule_actions_executed(
+        config,
+        workflow_id,
+    )
+    .expect("mark_on_workflow_start_schedule_actions_executed failed");
+
+    let actions = apis::workflow_actions_api::get_workflow_actions(config, workflow_id)
+        .expect("Failed to get workflow actions");
+    let find = |id: i64| actions.iter().find(|a| a.id == Some(id)).unwrap();
+
+    assert!(
+        find(target_id).executed,
+        "on_workflow_start schedule_nodes action should be marked executed"
+    );
+    assert!(
+        !find(run_cmd_id).executed,
+        "run_commands action should be left untouched"
+    );
+    assert!(
+        !find(other_trigger_id).executed,
+        "on_jobs_ready schedule_nodes action should be left untouched"
+    );
+    assert!(
+        !find(recovery_id).executed,
+        "recovery schedule_nodes action should be left untouched"
+    );
+}

--- a/tests/test_workflow_manager.rs
+++ b/tests/test_workflow_manager.rs
@@ -481,6 +481,50 @@ fn test_reinitialize_workflow_real(start_server: &ServerProcess) {
 }
 
 #[rstest]
+fn test_recover_reset_sequence_bumps_run_id_once(start_server: &ServerProcess) {
+    let config = start_server.config.clone();
+    let (manager, workflow) =
+        create_test_workflow_manager(config.clone(), "test_recover_run_id_once");
+    let workflow_id = workflow.id.unwrap();
+
+    // Initialize and run a job so the workflow has an established run.
+    let (job_id, _run_id) = execute_workflow_with_job(
+        &config,
+        &manager,
+        workflow_id,
+        "test_job",
+        "echo 'test'",
+        None,
+    )
+    .expect("execute workflow with job");
+
+    let before = apis::workflows_api::get_workflow(&config, workflow_id)
+        .expect("get workflow")
+        .run_id
+        .unwrap_or(0);
+
+    // The recover reset sequence: reset the failed jobs, then reinitialize.
+    // Together these must advance run_id by exactly 1 -- reset_failed_jobs no
+    // longer resets workflow status, so the single bump comes from
+    // reinitialize_workflow. Before the fix this bumped twice and skipped a
+    // run_id.
+    torc::client::commands::recover::reset_failed_jobs(&config, workflow_id, &[job_id])
+        .expect("reset_failed_jobs");
+    torc::client::commands::recover::reinitialize_workflow(&config, workflow_id)
+        .expect("reinitialize_workflow");
+
+    let after = apis::workflows_api::get_workflow(&config, workflow_id)
+        .expect("get workflow after")
+        .run_id
+        .unwrap_or(0);
+    assert_eq!(
+        after,
+        before + 1,
+        "recover reset sequence must bump run_id exactly once"
+    );
+}
+
+#[rstest]
 fn test_get_run_id(start_server: &ServerProcess) {
     let config = start_server.config.clone();
     let (manager, workflow) = create_test_workflow_manager(config.clone(), "test_get_run_id");


### PR DESCRIPTION
## Summary

Patch release **v0.34.1** on the `release/0.34.x` line. It backports client-only
bug fixes and improvements from `main` for production sites pinned to a **v0.34.0
server that cannot be upgraded**. Every change here is client-side — no server,
migration, or OpenAPI changes — so it is safe to deploy against an unchanged
v0.34.0 server.

Base branch is `release/0.34.x` (at tag `v0.34.0`), so this diff shows exactly
the backported commits rather than a reversal of newer `main` work.

## Backported PRs

| PR | Title | Notes |
|----|-------|-------|
| #368 | Fix double run_id bump in recover/watch reset path | clean cherry-pick |
| #378 | Fix recover wizard ignoring Skip for resource corrections | clean cherry-pick |
| #382 | Fix recover wizard ignoring user's Slurm allocation count | clean cherry-pick |
| #383 | Fix recover subprocess plumbing, preconditions, and JSON-mode prompts | clean cherry-pick |
| #385 | Add `torc jobs reset-status` command for selective job rerun (+ TUI) | adapted, see below |

Plus a backport of the **TUI Results number-key column sorting** UX (from the
post-v0.34.0 commit `f9c8b04a`).

## Backport adaptations (excluding server-dependent changes)

**`torc jobs reset-status` (#385).** The command itself is client-only: it issues
`manage_status_change` and relies on the server's existing
`uninitialize_blocked_jobs` CTE (unchanged since v0.34.0) via `torc workflows
reinit`. During cherry-pick I excluded the adjacent **`torc jobs running`**
subcommand, which depends on the `get_running_jobs` server endpoint added after
v0.34.0.

**TUI.** Kept the new `U` / `Space` / `*` job-reset and multi-select keybindings.

**TUI Results column sorting.** The upstream commit bundled server-dependent
features (running-jobs view, server-populated result `job_name`) with the
client-only number-key sorting. Only the sorting is taken here, adapted to the
columns available against a v0.34.0 server (no `Name` column, since results have
no server-populated `job_name`):

`1`=ID  `2`=Job ID  `3`=Return  `4`=Runtime  `5`=Completion  `6`=Peak Mem  `7`=Peak CPU

This replaces v0.34.0's old `m`/`p`/`E` Results sort keys.

## Verification

- `cargo build --bin torc --features "client,tui,plot_resources"` — clean
- `cargo fmt --check`, `cargo clippy --all --all-targets --all-features -D warnings`, `dprint check`, shellcheck — all pass (pre-commit hook)
- `cargo nextest run` reset-status suite — **15/15 pass**
- `test_workflow_manager` + `test_workflow_actions` — **62/62 pass**

## Not done here

- No git tag created yet (push + PR only, per request). Tagging `v0.34.1` /
  `cargo release` is left for a follow-up after review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
