### PR TITLE
Fix TUI: don't reset cursor row when job selection is hidden by filter

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -4098,9 +4098,16 @@ impl App {
     }
 
     /// Request a reset for every selected job that is currently listed.
-    /// Returns false when the selection is empty so the caller can fall back
-    /// to the single-job (cursor row) path.
+    /// Returns false only when the multi-select is empty, so the caller can
+    /// fall back to the single-job (cursor row) path. When a selection exists
+    /// but none of its jobs are listed (e.g., the filter changed), this warns
+    /// and returns true so the caller does NOT silently reset the cursor row.
     fn request_selected_jobs_reset(&mut self) -> bool {
+        // An empty selection is the only case where falling back to the
+        // cursor-row job is the intended behavior.
+        if self.selected_job_ids.is_empty() {
+            return false;
+        }
         // Intersect with the listed jobs: selections made under an earlier
         // filter may reference rows that are no longer shown, and acting on
         // invisible jobs would be surprising.
@@ -4110,7 +4117,14 @@ impl App {
             .filter(|j| j.id.is_some_and(|id| self.selected_job_ids.contains(&id)))
             .collect();
         if targets.is_empty() {
-            return false;
+            // A selection exists but none of its jobs are in the current view.
+            // Don't fall through to resetting the cursor row, which the user
+            // didn't pick; tell them their selection is hidden. The selection
+            // is left intact so clearing the filter restores it.
+            self.set_status(StatusMessage::warning(
+                "Selected jobs are not in the current view; clear the filter or press '*' to reselect",
+            ));
+            return true;
         }
 
         let completed = targets

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -4122,7 +4122,7 @@ impl App {
             // didn't pick; tell them their selection is hidden. The selection
             // is left intact so clearing the filter restores it.
             self.set_status(StatusMessage::warning(
-                "Selected jobs are not in the current view; clear the filter or press '*' to reselect",
+                "Selected jobs are hidden by the filter — clear it or press '*' to reselect",
             ));
             return true;
         }

--- a/tests/test_jobs_reset_status.rs
+++ b/tests/test_jobs_reset_status.rs
@@ -57,6 +57,28 @@ fn complete_job(
         .unwrap_or_else(|e| panic!("Failed to complete job {}: {}", job_id, e));
 }
 
+/// Poll until `job_id` reaches `expected`, tolerating the asynchronous unblocking
+/// task that flips a dependent from blocked -> ready after its predecessor
+/// completes. Without this, driving the dependent straight to `running` can race
+/// the unblocker and fail the server's optimistic-concurrency check with a 422.
+fn wait_for_status(config: &torc::client::Configuration, job_id: i64, expected: JobStatus) {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    loop {
+        let status = apis::jobs_api::get_job(config, job_id)
+            .expect("Failed to get job while waiting for status")
+            .status
+            .unwrap();
+        if status == expected {
+            return;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "job_id={job_id} did not reach {expected:?} within timeout (last status {status:?})"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Test 1: Selective reset — only targeted jobs are reset, others unchanged
 // ---------------------------------------------------------------------------
@@ -248,6 +270,7 @@ fn test_reset_status_recursive_downstream(start_server: &ServerProcess) {
 
     // After A completes, unblocking fires and B becomes ready
     // Advance B to running and complete it
+    wait_for_status(config, b_id, JobStatus::Ready);
     apis::jobs_api::manage_status_change(config, b_id, JobStatus::Running, run_id)
         .expect("set b running");
     complete_job(
@@ -261,6 +284,7 @@ fn test_reset_status_recursive_downstream(start_server: &ServerProcess) {
     );
 
     // After B completes, C becomes ready
+    wait_for_status(config, c_id, JobStatus::Ready);
     apis::jobs_api::manage_status_change(config, c_id, JobStatus::Running, run_id)
         .expect("set c running");
     complete_job(
@@ -690,6 +714,7 @@ fn test_reset_status_end_to_end_reinit(start_server: &ServerProcess) {
         JobStatus::Completed,
     );
 
+    wait_for_status(config, b_id, JobStatus::Ready);
     apis::jobs_api::manage_status_change(config, b_id, JobStatus::Running, run_id_before)
         .expect("set b running");
     complete_job(
@@ -865,6 +890,7 @@ fn test_reset_status_reinit_flag_end_to_end(start_server: &ServerProcess) {
         0,
         JobStatus::Completed,
     );
+    wait_for_status(config, b_id, JobStatus::Ready);
     apis::jobs_api::manage_status_change(config, b_id, JobStatus::Running, run_id_before)
         .expect("set b running");
     complete_job(


### PR DESCRIPTION
## Summary

Fixes a TUI Jobs-pane papercut in the multi-select job reset (`U`): when a
selection exists but none of the selected jobs are currently visible (e.g., the
user changed the filter after selecting), pressing `U` silently reset the
**cursor-row** job instead of acting on the selection.

## Root cause

`request_job_action(ResetStatus)` calls `request_selected_jobs_reset()` and, if
it returns `false`, falls through to the single-job (cursor row) path.
`request_selected_jobs_reset()` returned `false` whenever the intersection of
the selection with the *listed* jobs was empty — conflating two distinct cases:

- **empty selection** → falling back to the cursor row is intended, and
- **selection exists but is hidden by the filter** → falling back is surprising
  and resets a job the user never picked.

## Fix

`request_selected_jobs_reset()` now returns `false` only when the selection is
genuinely empty. A non-empty-but-hidden selection warns
(`Selected jobs are not in the current view; clear the filter or press '*' to reselect`)
and returns `true`, so the caller no longer falls back to the cursor row. The
selection is left intact so clearing the filter restores it.

## Notes

- Found while backporting the `torc jobs reset-status` work to the `release/0.34.x`
  line (PR #388); the same fix is included there. This PR carries it forward on
  `main`.
- Verified: `cargo clippy --all --all-targets --all-features -- -D warnings`,
  `cargo fmt --check`, `dprint check`, shellcheck — all pass (pre-commit hook).
  TUI behavior is interactive and not covered by integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
