### PR TITLE
Backport recover selective-reset fix to v0.34.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5125,7 +5125,7 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "torc"
-version = "0.34.2"
+version = "0.34.3"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.34.2"
+version = "0.34.3"
 authors = [
   "Daniel Thom",
   "Joseph McKinsey",
@@ -20,7 +20,7 @@ description = "Workflow management system"
 
 [workspace.dependencies]
 # Self-reference for sub-crates (version only specified here)
-torc = { version = "0.34.2", path = "." }
+torc = { version = "0.34.3", path = "." }
 
 # Shared dependencies
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Usage:
 #   # Download and extract release binaries
-#   VERSION=0.34.2
+#   VERSION=0.34.3
 #   mkdir -p artifact
 #   curl -fsSL "https://github.com/NatLabRockies/torc/releases/download/v${VERSION}/torc-x86_64-unknown-linux-musl.tar.gz" \
 #     | tar xz -C artifact/

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -53,9 +53,9 @@ listed below.
 
 ```
 /scratch/dthom/torc/
-├── 0.34.2/
+├── 0.34.3/
 ├── ...
-└── latest -> 0.34.2  (symlink to current version)
+└── latest -> 0.34.3  (symlink to current version)
 ```
 
 > **Recommended**: Use the `latest` directory. Torc maintains backwards compatibility, so you'll

--- a/python_client/pyproject.toml
+++ b/python_client/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "torc-client"
 # Note: Do not update manually. Use cargo-release from the repo root, such as
 # $ cargo release minor --execute
-version = "0.34.2"
+version = "0.34.3"
 description = "Workflow management system"
 requires-python = ">=3.11,<3.14"
 license = "BSD-3-Clause"

--- a/src/client/commands/recover.rs
+++ b/src/client/commands/recover.rs
@@ -904,13 +904,7 @@ pub fn reset_failed_jobs(
         return Ok(0);
     }
 
-    // Reset ONLY the selected jobs. Earlier this called
-    // `reset_job_status(failed_only=true)`, which is workflow-wide and ignored
-    // `job_ids` entirely -- so a user who chose to Skip some failures (e.g.
-    // unknown-cause jobs) had those jobs reset anyway. We instead reset each
-    // requested job individually via `manage_status_change`, exactly as the
-    // `torc jobs reset-status` command does.
-    //
+    // Reset the selected jobs.
     // NOTE: do not reset workflow status here. `reset_workflow_status` bumps
     // run_id, and every caller of this function follows it with
     // `reinitialize_workflow`, which already resets workflow status (and bumps
@@ -922,16 +916,72 @@ pub fn reset_failed_jobs(
         .run_id
         .unwrap_or(1);
 
+    // Statuses that recovery is allowed to reset. Mirrors
+    // `check_recovery_preconditions`; resetting a job in any other state (e.g. a
+    // still-running or already-completed job) would be unexpected, so we skip it
+    // and report rather than silently clobber it.
+    let recoverable_statuses = [
+        JobStatus::Failed,
+        JobStatus::Terminated,
+        JobStatus::Canceled,
+        JobStatus::PendingFailed,
+    ];
+
+    // Attempt every reset, accumulating errors instead of bailing on the first
+    // failure. There is no server-side bulk/atomic reset endpoint, so a mid-loop
+    // early return would leave the workflow partially reset with no report of
+    // what succeeded. Collecting failures lets the caller see the full picture.
     let mut reset_count = 0;
+    let mut errors: Vec<String> = Vec::new();
     for &job_id in job_ids {
-        apis::jobs_api::manage_status_change(config, job_id, JobStatus::Uninitialized, run_id)
-            .map_err(|e| format!("Failed to reset status for job {}: {}", job_id, e))?;
-        reset_count += 1;
+        // Validate the job before touching it. `manage_status_change` is not
+        // workflow-scoped, so without this check a stray job_id could reset a
+        // job in a different workflow.
+        let job = match apis::jobs_api::get_job(config, job_id) {
+            Ok(job) => job,
+            Err(e) => {
+                errors.push(format!("Failed to fetch job {}: {}", job_id, e));
+                continue;
+            }
+        };
+        if job.workflow_id != workflow_id {
+            errors.push(format!(
+                "Job {} belongs to workflow {}, not {}; refusing to reset",
+                job_id, job.workflow_id, workflow_id
+            ));
+            continue;
+        }
+        match job.status {
+            Some(status) if recoverable_statuses.contains(&status) => {}
+            other => {
+                warn!(
+                    "Skipping reset of job {} in workflow {}: status {:?} is not recoverable",
+                    job_id, workflow_id, other
+                );
+                continue;
+            }
+        }
+
+        match apis::jobs_api::manage_status_change(config, job_id, JobStatus::Uninitialized, run_id)
+        {
+            Ok(_) => reset_count += 1,
+            Err(e) => errors.push(format!("Failed to reset status for job {}: {}", job_id, e)),
+        }
     }
     info!(
         "  Reset {} failed job(s) for workflow {}",
         reset_count, workflow_id
     );
+
+    if !errors.is_empty() {
+        return Err(format!(
+            "Reset {} of {} job(s); {} failed: {}",
+            reset_count,
+            job_ids.len(),
+            errors.len(),
+            errors.join("; ")
+        ));
+    }
 
     Ok(reset_count)
 }

--- a/src/client/commands/recover.rs
+++ b/src/client/commands/recover.rs
@@ -894,7 +894,35 @@ pub fn apply_recovery_heuristics(
     })
 }
 
-/// Reset specific failed jobs for retry (without reinitializing)
+/// Build a capped, human-readable summary of jobs that could not be reset. The
+/// full per-job list is logged separately; this keeps the returned error from
+/// ballooning when many job IDs are passed or API errors carry verbose payloads.
+fn summarize_not_reset(total: usize, reset_count: usize, not_reset: &[String]) -> String {
+    const MAX_DETAIL: usize = 5;
+    let shown = not_reset.len().min(MAX_DETAIL);
+    let mut msg = format!(
+        "Reset {} of {} job(s); {} skipped or failed: {}",
+        reset_count,
+        total,
+        not_reset.len(),
+        not_reset[..shown].join("; ")
+    );
+    if not_reset.len() > shown {
+        msg.push_str(&format!(
+            " ({} more not shown; see logs)",
+            not_reset.len() - shown
+        ));
+    }
+    msg
+}
+
+/// Reset specific failed jobs for retry (without reinitializing).
+///
+/// Best-effort: every job ID is attempted, accumulating a per-job reason for any
+/// that is skipped (wrong workflow / non-recoverable status) or fails (fetch or
+/// reset error). Returns `Ok(reset_count)` as long as at least one job was reset
+/// -- partial success is not an error -- and `Err` only when nothing could be
+/// reset. Skips and failures are always logged.
 pub fn reset_failed_jobs(
     config: &Configuration,
     workflow_id: i64,
@@ -930,10 +958,7 @@ pub fn reset_failed_jobs(
     // Attempt every reset, accumulating the reason any job was not reset instead
     // of bailing on the first problem. There is no server-side bulk/atomic reset
     // endpoint, so a mid-loop early return would leave the workflow partially
-    // reset with no report of what succeeded. We collect a per-job reason for
-    // every job that was skipped (validation/status) or failed (fetch/reset) so
-    // the caller is reliably informed -- including the case where nothing was
-    // reset at all.
+    // reset with no report of what succeeded.
     let mut reset_count = 0;
     let mut not_reset: Vec<String> = Vec::new();
     for &job_id in job_ids {
@@ -957,12 +982,10 @@ pub fn reset_failed_jobs(
         match job.status {
             Some(status) if recoverable_statuses.contains(&status) => {}
             other => {
-                let reason = format!(
+                not_reset.push(format!(
                     "job {}: status {:?} is not recoverable; skipped",
                     job_id, other
-                );
-                warn!("{} (workflow {})", reason, workflow_id);
-                not_reset.push(reason);
+                ));
                 continue;
             }
         }
@@ -979,13 +1002,22 @@ pub fn reset_failed_jobs(
     );
 
     if !not_reset.is_empty() {
-        return Err(format!(
-            "Reset {} of {} job(s); {} skipped or failed: {}",
-            reset_count,
-            job_ids.len(),
-            not_reset.len(),
-            not_reset.join("; ")
-        ));
+        // Log the full list for diagnosis regardless of outcome; the returned
+        // message is capped so a large `job_ids` (or verbose API errors) can't
+        // produce an oversized CLI error.
+        for reason in &not_reset {
+            warn!("Job not reset (workflow {}): {}", workflow_id, reason);
+        }
+
+        // Only a hard error when *nothing* was reset -- a total failure the
+        // caller should abort on. Partial success returns Ok(reset_count): the
+        // callers propagate with `?` and go on to reinitialize, so turning a
+        // partial reset into an Err would abort recovery and strand the workflow
+        // in a partially-reset state. The skips/failures are surfaced via the
+        // warnings above.
+        if reset_count == 0 {
+            return Err(summarize_not_reset(job_ids.len(), reset_count, &not_reset));
+        }
     }
 
     Ok(reset_count)

--- a/src/client/commands/recover.rs
+++ b/src/client/commands/recover.rs
@@ -927,12 +927,15 @@ pub fn reset_failed_jobs(
         JobStatus::PendingFailed,
     ];
 
-    // Attempt every reset, accumulating errors instead of bailing on the first
-    // failure. There is no server-side bulk/atomic reset endpoint, so a mid-loop
-    // early return would leave the workflow partially reset with no report of
-    // what succeeded. Collecting failures lets the caller see the full picture.
+    // Attempt every reset, accumulating the reason any job was not reset instead
+    // of bailing on the first problem. There is no server-side bulk/atomic reset
+    // endpoint, so a mid-loop early return would leave the workflow partially
+    // reset with no report of what succeeded. We collect a per-job reason for
+    // every job that was skipped (validation/status) or failed (fetch/reset) so
+    // the caller is reliably informed -- including the case where nothing was
+    // reset at all.
     let mut reset_count = 0;
-    let mut errors: Vec<String> = Vec::new();
+    let mut not_reset: Vec<String> = Vec::new();
     for &job_id in job_ids {
         // Validate the job before touching it. `manage_status_change` is not
         // workflow-scoped, so without this check a stray job_id could reset a
@@ -940,13 +943,13 @@ pub fn reset_failed_jobs(
         let job = match apis::jobs_api::get_job(config, job_id) {
             Ok(job) => job,
             Err(e) => {
-                errors.push(format!("Failed to fetch job {}: {}", job_id, e));
+                not_reset.push(format!("job {}: failed to fetch ({})", job_id, e));
                 continue;
             }
         };
         if job.workflow_id != workflow_id {
-            errors.push(format!(
-                "Job {} belongs to workflow {}, not {}; refusing to reset",
+            not_reset.push(format!(
+                "job {}: belongs to workflow {}, not {}; refusing to reset",
                 job_id, job.workflow_id, workflow_id
             ));
             continue;
@@ -954,10 +957,12 @@ pub fn reset_failed_jobs(
         match job.status {
             Some(status) if recoverable_statuses.contains(&status) => {}
             other => {
-                warn!(
-                    "Skipping reset of job {} in workflow {}: status {:?} is not recoverable",
-                    job_id, workflow_id, other
+                let reason = format!(
+                    "job {}: status {:?} is not recoverable; skipped",
+                    job_id, other
                 );
+                warn!("{} (workflow {})", reason, workflow_id);
+                not_reset.push(reason);
                 continue;
             }
         }
@@ -965,7 +970,7 @@ pub fn reset_failed_jobs(
         match apis::jobs_api::manage_status_change(config, job_id, JobStatus::Uninitialized, run_id)
         {
             Ok(_) => reset_count += 1,
-            Err(e) => errors.push(format!("Failed to reset status for job {}: {}", job_id, e)),
+            Err(e) => not_reset.push(format!("job {}: reset failed ({})", job_id, e)),
         }
     }
     info!(
@@ -973,13 +978,13 @@ pub fn reset_failed_jobs(
         reset_count, workflow_id
     );
 
-    if !errors.is_empty() {
+    if !not_reset.is_empty() {
         return Err(format!(
-            "Reset {} of {} job(s); {} failed: {}",
+            "Reset {} of {} job(s); {} skipped or failed: {}",
             reset_count,
             job_ids.len(),
-            errors.len(),
-            errors.join("; ")
+            not_reset.len(),
+            not_reset.join("; ")
         ));
     }
 

--- a/src/client/commands/recover.rs
+++ b/src/client/commands/recover.rs
@@ -904,19 +904,30 @@ pub fn reset_failed_jobs(
         return Ok(0);
     }
 
+    // Reset ONLY the selected jobs. Earlier this called
+    // `reset_job_status(failed_only=true)`, which is workflow-wide and ignored
+    // `job_ids` entirely -- so a user who chose to Skip some failures (e.g.
+    // unknown-cause jobs) had those jobs reset anyway. We instead reset each
+    // requested job individually via `manage_status_change`, exactly as the
+    // `torc jobs reset-status` command does.
+    //
     // NOTE: do not reset workflow status here. `reset_workflow_status` bumps
     // run_id, and every caller of this function follows it with
     // `reinitialize_workflow`, which already resets workflow status (and bumps
     // run_id) exactly once. Resetting here too bumps run_id twice per recovery,
-    // leaving a gap (e.g. a recovered job jumping from run 1 to run 3). Reset
-    // only the failed jobs so the run_id bump stays single.
-    //
-    // `reset_job_status` resets all retryable failed jobs workflow-wide (the
-    // `job_ids` argument here only gates the no-op early return above), so use
-    // the server-reported `updated_count` for an accurate count, not job_ids.len().
-    let response = apis::workflows_api::reset_job_status(config, workflow_id, Some(true))
-        .map_err(|e| format!("Failed to reset failed job status: {}", e))?;
-    let reset_count = response.updated_count.max(0) as usize;
+    // leaving a gap (e.g. a recovered job jumping from run 1 to run 3). We pass
+    // the current run_id (no bump) so the single bump stays with reinitialize.
+    let run_id = apis::workflows_api::get_workflow(config, workflow_id)
+        .map_err(|e| format!("Failed to fetch workflow for reset: {}", e))?
+        .run_id
+        .unwrap_or(1);
+
+    let mut reset_count = 0;
+    for &job_id in job_ids {
+        apis::jobs_api::manage_status_change(config, job_id, JobStatus::Uninitialized, run_id)
+            .map_err(|e| format!("Failed to reset status for job {}: {}", job_id, e))?;
+        reset_count += 1;
+    }
     info!(
         "  Reset {} failed job(s) for workflow {}",
         reset_count, workflow_id

--- a/src/client/commands/recover.rs
+++ b/src/client/commands/recover.rs
@@ -959,6 +959,7 @@ pub fn reset_failed_jobs(
     // of bailing on the first problem. There is no server-side bulk/atomic reset
     // endpoint, so a mid-loop early return would leave the workflow partially
     // reset with no report of what succeeded.
+    // PERF: make a new API endpoint to do this in one command.
     let mut reset_count = 0;
     let mut not_reset: Vec<String> = Vec::new();
     for &job_id in job_ids {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2278,6 +2278,11 @@ impl App {
         // The Jobs pane filters server-side (across the whole workflow); other
         // views filter the loaded page client-side.
         if target == FilterTarget::Details && self.detail_view == DetailViewType::Jobs {
+            // The multi-reset selection is scoped to the active filter (so a
+            // cross-page reset only touches jobs in the current view). Changing
+            // the filter changes that scope, so drop selections that may no
+            // longer match -- matching the clear on workflow change.
+            self.selected_job_ids.clear();
             self.jobs_offset = 0;
             if let Err(err) = self.reload_jobs_page() {
                 self.set_status(StatusMessage::error(&format!(
@@ -2520,6 +2525,10 @@ impl App {
         }
         match self.detail_view {
             DetailViewType::Jobs => {
+                // Clearing the filter widens the scope of the multi-reset
+                // selection, so drop it to keep the selection coherent with the
+                // visible set (mirrors the clear in apply_filter).
+                self.selected_job_ids.clear();
                 // Re-fetch an unfiltered first page from the server (the Jobs
                 // filter is server-side, so the loaded page may be a strict
                 // subset that can't be widened client-side).
@@ -3659,54 +3668,56 @@ impl App {
         }
     }
 
-    /// Request a reset for every selected job that is currently listed.
-    /// Returns false only when the multi-select is empty, so the caller can
-    /// fall back to the single-job (cursor row) path. When a selection exists
-    /// but none of its jobs are listed (e.g., the filter changed), this warns
-    /// and returns true so the caller does NOT silently reset the cursor row.
+    /// Request a reset for every selected job, including jobs selected on other
+    /// pages. Returns false only when the multi-select is empty, so the caller
+    /// can fall back to the single-job (cursor row) path.
+    ///
+    /// The selection spans all pages of the active filter: `selected_job_ids`
+    /// persists across `]`/`[` paging and is cleared whenever the workflow or
+    /// the Jobs filter changes, so every id here is a valid target even if it is
+    /// not on the currently-loaded page. The reset goes through the
+    /// `jobs reset-status` CLI, which accepts ids regardless of page.
     fn request_selected_jobs_reset(&mut self) -> bool {
         // An empty selection is the only case where falling back to the
         // cursor-row job is the intended behavior.
         if self.selected_job_ids.is_empty() {
             return false;
         }
-        // Intersect with the listed jobs: selections made under an earlier
-        // filter may reference rows that are no longer shown, and acting on
-        // invisible jobs would be surprising.
-        let targets: Vec<&JobModel> = self
+
+        let mut job_ids: Vec<i64> = self.selected_job_ids.iter().copied().collect();
+        job_ids.sort_unstable();
+
+        // The completed-job warning is best-effort: only jobs on the currently
+        // loaded page have their status in memory, so off-page completed jobs
+        // can't be counted. Hedge the wording with "at least" unless the whole
+        // selection is on the loaded page.
+        let completed = self
             .jobs
             .iter()
-            .filter(|j| j.id.is_some_and(|id| self.selected_job_ids.contains(&id)))
-            .collect();
-        if targets.is_empty() {
-            // A selection exists but none of its jobs are in the current view.
-            // Don't fall through to resetting the cursor row, which the user
-            // didn't pick; tell them their selection is hidden. The selection
-            // is left intact so clearing the filter restores it.
-            self.set_status(StatusMessage::warning(
-                "Selected jobs are not in the current view; clear the filter or press '*' to reselect",
-            ));
-            return true;
-        }
-
-        let completed = targets
-            .iter()
-            .filter(|j| j.status == Some(JobStatus::Completed))
+            .filter(|j| {
+                j.status == Some(JobStatus::Completed)
+                    && j.id.is_some_and(|id| self.selected_job_ids.contains(&id))
+            })
             .count();
+        let all_loaded = self
+            .selected_job_ids
+            .iter()
+            .all(|id| self.jobs.iter().any(|j| j.id == Some(*id)));
+
         let mut message = format!(
             "Reset {} selected job(s) to uninitialized for rerun?\n\
              Downstream dependents are reset when the workflow is re-initialized ('I').",
-            targets.len()
+            job_ids.len()
         );
         if completed > 0 {
             message.push_str(&format!(
-                "\nWarning: {} of them completed successfully; resetting discards their \
+                "\nWarning: {}{} of them completed successfully; resetting discards their \
                  results and reruns them.",
+                if all_loaded { "" } else { "at least " },
                 completed
             ));
         }
 
-        let job_ids: Vec<i64> = targets.iter().filter_map(|j| j.id).collect();
         self.previous_focus = self.focus;
         self.focus = Focus::Popup;
         self.popup = Some(PopupType::Confirmation {

--- a/tests/test_correct_resources.rs
+++ b/tests/test_correct_resources.rs
@@ -5,6 +5,7 @@ use common::{
 };
 use rstest::rstest;
 use torc::client::apis;
+use torc::client::commands::reports::build_resource_utilization_report;
 use torc::client::report_models::ResourceUtilizationReport;
 use torc::client::resource_correction::{
     ResourceCorrectionContext, ResourceCorrectionOptions, apply_resource_corrections,
@@ -1606,4 +1607,113 @@ fn test_downsize_adjustment_report_direction(start_server: &ServerProcess) {
     assert!(adj.memory_adjusted);
     assert!(adj.cpu_adjusted);
     assert!(adj.runtime_adjusted);
+}
+
+/// Regression test for the resource-correction half of the recover "Skip" bug
+/// (the issue PR #378 addressed). When the user selects only a subset of
+/// violating jobs to correct, `apply_resource_corrections` must touch ONLY the
+/// resource requirements of the included jobs. Jobs that were skipped must keep
+/// their original allocation.
+///
+/// Before this invariant held, `include_jobs` was effectively ignored in the
+/// wizard path (an empty list meant "all"), so skipped jobs had their resources
+/// silently bumped. This test uses two OOM jobs with SEPARATE resource
+/// requirements and includes only one, asserting the other's RR is untouched.
+#[rstest]
+fn test_correct_resources_include_jobs_skips_others(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let (workflow_id, run_id) = create_and_initialize_workflow(config, "test_include_jobs_skip");
+
+    let compute_node = create_test_compute_node(config, workflow_id);
+    let compute_node_id = compute_node.id.unwrap();
+
+    // Two separate RRs (2g each) so a correction to one job cannot incidentally
+    // change the other's allocation.
+    let make_rr = |name: &str| {
+        let mut rr = models::ResourceRequirementsModel::new(workflow_id, name.to_string());
+        rr.memory = "2g".to_string();
+        rr.runtime = "PT1H".to_string();
+        rr.num_cpus = 1;
+        apis::resource_requirements_api::create_resource_requirements(config, rr)
+            .expect("Failed to create RR")
+            .id
+            .unwrap()
+    };
+    let rr_retry_id = make_rr("rr_retry");
+    let rr_skip_id = make_rr("rr_skip");
+
+    let job_retry_id = create_job_with_rr(config, workflow_id, "job_retry", rr_retry_id);
+    let job_skip_id = create_job_with_rr(config, workflow_id, "job_skip", rr_skip_id);
+
+    apis::workflows_api::initialize_jobs(config, workflow_id, None, None, None)
+        .expect("Failed to reinitialize");
+
+    // Both jobs OOM (137) with peak memory 3.5GB, exceeding the 2GB limit.
+    let peak = Some(3_500_000_000);
+    claim_and_complete_jobs(
+        config,
+        workflow_id,
+        run_id,
+        compute_node_id,
+        &[
+            (job_retry_id, 137, 1.0, JobStatus::Failed, peak, None),
+            (job_skip_id, 137, 1.0, JobStatus::Failed, peak, None),
+        ],
+    );
+
+    // Build the real diagnosis (include_failed=true so OOM jobs are analyzed).
+    let diagnosis = build_resource_utilization_report(config, Some(workflow_id), None, true, 1.0)
+        .expect("Failed to build diagnosis");
+    assert_eq!(
+        diagnosis.resource_violations.len(),
+        2,
+        "both OOM jobs should be flagged as violations"
+    );
+
+    let all_results = fetch_results(config, workflow_id);
+    let all_jobs = fetch_jobs(config, workflow_id);
+    let all_rrs = fetch_resource_requirements(config, workflow_id);
+
+    let ctx = ResourceCorrectionContext {
+        config,
+        workflow_id,
+        diagnosis: &diagnosis,
+        all_results: &all_results,
+        all_jobs: &all_jobs,
+        all_resource_requirements: &all_rrs,
+    };
+    // Include ONLY the retried job — mirrors the wizard passing the selected
+    // job ids while the user skipped the other.
+    let opts = ResourceCorrectionOptions {
+        memory_multiplier: 1.2,
+        cpu_multiplier: 1.2,
+        runtime_multiplier: 1.2,
+        include_jobs: vec![job_retry_id],
+        dry_run: false,
+        no_downsize: true,
+    };
+
+    let result = apply_resource_corrections(&ctx, &opts).expect("Failed to apply corrections");
+    assert_eq!(
+        result.resource_requirements_updated, 1,
+        "exactly one RR (the retried job's) should be updated"
+    );
+
+    // The retried job's RR was bumped above 2g.
+    let rr_retry_after =
+        apis::resource_requirements_api::get_resource_requirements(config, rr_retry_id)
+            .expect("Failed to get retried RR");
+    assert_ne!(
+        rr_retry_after.memory, "2g",
+        "retried job's memory should have been corrected"
+    );
+
+    // The skipped job's RR must be untouched — this is the bug fix.
+    let rr_skip_after =
+        apis::resource_requirements_api::get_resource_requirements(config, rr_skip_id)
+            .expect("Failed to get skipped RR");
+    assert_eq!(
+        rr_skip_after.memory, "2g",
+        "skipped job's memory must remain 2g"
+    );
 }

--- a/tests/test_workflow_manager.rs
+++ b/tests/test_workflow_manager.rs
@@ -705,8 +705,12 @@ fn test_reset_failed_jobs_validates_workflow_and_status(start_server: &ServerPro
         "error should report 1 of 3 reset, got: {err}"
     );
     assert!(
-        err.contains(&format!("Job {foreign_id} belongs to workflow")),
+        err.contains(&format!("job {foreign_id}: belongs to workflow")),
         "error should flag the cross-workflow job, got: {err}"
+    );
+    assert!(
+        err.contains(&format!("job {ready_id}: status")) && err.contains("not recoverable"),
+        "error should flag the Ready job as a non-recoverable status skip, got: {err}"
     );
 
     // The eligible job was reset despite the other two being rejected.

--- a/tests/test_workflow_manager.rs
+++ b/tests/test_workflow_manager.rs
@@ -621,9 +621,10 @@ fn test_reset_failed_jobs_only_resets_selected(start_server: &ServerProcess) {
 
 /// `reset_failed_jobs` must validate every job before resetting it: a job that
 /// belongs to a different workflow, or one that is not in a recoverable status,
-/// must be skipped. When any job is skipped or fails, the call attempts all the
-/// others and returns a combined error rather than bailing on the first problem
-/// (there is no server-side atomic bulk reset).
+/// must be skipped. It is best-effort -- a partial success returns
+/// `Ok(reset_count)` (so callers don't abort recovery), while a call where
+/// nothing could be reset returns `Err`. We assert primarily on the resulting
+/// job statuses and only loosely on the error text.
 #[rstest]
 fn test_reset_failed_jobs_validates_workflow_and_status(start_server: &ServerProcess) {
     let config = start_server.config.clone();
@@ -692,54 +693,57 @@ fn test_reset_failed_jobs_validates_workflow_and_status(start_server: &ServerPro
     fail_job(foreign_id, other_workflow_id, other_run_id, other_cn_id);
     // `ready_id` is left in its initialized (Ready) state -- not recoverable.
 
-    // Ask to reset all three. Only `failed_id` is eligible; the other two must
-    // be rejected and surfaced in a combined error.
-    let result = torc::client::commands::recover::reset_failed_jobs(
+    let job_status = |id: i64| {
+        apis::jobs_api::get_job(&config, id)
+            .unwrap()
+            .status
+            .unwrap()
+    };
+
+    // Partial success: ask to reset all three. Only `failed_id` is eligible; the
+    // Ready job (wrong status) and the foreign job (wrong workflow) are skipped,
+    // but the eligible job is still reset, so the call returns Ok(1).
+    let reset_count = torc::client::commands::recover::reset_failed_jobs(
         &config,
         workflow_id,
         &[failed_id, ready_id, foreign_id],
-    );
-    let err = result.expect_err("expected combined error for skipped jobs");
-    assert!(
-        err.contains("Reset 1 of 3"),
-        "error should report 1 of 3 reset, got: {err}"
-    );
-    assert!(
-        err.contains(&format!("job {foreign_id}: belongs to workflow")),
-        "error should flag the cross-workflow job, got: {err}"
-    );
-    assert!(
-        err.contains(&format!("job {ready_id}: status")) && err.contains("not recoverable"),
-        "error should flag the Ready job as a non-recoverable status skip, got: {err}"
-    );
+    )
+    .expect("partial success should not be an error");
+    assert_eq!(reset_count, 1, "only the eligible job should be reset");
 
-    // The eligible job was reset despite the other two being rejected.
+    // Behavior is verified primarily through the resulting statuses.
     assert_eq!(
-        apis::jobs_api::get_job(&config, failed_id)
-            .unwrap()
-            .status
-            .unwrap(),
+        job_status(failed_id),
         models::JobStatus::Uninitialized,
-        "eligible failed job should still be reset"
+        "eligible failed job should be reset"
     );
-    // The non-recoverable job was left alone.
     assert_eq!(
-        apis::jobs_api::get_job(&config, ready_id)
-            .unwrap()
-            .status
-            .unwrap(),
+        job_status(ready_id),
         models::JobStatus::Ready,
-        "Ready job must not be reset"
+        "Ready (non-recoverable) job must not be reset"
     );
-    // The foreign workflow's job is untouched.
     assert_eq!(
-        apis::jobs_api::get_job(&config, foreign_id)
-            .unwrap()
-            .status
-            .unwrap(),
+        job_status(foreign_id),
         models::JobStatus::Failed,
         "job in another workflow must not be reset"
     );
+
+    // Total failure: neither remaining job is eligible (Ready status / foreign
+    // workflow), so nothing is reset and the call returns Err. Check only that
+    // the error references the offending jobs, not its exact phrasing.
+    let err = torc::client::commands::recover::reset_failed_jobs(
+        &config,
+        workflow_id,
+        &[ready_id, foreign_id],
+    )
+    .expect_err("a reset where nothing succeeds should be an error");
+    assert!(
+        err.contains(&ready_id.to_string()) && err.contains(&foreign_id.to_string()),
+        "error should reference both un-reset jobs, got: {err}"
+    );
+    // Statuses remain unchanged after the failed call.
+    assert_eq!(job_status(ready_id), models::JobStatus::Ready);
+    assert_eq!(job_status(foreign_id), models::JobStatus::Failed);
 }
 
 #[rstest]

--- a/tests/test_workflow_manager.rs
+++ b/tests/test_workflow_manager.rs
@@ -7,7 +7,7 @@ mod common;
 
 use common::{
     ServerProcess, create_diamond_workflow, create_test_compute_node, create_test_file,
-    create_test_user_data, create_test_workflow_advanced, start_server,
+    create_test_user_data, create_test_workflow, create_test_workflow_advanced, start_server,
 };
 use rstest::rstest;
 use std::fs;
@@ -522,6 +522,101 @@ fn test_recover_reset_sequence_bumps_run_id_once(start_server: &ServerProcess) {
         before + 1,
         "recover reset sequence must bump run_id exactly once"
     );
+}
+
+/// Regression test for the `torc recover` bug where choosing "Skip" for some
+/// failed jobs still reset them. `reset_failed_jobs` previously called the
+/// workflow-wide `reset_job_status(failed_only=true)`, ignoring its `job_ids`
+/// argument, so EVERY failed job was reset regardless of the user's selection.
+/// It must now reset ONLY the jobs whose IDs are passed in, leaving other
+/// failed jobs untouched.
+#[rstest]
+fn test_reset_failed_jobs_only_resets_selected(start_server: &ServerProcess) {
+    let config = start_server.config.clone();
+    let workflow = create_test_workflow(&config, "reset_failed_selective");
+    let workflow_id = workflow.id.unwrap();
+
+    // Create three independent jobs; we will fail all three but only ask to
+    // reset two of them, mirroring the recover scenario (retry OOM, skip the
+    // unknown-cause failures).
+    let mut job_ids = Vec::new();
+    for name in ["job_a", "job_b", "job_c"] {
+        let job = apis::jobs_api::create_job(
+            &config,
+            models::JobModel::new(workflow_id, name.to_string(), format!("echo {name}")),
+        )
+        .unwrap_or_else(|e| panic!("Failed to create {name}: {e}"));
+        job_ids.push(job.id.unwrap());
+    }
+
+    let torc_config = TorcConfig::load().unwrap_or_default();
+    let manager = WorkflowManager::new(config.clone(), torc_config, workflow.clone());
+    manager.initialize(false).expect("Failed to initialize");
+    let run_id = apis::workflows_api::get_workflow(&config, workflow_id)
+        .expect("get workflow")
+        .run_id
+        .unwrap_or(1);
+    let compute_node = create_test_compute_node(&config, workflow_id);
+    let cn_id = compute_node.id.unwrap();
+
+    // Drive all three to Running, then fail them.
+    for &id in &job_ids {
+        apis::jobs_api::manage_status_change(&config, id, models::JobStatus::Running, run_id)
+            .unwrap_or_else(|e| panic!("Failed to set job {id} running: {e}"));
+        let result = models::ResultModel::new(
+            id,
+            workflow_id,
+            run_id,
+            1, // attempt_id
+            cn_id,
+            1,   // return_code
+            1.0, // exec_time_minutes
+            chrono::Utc::now().to_rfc3339(),
+            models::JobStatus::Failed,
+        );
+        apis::jobs_api::complete_job(&config, id, models::JobStatus::Failed, run_id, result)
+            .unwrap_or_else(|e| panic!("Failed to fail job {id}: {e}"));
+    }
+
+    // Reset only the first two jobs.
+    let selected = &job_ids[0..2];
+    let reset_count =
+        torc::client::commands::recover::reset_failed_jobs(&config, workflow_id, selected)
+            .expect("reset_failed_jobs");
+
+    // The reported count must reflect exactly what was reset, not all failures.
+    assert_eq!(reset_count, 2, "only the two selected jobs should be reset");
+
+    // Selected jobs are now Uninitialized.
+    for &id in selected {
+        assert_eq!(
+            apis::jobs_api::get_job(&config, id)
+                .unwrap()
+                .status
+                .unwrap(),
+            models::JobStatus::Uninitialized,
+            "selected job {id} should be reset to Uninitialized"
+        );
+    }
+
+    // The unselected (skipped) job must remain Failed -- this is the bug fix.
+    assert_eq!(
+        apis::jobs_api::get_job(&config, job_ids[2])
+            .unwrap()
+            .status
+            .unwrap(),
+        models::JobStatus::Failed,
+        "skipped job {} must remain Failed",
+        job_ids[2]
+    );
+
+    // run_id must be unchanged: reset_failed_jobs does not bump it (only the
+    // subsequent reinitialize does).
+    let after = apis::workflows_api::get_workflow(&config, workflow_id)
+        .expect("get workflow after")
+        .run_id
+        .unwrap_or(0);
+    assert_eq!(after, run_id, "reset_failed_jobs must not bump run_id");
 }
 
 #[rstest]

--- a/tests/test_workflow_manager.rs
+++ b/tests/test_workflow_manager.rs
@@ -487,16 +487,45 @@ fn test_recover_reset_sequence_bumps_run_id_once(start_server: &ServerProcess) {
         create_test_workflow_manager(config.clone(), "test_recover_run_id_once");
     let workflow_id = workflow.id.unwrap();
 
-    // Initialize and run a job so the workflow has an established run.
-    let (job_id, _run_id) = execute_workflow_with_job(
+    // Initialize and run a job so the workflow has an established run, then fail
+    // it: `reset_failed_jobs` only resets jobs in a recoverable state, and the
+    // test cares about run_id bookkeeping, not how the job got to that state.
+    let job = apis::jobs_api::create_job(
         &config,
-        &manager,
-        workflow_id,
-        "test_job",
-        "echo 'test'",
-        None,
+        models::JobModel::new(
+            workflow_id,
+            "test_job".to_string(),
+            "echo 'test'".to_string(),
+        ),
     )
-    .expect("execute workflow with job");
+    .expect("create job");
+    let job_id = job.id.unwrap();
+
+    manager.initialize(false).expect("initialize");
+    let run_id = manager.get_run_id().expect("get run_id");
+    let compute_node = create_test_compute_node(&config, workflow_id);
+
+    apis::jobs_api::manage_status_change(&config, job_id, models::JobStatus::Running, run_id)
+        .expect("set job running");
+    let failed_result = models::ResultModel::new(
+        job_id,
+        workflow_id,
+        run_id,
+        1, // attempt_id
+        compute_node.id.unwrap(),
+        1,   // return_code
+        1.0, // exec_time_minutes
+        chrono::Utc::now().to_rfc3339(),
+        models::JobStatus::Failed,
+    );
+    apis::jobs_api::complete_job(
+        &config,
+        job_id,
+        models::JobStatus::Failed,
+        run_id,
+        failed_result,
+    )
+    .expect("fail job");
 
     let before = apis::workflows_api::get_workflow(&config, workflow_id)
         .expect("get workflow")

--- a/tests/test_workflow_manager.rs
+++ b/tests/test_workflow_manager.rs
@@ -619,6 +619,125 @@ fn test_reset_failed_jobs_only_resets_selected(start_server: &ServerProcess) {
     assert_eq!(after, run_id, "reset_failed_jobs must not bump run_id");
 }
 
+/// `reset_failed_jobs` must validate every job before resetting it: a job that
+/// belongs to a different workflow, or one that is not in a recoverable status,
+/// must be skipped. When any job is skipped or fails, the call attempts all the
+/// others and returns a combined error rather than bailing on the first problem
+/// (there is no server-side atomic bulk reset).
+#[rstest]
+fn test_reset_failed_jobs_validates_workflow_and_status(start_server: &ServerProcess) {
+    let config = start_server.config.clone();
+
+    // Two separate workflows. The target workflow gets one failed job (eligible)
+    // and one still-Ready job (ineligible status). The other workflow gets one
+    // failed job that must never be touched via the target workflow's reset.
+    let workflow = create_test_workflow(&config, "reset_validate_target");
+    let workflow_id = workflow.id.unwrap();
+    let other_workflow = create_test_workflow(&config, "reset_validate_other");
+    let other_workflow_id = other_workflow.id.unwrap();
+
+    let make_job = |wf_id: i64, name: &str| {
+        apis::jobs_api::create_job(
+            &config,
+            models::JobModel::new(wf_id, name.to_string(), format!("echo {name}")),
+        )
+        .unwrap_or_else(|e| panic!("Failed to create {name}: {e}"))
+        .id
+        .unwrap()
+    };
+    let failed_id = make_job(workflow_id, "failed_job");
+    let ready_id = make_job(workflow_id, "ready_job");
+    let foreign_id = make_job(other_workflow_id, "foreign_job");
+
+    let torc_config = TorcConfig::load().unwrap_or_default();
+    WorkflowManager::new(config.clone(), torc_config.clone(), workflow.clone())
+        .initialize(false)
+        .expect("initialize target");
+    WorkflowManager::new(config.clone(), torc_config, other_workflow.clone())
+        .initialize(false)
+        .expect("initialize other");
+
+    let run_id = apis::workflows_api::get_workflow(&config, workflow_id)
+        .expect("get workflow")
+        .run_id
+        .unwrap_or(1);
+    let other_run_id = apis::workflows_api::get_workflow(&config, other_workflow_id)
+        .expect("get other workflow")
+        .run_id
+        .unwrap_or(1);
+    let cn_id = create_test_compute_node(&config, workflow_id).id.unwrap();
+    let other_cn_id = create_test_compute_node(&config, other_workflow_id)
+        .id
+        .unwrap();
+
+    // Fail the eligible job in the target workflow and the foreign job.
+    let fail_job = |id: i64, wf_id: i64, rid: i64, cn: i64| {
+        apis::jobs_api::manage_status_change(&config, id, models::JobStatus::Running, rid)
+            .unwrap_or_else(|e| panic!("set job {id} running: {e}"));
+        let result = models::ResultModel::new(
+            id,
+            wf_id,
+            rid,
+            1,
+            cn,
+            1,
+            1.0,
+            chrono::Utc::now().to_rfc3339(),
+            models::JobStatus::Failed,
+        );
+        apis::jobs_api::complete_job(&config, id, models::JobStatus::Failed, rid, result)
+            .unwrap_or_else(|e| panic!("fail job {id}: {e}"));
+    };
+    fail_job(failed_id, workflow_id, run_id, cn_id);
+    fail_job(foreign_id, other_workflow_id, other_run_id, other_cn_id);
+    // `ready_id` is left in its initialized (Ready) state -- not recoverable.
+
+    // Ask to reset all three. Only `failed_id` is eligible; the other two must
+    // be rejected and surfaced in a combined error.
+    let result = torc::client::commands::recover::reset_failed_jobs(
+        &config,
+        workflow_id,
+        &[failed_id, ready_id, foreign_id],
+    );
+    let err = result.expect_err("expected combined error for skipped jobs");
+    assert!(
+        err.contains("Reset 1 of 3"),
+        "error should report 1 of 3 reset, got: {err}"
+    );
+    assert!(
+        err.contains(&format!("Job {foreign_id} belongs to workflow")),
+        "error should flag the cross-workflow job, got: {err}"
+    );
+
+    // The eligible job was reset despite the other two being rejected.
+    assert_eq!(
+        apis::jobs_api::get_job(&config, failed_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        models::JobStatus::Uninitialized,
+        "eligible failed job should still be reset"
+    );
+    // The non-recoverable job was left alone.
+    assert_eq!(
+        apis::jobs_api::get_job(&config, ready_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        models::JobStatus::Ready,
+        "Ready job must not be reset"
+    );
+    // The foreign workflow's job is untouched.
+    assert_eq!(
+        apis::jobs_api::get_job(&config, foreign_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        models::JobStatus::Failed,
+        "job in another workflow must not be reset"
+    );
+}
+
 #[rstest]
 fn test_get_run_id(start_server: &ServerProcess) {
     let config = start_server.config.clone();


### PR DESCRIPTION
Backports the `torc recover` selective-reset fix to the `release/0.34.x` line and bumps the patch release to **v0.34.3**.

## Changes
- **Fix torc recover to reset only selected jobs** (cherry-picked from `daniel-thom/fix-recover-selective-reset`) — recover now resets only the selected jobs rather than all jobs, and respects the `Skip` resource-correction filtering.
- **Regression test** for recover `Skip` resource-correction filtering.
- **Bump release to v0.34.3** across `Cargo.toml`, `Cargo.lock`, `Dockerfile`, `python_client/pyproject.toml`, and `docs/src/getting-started/installation.md`.

Both fix commits cherry-picked cleanly onto `release/0.34.x` (no conflicts). Pre-commit checks (fmt, clippy, dprint, shellcheck) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)