### PR TITLE
Fix recover bugs and unify watch onto recover_workflow

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -814,6 +814,20 @@ SEE ALSO:
         ///   claude - Claude Code CLI (default)
         #[arg(long, default_value = "claude", verbatim_doc_comment)]
         ai_agent: String,
+
+        /// Fixed Slurm partition for regenerated schedulers (bypasses auto-selection)
+        ///
+        /// Only applies to non-interactive recovery (--no-prompts, JSON output, or a
+        /// non-TTY stdin). The interactive wizard prompts for the partition instead.
+        #[arg(long)]
+        partition: Option<String>,
+
+        /// Fixed Slurm walltime for regenerated schedulers (bypasses auto-calculation)
+        ///
+        /// Only applies to non-interactive recovery (--no-prompts, JSON output, or a
+        /// non-TTY stdin). The interactive wizard prompts for the walltime instead.
+        #[arg(long)]
+        walltime: Option<String>,
     },
     /// Cancel a workflow and all associated Slurm jobs
     ///

--- a/src/client/commands/recover.rs
+++ b/src/client/commands/recover.rs
@@ -145,8 +145,6 @@ pub(crate) fn effective_retry_unknown(retry_unknown: bool, recovery_hook: Option
 }
 
 /// Whether the workflow has any Slurm scheduler configured.
-///
-/// Whether the workflow has any Slurm scheduler configured.
 pub fn workflow_has_schedulers(config: &Configuration, workflow_id: i64) -> Result<bool, String> {
     let schedulers = apis::slurm_schedulers_api::list_slurm_schedulers(
         config,
@@ -251,7 +249,13 @@ fn record_recovery_event(
         "action": "recover",
         "execution_mode": exec_mode,
         "interactive": args.interactive,
+        // Both the raw flag and the value recovery actually used: a recovery hook implies
+        // retry-unknown (see effective_retry_unknown), so the raw flag alone is misleading.
         "retry_unknown": args.retry_unknown,
+        "effective_retry_unknown": effective_retry_unknown(
+            args.retry_unknown,
+            args.recovery_hook.as_deref(),
+        ),
         "recovery_hook": args.recovery_hook,
         "ai_recovery": args.ai_recovery,
         "memory_multiplier": effective_memory_multiplier,

--- a/src/client/commands/recover.rs
+++ b/src/client/commands/recover.rs
@@ -86,6 +86,12 @@ pub struct RecoverArgs {
     pub ai_recovery: bool,
     /// AI agent CLI to use for --ai-recovery (e.g., "claude")
     pub ai_agent: String,
+    /// Fixed Slurm partition for regenerated schedulers (bypasses auto-selection).
+    /// Only used by the non-interactive path; the wizard prompts for it instead.
+    pub partition: Option<String>,
+    /// Fixed Slurm walltime for regenerated schedulers (bypasses auto-calculation).
+    /// Only used by the non-interactive path; the wizard prompts for it instead.
+    pub walltime: Option<String>,
 }
 
 /// Result of applying recovery heuristics
@@ -124,6 +130,18 @@ pub struct SlurmLogInfo {
     pub slurm_job_id: Option<String>,
     pub slurm_stdout: Option<String>,
     pub slurm_stderr: Option<String>,
+}
+
+/// Whether unknown-cause failures should be retried.
+///
+/// `--retry-unknown` retries them directly. A `--recovery-hook` also implies retry-unknown:
+/// the hook exists to fix unknown failures, so the user clearly intends those jobs to be
+/// retried after it runs. Without this implication the hook would run (with real side
+/// effects) and recovery would then abort with "no auto-recoverable jobs" because the
+/// unknown jobs were never added to the retry set. Both `torc recover` and
+/// `torc watch --recover` flow through here, so the rule is applied identically.
+pub(crate) fn effective_retry_unknown(retry_unknown: bool, recovery_hook: Option<&str>) -> bool {
+    retry_unknown || recovery_hook.is_some()
 }
 
 /// Recover a Slurm workflow by:
@@ -244,6 +262,10 @@ pub fn recover_workflow(
         return recover_workflow_interactive(config, args);
     }
 
+    // A recovery hook implies the user wants unknown failures retried (see
+    // effective_retry_unknown); otherwise the hook would run and recovery would abort.
+    let retry_unknown = effective_retry_unknown(args.retry_unknown, args.recovery_hook.as_deref());
+
     // Step 2: Diagnose failures
     info!("Diagnosing failures...");
     let diagnosis = diagnose_failures(config, args.workflow_id)?;
@@ -260,7 +282,7 @@ pub fn recover_workflow(
         &diagnosis,
         args.memory_multiplier,
         args.runtime_multiplier,
-        args.retry_unknown,
+        retry_unknown,
         &args.output_dir,
         args.dry_run,
     )?;
@@ -280,7 +302,7 @@ pub fn recover_workflow(
     }
 
     if result.other_failures > 0 {
-        if args.retry_unknown {
+        if retry_unknown {
             if args.recovery_hook.is_some() {
                 info!(
                     "  {} job(s) with unknown failure cause (would run recovery hook)",
@@ -437,7 +459,13 @@ pub fn recover_workflow(
 
     // Step 7: Regenerate Slurm schedulers and submit
     info!("Schedulers regenerating workflow_id={}", args.workflow_id);
-    regenerate_and_submit(config, args.workflow_id, &args.output_dir, None, None)?;
+    regenerate_and_submit(
+        config,
+        args.workflow_id,
+        &args.output_dir,
+        args.partition.as_deref(),
+        args.walltime.as_deref(),
+    )?;
 
     Ok(result)
 }
@@ -1274,14 +1302,21 @@ fn print_truncated_names<S: AsRef<str>>(names: &[S], max: usize) {
     }
 }
 
-/// Read a line from stdin, trimmed. Returns the default if the user presses Enter.
-/// Errors on EOF (e.g. Ctrl-D): no more input will ever arrive, so aborting beats
-/// prompt loops that re-prompt on invalid input spinning forever on empty reads.
-fn prompt_line(prompt: &str) -> Result<String, String> {
-    eprint!("{}", prompt);
-    io::stderr().flush().ok();
+/// Read a line from `reader`, trimmed, writing `prompt` to `writer` first. Returns the
+/// default (empty string) if the user presses Enter. Errors on EOF (e.g. Ctrl-D): no more
+/// input will ever arrive, so aborting beats prompt loops re-prompting forever on empty reads.
+///
+/// The reader/writer are injected so the wizard's input parsing can be unit-tested; the
+/// public [`prompt_line`] wrapper binds them to stdin/stderr.
+fn prompt_line_from<R: io::BufRead, W: Write>(
+    reader: &mut R,
+    writer: &mut W,
+    prompt: &str,
+) -> Result<String, String> {
+    write!(writer, "{}", prompt).ok();
+    writer.flush().ok();
     let mut buf = String::new();
-    let bytes_read = io::stdin()
+    let bytes_read = reader
         .read_line(&mut buf)
         .map_err(|e| format!("Failed to read input: {}", e))?;
     if bytes_read == 0 {
@@ -1290,11 +1325,17 @@ fn prompt_line(prompt: &str) -> Result<String, String> {
     Ok(buf.trim().to_string())
 }
 
-/// Prompt the user for a choice. `valid` lists accepted single-char answers (lowercase).
-/// Returns the default if the user presses Enter.
-fn prompt_choice(prompt: &str, valid: &[&str], default: &str) -> Result<String, String> {
+/// Prompt the user for a choice over `reader`/`writer`. `valid` lists accepted single-char
+/// answers (lowercase). Returns the default if the user presses Enter.
+fn prompt_choice_from<R: io::BufRead, W: Write>(
+    reader: &mut R,
+    writer: &mut W,
+    prompt: &str,
+    valid: &[&str],
+    default: &str,
+) -> Result<String, String> {
     loop {
-        let input = prompt_line(prompt)?;
+        let input = prompt_line_from(reader, writer, prompt)?;
         let answer = if input.is_empty() {
             default.to_string()
         } else {
@@ -1303,29 +1344,101 @@ fn prompt_choice(prompt: &str, valid: &[&str], default: &str) -> Result<String, 
         if valid.contains(&answer.as_str()) {
             return Ok(answer);
         }
-        eprintln!(
+        writeln!(
+            writer,
             "  Invalid choice '{}'. Valid options: {}",
             answer,
             valid.join(", ")
-        );
+        )
+        .ok();
     }
 }
 
-/// Prompt for a floating-point multiplier with a default value.
-fn prompt_multiplier(label: &str, default: f64) -> Result<f64, String> {
+/// Prompt for a floating-point multiplier over `reader`/`writer` with a default value.
+/// Only accepts strictly positive numbers.
+fn prompt_multiplier_from<R: io::BufRead, W: Write>(
+    reader: &mut R,
+    writer: &mut W,
+    label: &str,
+    default: f64,
+) -> Result<f64, String> {
     loop {
-        let input = prompt_line(&format!(
-            "  Enter {} multiplier [default: {}]: ",
-            label, default
-        ))?;
+        let input = prompt_line_from(
+            reader,
+            writer,
+            &format!("  Enter {} multiplier [default: {}]: ", label, default),
+        )?;
         if input.is_empty() {
             return Ok(default);
         }
         match input.parse::<f64>() {
             Ok(v) if v > 0.0 => return Ok(v),
-            _ => eprintln!("  Please enter a positive number."),
+            _ => writeln!(writer, "  Please enter a positive number.").ok(),
+        };
+    }
+}
+
+/// Read a line from stdin, trimmed, prompting on stderr. See [`prompt_line_from`].
+fn prompt_line(prompt: &str) -> Result<String, String> {
+    let stdin = io::stdin();
+    let mut reader = stdin.lock();
+    let mut writer = io::stderr();
+    prompt_line_from(&mut reader, &mut writer, prompt)
+}
+
+/// Prompt the user for a choice on stdin/stderr. See [`prompt_choice_from`].
+fn prompt_choice(prompt: &str, valid: &[&str], default: &str) -> Result<String, String> {
+    let stdin = io::stdin();
+    let mut reader = stdin.lock();
+    let mut writer = io::stderr();
+    prompt_choice_from(&mut reader, &mut writer, prompt, valid, default)
+}
+
+/// Prompt for a floating-point multiplier on stdin/stderr. See [`prompt_multiplier_from`].
+fn prompt_multiplier(label: &str, default: f64) -> Result<f64, String> {
+    let stdin = io::stdin();
+    let mut reader = stdin.lock();
+    let mut writer = io::stderr();
+    prompt_multiplier_from(&mut reader, &mut writer, label, default)
+}
+
+/// Failed-job resource violations grouped by failure cause for the interactive wizard.
+struct CategorizedViolations<'a> {
+    oom: Vec<&'a crate::client::report_models::ResourceViolationInfo>,
+    timeout: Vec<&'a crate::client::report_models::ResourceViolationInfo>,
+    cpu: Vec<&'a crate::client::report_models::ResourceViolationInfo>,
+    unknown: Vec<&'a crate::client::report_models::ResourceViolationInfo>,
+}
+
+/// Categorize resource violations by failure cause. The precedence (memory, then
+/// timeout/runtime, then cpu, then unknown) and the "unknown = no flags set" definition
+/// mirror the non-interactive path's classification in [`apply_recovery_heuristics`], so
+/// both surfaces agree on which jobs are correctable vs unknown-cause. Pure (no I/O) so it
+/// can be unit-tested.
+fn categorize_violations(
+    violations: &[crate::client::report_models::ResourceViolationInfo],
+) -> CategorizedViolations<'_> {
+    let mut categorized = CategorizedViolations {
+        oom: Vec::new(),
+        timeout: Vec::new(),
+        cpu: Vec::new(),
+        unknown: Vec::new(),
+    };
+    for v in violations {
+        if v.memory_violation {
+            categorized.oom.push(v);
+        } else if v.likely_timeout || v.likely_runtime_violation {
+            // likely_runtime_violation (exec > 100% of runtime) implies likely_timeout
+            // (exec > 90%) today, but check it explicitly so the wizard's classification
+            // matches the non-interactive path even if the diagnosis thresholds drift apart.
+            categorized.timeout.push(v);
+        } else if v.likely_cpu_violation {
+            categorized.cpu.push(v);
+        } else {
+            categorized.unknown.push(v);
         }
     }
+    categorized
 }
 
 /// Interactive recovery wizard (default when stdin is a TTY). Guides the user
@@ -1344,26 +1457,12 @@ fn recover_workflow_interactive(
     // are offered the same correct-and-retry treatment as OOM/timeout (matching
     // the non-interactive path) instead of being lumped in with unknown-cause
     // failures and retried without a CPU correction.
-    let mut oom_jobs: Vec<&crate::client::report_models::ResourceViolationInfo> = Vec::new();
-    let mut timeout_jobs: Vec<&crate::client::report_models::ResourceViolationInfo> = Vec::new();
-    let mut cpu_jobs: Vec<&crate::client::report_models::ResourceViolationInfo> = Vec::new();
-    let mut unknown_jobs: Vec<&crate::client::report_models::ResourceViolationInfo> = Vec::new();
-
-    for v in &diagnosis.resource_violations {
-        if v.memory_violation {
-            oom_jobs.push(v);
-        } else if v.likely_timeout || v.likely_runtime_violation {
-            // likely_runtime_violation (exec > 100% of runtime) implies
-            // likely_timeout (exec > 90%) today, but check it explicitly so the
-            // wizard's classification matches the non-interactive path even if
-            // the diagnosis thresholds drift apart.
-            timeout_jobs.push(v);
-        } else if v.likely_cpu_violation {
-            cpu_jobs.push(v);
-        } else {
-            unknown_jobs.push(v);
-        }
-    }
+    let CategorizedViolations {
+        oom: oom_jobs,
+        timeout: timeout_jobs,
+        cpu: cpu_jobs,
+        unknown: unknown_jobs,
+    } = categorize_violations(&diagnosis.resource_violations);
 
     if oom_jobs.is_empty()
         && timeout_jobs.is_empty()
@@ -1587,14 +1686,23 @@ fn recover_workflow_interactive(
     }
 
     if !unknown_jobs.is_empty() {
+        // A recovery hook is meant to fix unknown failures, so default to retrying them
+        // when one is configured — consistent with effective_retry_unknown on the
+        // non-interactive path.
+        let unknown_default = if args.recovery_hook.is_some() {
+            "r"
+        } else {
+            "s"
+        };
         let choice = prompt_choice(
             &format!(
-                "Unknown failures ({} job{}): [R]etry as-is / [S]kip (default: S): ",
+                "Unknown failures ({} job{}): [R]etry as-is / [S]kip (default: {}): ",
                 unknown_jobs.len(),
                 plural(unknown_jobs.len()),
+                unknown_default.to_uppercase(),
             ),
             &["r", "s"],
-            "s",
+            unknown_default,
         )?;
         if choice == "r" {
             include_unknown = true;
@@ -1792,14 +1900,14 @@ fn recover_workflow_interactive(
             }
         }
         SchedulerChoice::Existing {
-            scheduler_id,
-            scheduler_name,
+            source,
             num_allocations,
             start_one_worker_per_node,
         } => {
             eprintln!(
-                "\n  Scheduler: {} (ID {}), {} allocation(s)",
-                scheduler_name, scheduler_id, num_allocations
+                "\n  Scheduler: {}, {} allocation(s)",
+                source.display_label(),
+                num_allocations
             );
             if *start_one_worker_per_node {
                 eprintln!("  Start one worker per node: yes");
@@ -1862,11 +1970,15 @@ fn recover_workflow_interactive(
             )?;
         }
         SchedulerChoice::Existing {
-            scheduler_id,
+            source,
             num_allocations,
             start_one_worker_per_node,
-            ..
         } => {
+            // Now that the user has confirmed, materialize the scheduler (creating the
+            // walltime-override clone if one was deferred — see ExistingSchedulerSource).
+            let (scheduler_id, _scheduler_name) =
+                resolve_existing_scheduler_source(config, source)?;
+
             // Reinitialization above re-armed the workflow's on_workflow_start schedule_nodes
             // action. Mark it executed before submitting so it doesn't re-fire on the first
             // compute node and submit the action's original allocation count instead of the
@@ -1879,7 +1991,7 @@ fn recover_workflow_interactive(
             submit_existing_scheduler(
                 config,
                 args.workflow_id,
-                *scheduler_id,
+                scheduler_id,
                 *num_allocations,
                 *start_one_worker_per_node,
                 &args.output_dir,
@@ -1910,13 +2022,69 @@ enum SchedulerChoice {
         partition: Option<String>,
         walltime: Option<String>,
     },
-    /// Reuse an existing scheduler config
+    /// Reuse an existing scheduler config (possibly a deferred clone)
     Existing {
-        scheduler_id: i64,
-        scheduler_name: String,
+        source: ExistingSchedulerSource,
         num_allocations: i32,
         start_one_worker_per_node: bool,
     },
+}
+
+/// Where an `Existing` scheduler submission gets its scheduler config.
+///
+/// A walltime override clones the selected scheduler, but that database write is DEFERRED
+/// (see [`resolve_existing_scheduler_source`]) until after the user confirms recovery, so
+/// declining at the confirmation prompt leaves no orphaned `*_recovery` scheduler behind.
+enum ExistingSchedulerSource {
+    /// Reuse an existing scheduler config by ID.
+    Existing { id: i64, name: String },
+    /// Create a new scheduler cloned from `base` with `walltime`, after confirmation.
+    CloneWithWalltime {
+        base: Box<crate::models::SlurmSchedulerModel>,
+        walltime: String,
+    },
+}
+
+impl ExistingSchedulerSource {
+    /// Human-readable label for the confirmation prompt (before any clone is created).
+    fn display_label(&self) -> String {
+        match self {
+            ExistingSchedulerSource::Existing { id, name } => format!("{} (ID {})", name, id),
+            ExistingSchedulerSource::CloneWithWalltime { base, walltime } => format!(
+                "{}_recovery (new scheduler, walltime {})",
+                base.name.as_deref().unwrap_or("scheduler"),
+                walltime
+            ),
+        }
+    }
+}
+
+/// Resolve an [`ExistingSchedulerSource`] to a concrete `(scheduler_id, name)`, creating the
+/// cloned scheduler now if one was deferred. Called only after the user confirms recovery.
+fn resolve_existing_scheduler_source(
+    config: &Configuration,
+    source: &ExistingSchedulerSource,
+) -> Result<(i64, String), String> {
+    match source {
+        ExistingSchedulerSource::Existing { id, name } => Ok((*id, name.clone())),
+        ExistingSchedulerSource::CloneWithWalltime { base, walltime } => {
+            eprintln!("  Creating new scheduler with walltime {}...", walltime);
+            let mut new_sched = (**base).clone();
+            new_sched.id = None;
+            new_sched.walltime = walltime.clone();
+            let base_name = base.name.as_deref().unwrap_or("scheduler");
+            new_sched.name = Some(format!("{}_recovery", base_name));
+            let created = apis::slurm_schedulers_api::create_slurm_scheduler(config, new_sched)
+                .map_err(|e| format!("Failed to create scheduler: {}", e))?;
+            let new_id = created.id.ok_or("Created scheduler missing ID")?;
+            let new_name = created.name.unwrap_or_default();
+            eprintln!(
+                "  Created scheduler '{}' (ID {}) with walltime {}",
+                &new_name, new_id, &created.walltime
+            );
+            Ok((new_id, new_name))
+        }
+    }
 }
 
 /// Prompt the user to choose between auto-generating schedulers or reusing an existing one.
@@ -2012,34 +2180,24 @@ fn prompt_scheduler_choice(
             }
         };
 
-        // Prompt for walltime override
+        // Prompt for walltime override. A clone is NOT created here: we capture the intent
+        // and defer the database write to resolve_existing_scheduler_source, which runs only
+        // after the user confirms recovery (so declining leaves no orphaned scheduler).
         let walltime_input = prompt_line(&format!(
             "  Walltime [default: {}] (press Enter to keep): ",
             &scheduler.walltime
         ))?;
 
-        let (final_id, final_name) = if walltime_input.is_empty() {
-            (id, scheduler.name.clone().unwrap_or_default())
+        let source = if walltime_input.is_empty() {
+            ExistingSchedulerSource::Existing {
+                id,
+                name: scheduler.name.clone().unwrap_or_default(),
+            }
         } else {
-            // Create a new scheduler cloned from the selected one with the new walltime
-            eprintln!(
-                "  Creating new scheduler with walltime {}...",
-                &walltime_input
-            );
-            let mut new_sched = scheduler.clone();
-            new_sched.id = None;
-            new_sched.walltime = walltime_input;
-            let base_name = scheduler.name.as_deref().unwrap_or("scheduler");
-            new_sched.name = Some(format!("{}_recovery", base_name));
-            let created = apis::slurm_schedulers_api::create_slurm_scheduler(config, new_sched)
-                .map_err(|e| format!("Failed to create scheduler: {}", e))?;
-            let new_id = created.id.ok_or("Created scheduler missing ID")?;
-            let new_name = created.name.unwrap_or_default();
-            eprintln!(
-                "  Created scheduler '{}' (ID {}) with walltime {}",
-                &new_name, new_id, &created.walltime
-            );
-            (new_id, new_name)
+            ExistingSchedulerSource::CloneWithWalltime {
+                base: Box::new(scheduler.clone()),
+                walltime: walltime_input,
+            }
         };
 
         // Prompt for number of allocations
@@ -2077,8 +2235,7 @@ fn prompt_scheduler_choice(
         };
 
         return Ok(SchedulerChoice::Existing {
-            scheduler_id: final_id,
-            scheduler_name: final_name,
+            source,
             num_allocations,
             start_one_worker_per_node,
         });
@@ -2286,5 +2443,219 @@ mod tests {
 
         let bad = OsStr::from_bytes(b"out\xffput");
         assert!(output_dir_arg(Path::new(bad)).is_err());
+    }
+
+    // ---- effective_retry_unknown -----------------------------------------------------
+
+    #[test]
+    fn retry_unknown_flag_alone_enables_retry() {
+        assert!(effective_retry_unknown(true, None));
+    }
+
+    #[test]
+    fn recovery_hook_implies_retry_unknown() {
+        // The core of Bug #2: a hook must imply retry-unknown so it doesn't run then abort.
+        assert!(effective_retry_unknown(false, Some("bash fix.sh")));
+        assert!(effective_retry_unknown(true, Some("bash fix.sh")));
+    }
+
+    #[test]
+    fn no_flag_and_no_hook_means_no_retry() {
+        assert!(!effective_retry_unknown(false, None));
+    }
+
+    // ---- prompt_line_from ------------------------------------------------------------
+
+    /// Drive a prompt helper with scripted stdin, capturing what was written.
+    fn run_line(input: &str) -> (Result<String, String>, String) {
+        let mut reader = input.as_bytes();
+        let mut writer: Vec<u8> = Vec::new();
+        let result = prompt_line_from(&mut reader, &mut writer, "prompt> ");
+        (result, String::from_utf8(writer).unwrap())
+    }
+
+    #[test]
+    fn prompt_line_trims_and_returns_value() {
+        let (result, written) = run_line("  hello \n");
+        assert_eq!(result.unwrap(), "hello");
+        // The prompt itself is written to the writer (stderr in production).
+        assert!(written.contains("prompt> "));
+    }
+
+    #[test]
+    fn prompt_line_empty_input_returns_empty_string() {
+        let (result, _) = run_line("\n");
+        assert_eq!(result.unwrap(), "");
+    }
+
+    #[test]
+    fn prompt_line_eof_is_error() {
+        // No newline and no data: read_line returns 0 bytes -> EOF error, not an empty string.
+        let (result, _) = run_line("");
+        assert!(result.unwrap_err().contains("EOF"));
+    }
+
+    // ---- prompt_choice_from ----------------------------------------------------------
+
+    fn run_choice(input: &str, valid: &[&str], default: &str) -> Result<String, String> {
+        let mut reader = input.as_bytes();
+        let mut writer: Vec<u8> = Vec::new();
+        prompt_choice_from(&mut reader, &mut writer, "choose: ", valid, default)
+    }
+
+    #[test]
+    fn prompt_choice_uses_default_on_empty() {
+        assert_eq!(run_choice("\n", &["y", "n"], "n").unwrap(), "n");
+    }
+
+    #[test]
+    fn prompt_choice_is_case_insensitive() {
+        assert_eq!(run_choice("Y\n", &["y", "n"], "n").unwrap(), "y");
+    }
+
+    #[test]
+    fn prompt_choice_reprompts_until_valid() {
+        // "maybe" is rejected, then "y" is accepted.
+        let mut reader = "maybe\ny\n".as_bytes();
+        let mut writer: Vec<u8> = Vec::new();
+        let answer =
+            prompt_choice_from(&mut reader, &mut writer, "choose: ", &["y", "n"], "n").unwrap();
+        assert_eq!(answer, "y");
+        let written = String::from_utf8(writer).unwrap();
+        assert!(written.contains("Invalid choice 'maybe'"));
+    }
+
+    #[test]
+    fn prompt_choice_eof_mid_reprompt_is_error() {
+        // Invalid answer then EOF (stream closes): must error rather than loop forever.
+        assert!(run_choice("nope", &["y", "n"], "n").is_err());
+    }
+
+    // ---- prompt_multiplier_from ------------------------------------------------------
+
+    fn run_multiplier(input: &str, default: f64) -> Result<f64, String> {
+        let mut reader = input.as_bytes();
+        let mut writer: Vec<u8> = Vec::new();
+        prompt_multiplier_from(&mut reader, &mut writer, "memory", default)
+    }
+
+    #[test]
+    fn prompt_multiplier_uses_default_on_empty() {
+        assert_eq!(run_multiplier("\n", 1.5).unwrap(), 1.5);
+    }
+
+    #[test]
+    fn prompt_multiplier_accepts_positive() {
+        assert_eq!(run_multiplier("2.0\n", 1.5).unwrap(), 2.0);
+    }
+
+    #[test]
+    fn prompt_multiplier_rejects_nonpositive_then_accepts() {
+        // Zero, negative, and non-numeric are all rejected; the loop continues to "3".
+        let answer = run_multiplier("0\n-1\nabc\n3\n", 1.5).unwrap();
+        assert_eq!(answer, 3.0);
+    }
+
+    // ---- categorize_violations -------------------------------------------------------
+
+    /// Build a violation with all flags off; callers flip the ones they need.
+    fn violation(job_id: i64) -> crate::client::report_models::ResourceViolationInfo {
+        crate::client::report_models::ResourceViolationInfo {
+            job_id,
+            job_name: format!("job_{}", job_id),
+            return_code: 1,
+            exec_time_minutes: 0.0,
+            configured_memory: "1g".to_string(),
+            configured_runtime: "PT1H".to_string(),
+            configured_cpus: 1,
+            peak_memory_bytes: None,
+            peak_memory_formatted: None,
+            memory_violation: false,
+            oom_reason: None,
+            memory_over_utilization: None,
+            likely_timeout: false,
+            timeout_reason: None,
+            runtime_utilization: None,
+            likely_cpu_violation: false,
+            peak_cpu_percent: None,
+            likely_runtime_violation: false,
+        }
+    }
+
+    #[test]
+    fn categorize_sorts_each_failure_type() {
+        let mut mem = violation(1);
+        mem.memory_violation = true;
+        let mut timeout = violation(2);
+        timeout.likely_timeout = true;
+        let mut runtime = violation(3);
+        runtime.likely_runtime_violation = true;
+        let mut cpu = violation(4);
+        cpu.likely_cpu_violation = true;
+        let unknown = violation(5);
+
+        let all = [mem, timeout, runtime, cpu, unknown];
+        let c = categorize_violations(&all);
+        assert_eq!(c.oom.iter().map(|v| v.job_id).collect::<Vec<_>>(), [1]);
+        // runtime violations join the timeout bucket.
+        assert_eq!(
+            c.timeout.iter().map(|v| v.job_id).collect::<Vec<_>>(),
+            [2, 3]
+        );
+        assert_eq!(c.cpu.iter().map(|v| v.job_id).collect::<Vec<_>>(), [4]);
+        assert_eq!(c.unknown.iter().map(|v| v.job_id).collect::<Vec<_>>(), [5]);
+    }
+
+    #[test]
+    fn categorize_precedence_memory_wins_over_other_flags() {
+        // A job flagged for memory AND cpu AND timeout is classified as OOM (memory first),
+        // so it is corrected once, not double-counted across buckets.
+        let mut v = violation(1);
+        v.memory_violation = true;
+        v.likely_timeout = true;
+        v.likely_cpu_violation = true;
+        let c = categorize_violations(std::slice::from_ref(&v));
+        assert_eq!(c.oom.len(), 1);
+        assert!(c.timeout.is_empty());
+        assert!(c.cpu.is_empty());
+        assert!(c.unknown.is_empty());
+    }
+
+    #[test]
+    fn categorize_no_flags_is_unknown() {
+        let all = [violation(9)];
+        let c = categorize_violations(&all);
+        assert_eq!(c.unknown.iter().map(|v| v.job_id).collect::<Vec<_>>(), [9]);
+        assert!(c.oom.is_empty() && c.timeout.is_empty() && c.cpu.is_empty());
+    }
+
+    #[test]
+    fn categorize_empty_input_is_all_empty() {
+        let c = categorize_violations(&[]);
+        assert!(
+            c.oom.is_empty() && c.timeout.is_empty() && c.cpu.is_empty() && c.unknown.is_empty()
+        );
+    }
+
+    // ---- summarize_not_reset ---------------------------------------------------------
+
+    #[test]
+    fn summarize_not_reset_lists_all_when_under_cap() {
+        let not_reset = vec!["job 1: nope".to_string(), "job 2: nope".to_string()];
+        let msg = summarize_not_reset(5, 3, &not_reset);
+        assert!(msg.contains("Reset 3 of 5"));
+        assert!(msg.contains("job 1: nope"));
+        assert!(msg.contains("job 2: nope"));
+        assert!(!msg.contains("more not shown"));
+    }
+
+    #[test]
+    fn summarize_not_reset_caps_detail_and_counts_remainder() {
+        let not_reset: Vec<String> = (0..8).map(|i| format!("job {}: nope", i)).collect();
+        let msg = summarize_not_reset(10, 2, &not_reset);
+        // Only the first 5 are shown; the remaining 3 are summarized.
+        assert!(msg.contains("job 4: nope"));
+        assert!(!msg.contains("job 5: nope"));
+        assert!(msg.contains("3 more not shown"));
     }
 }

--- a/src/client/commands/recover.rs
+++ b/src/client/commands/recover.rs
@@ -144,6 +144,137 @@ pub(crate) fn effective_retry_unknown(retry_unknown: bool, recovery_hook: Option
     retry_unknown || recovery_hook.is_some()
 }
 
+/// Whether the workflow has any Slurm scheduler configured.
+///
+/// Whether the workflow has any Slurm scheduler configured.
+pub fn workflow_has_schedulers(config: &Configuration, workflow_id: i64) -> Result<bool, String> {
+    let schedulers = apis::slurm_schedulers_api::list_slurm_schedulers(
+        config,
+        workflow_id,
+        None,
+        None,
+        None,
+        None,
+    )
+    .map_err(|e| format!("Failed to list schedulers: {}", e))?;
+    Ok(!schedulers.items.is_empty())
+}
+
+/// How a workflow's jobs are executed, which decides how recovery re-runs them.
+///
+/// Only Slurm workflows can have their allocations regenerated and submitted by recovery.
+/// For remote and local workflows, recovery resets the jobs and the user re-runs them with
+/// the appropriate command — recovery cannot (and must not) auto-generate a Slurm scheduler.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum RecoveryExecutionMode {
+    /// Slurm schedulers are configured: regenerate and submit allocations.
+    Slurm,
+    /// Remote SSH workers are registered: re-run with `torc remote run <id>`.
+    Remote,
+    /// Neither: the workflow was run locally; re-run with `torc run <id>`.
+    Local,
+}
+
+impl RecoveryExecutionMode {
+    fn is_slurm(self) -> bool {
+        self == RecoveryExecutionMode::Slurm
+    }
+
+    /// The command the user runs to re-execute the workflow after recovery resets its jobs.
+    /// `None` for Slurm, where recovery submits the allocations itself.
+    fn rerun_command(self, workflow_id: i64) -> Option<String> {
+        match self {
+            RecoveryExecutionMode::Slurm => None,
+            RecoveryExecutionMode::Remote => Some(format!("torc remote run {}", workflow_id)),
+            RecoveryExecutionMode::Local => Some(format!("torc run {}", workflow_id)),
+        }
+    }
+
+    /// One-line description of where the workflow runs, for recovery messaging.
+    fn description(self) -> &'static str {
+        match self {
+            RecoveryExecutionMode::Slurm => "Slurm schedulers",
+            RecoveryExecutionMode::Remote => "remote workers (no Slurm schedulers)",
+            RecoveryExecutionMode::Local => {
+                "no Slurm schedulers or remote workers (it was run locally)"
+            }
+        }
+    }
+
+    /// Print the post-reset "re-run it with ..." guidance (non-Slurm modes only).
+    fn print_rerun_hint(self, workflow_id: i64) {
+        if let Some(cmd) = self.rerun_command(workflow_id) {
+            eprintln!("\nThis workflow has {}.", self.description());
+            eprintln!("Re-run it with:\n  {}", cmd);
+        }
+    }
+}
+
+/// Determine how a workflow runs so recovery knows whether to submit Slurm allocations or
+/// reset-and-point the user at `torc remote run` / `torc run`. Slurm takes precedence (a
+/// workflow could have both schedulers and stale remote-worker rows).
+pub fn detect_recovery_execution_mode(
+    config: &Configuration,
+    workflow_id: i64,
+) -> Result<RecoveryExecutionMode, String> {
+    if workflow_has_schedulers(config, workflow_id)? {
+        return Ok(RecoveryExecutionMode::Slurm);
+    }
+    let remote_workers = apis::remote_workers_api::list_remote_workers(config, workflow_id)
+        .map_err(|e| format!("Failed to list remote workers: {}", e))?;
+    Ok(if remote_workers.is_empty() {
+        RecoveryExecutionMode::Local
+    } else {
+        RecoveryExecutionMode::Remote
+    })
+}
+
+/// Record a best-effort audit event capturing the recovery choices and outcome so a later
+/// investigation can see what `torc recover` did and how it was driven. The event is only
+/// emitted for applied (non-dry-run) recoveries. Failures are logged and swallowed — audit
+/// logging must never break a recovery that otherwise succeeded.
+///
+/// `effective_memory_multiplier` / `effective_runtime_multiplier` are the values actually
+/// used (the interactive wizard may prompt for different values than the CLI args).
+/// `scheduler` summarizes the scheduler decision for the Slurm path (None for non-Slurm).
+fn record_recovery_event(
+    config: &Configuration,
+    args: &RecoverArgs,
+    exec_mode: RecoveryExecutionMode,
+    effective_memory_multiplier: f64,
+    effective_runtime_multiplier: f64,
+    scheduler: Option<&str>,
+    result: &RecoveryResult,
+) {
+    let data = serde_json::json!({
+        "category": "recovery",
+        "action": "recover",
+        "execution_mode": exec_mode,
+        "interactive": args.interactive,
+        "retry_unknown": args.retry_unknown,
+        "recovery_hook": args.recovery_hook,
+        "ai_recovery": args.ai_recovery,
+        "memory_multiplier": effective_memory_multiplier,
+        "runtime_multiplier": effective_runtime_multiplier,
+        "partition": args.partition,
+        "walltime": args.walltime,
+        "scheduler": scheduler,
+        "oom_fixed": result.oom_fixed,
+        "timeout_fixed": result.timeout_fixed,
+        "unknown_retried": result.unknown_retried,
+        "other_failures": result.other_failures,
+        "jobs_reset": result.jobs_to_retry.len(),
+        "jobs_to_retry": result.jobs_to_retry,
+    });
+    let event = crate::models::EventModel::new(args.workflow_id, data);
+    if let Err(e) = apis::events_api::create_event(config, event) {
+        warn!(
+            "Failed to record recovery event workflow_id={}: {}",
+            args.workflow_id, e
+        );
+    }
+}
+
 /// Recover a Slurm workflow by:
 /// 1. Cleaning up orphaned jobs (from terminated Slurm allocations)
 /// 2. Checking preconditions (workflow complete, no active workers)
@@ -324,10 +455,25 @@ pub fn recover_workflow(
         }
     }
 
+    // Determine how the workflow runs. Only Slurm workflows have their allocations
+    // regenerated/submitted by recovery; remote and local workflows are reset and re-run by
+    // the user with `torc remote run` / `torc run`.
+    let exec_mode = detect_recovery_execution_mode(config, args.workflow_id)?;
+
     // In dry_run mode, stop here
     if args.dry_run {
         if result.jobs_to_retry.is_empty() {
             info!("[DRY RUN] No auto-recoverable jobs found.");
+        } else if let Some(rerun) = exec_mode.rerun_command(args.workflow_id) {
+            info!(
+                "[DRY RUN] Would reset {} job(s) for retry",
+                result.jobs_to_retry.len()
+            );
+            info!("[DRY RUN] Would reinitialize workflow");
+            info!(
+                "[DRY RUN] This workflow has no Slurm schedulers; it would be re-run with '{}'",
+                rerun
+            );
         } else {
             info!(
                 "[DRY RUN] Would reset {} job(s) for retry",
@@ -457,15 +603,35 @@ pub fn recover_workflow(
     info!("Workflow reinitializing workflow_id={}", args.workflow_id);
     reinitialize_workflow(config, args.workflow_id)?;
 
-    // Step 7: Regenerate Slurm schedulers and submit
-    info!("Schedulers regenerating workflow_id={}", args.workflow_id);
-    regenerate_and_submit(
+    // Step 7: Regenerate Slurm schedulers and submit — unless the workflow runs remotely or
+    // locally (no schedulers), in which case the jobs are now reset and the user re-runs with
+    // `torc remote run <id>` / `torc run <id>`.
+    if exec_mode.is_slurm() {
+        info!("Schedulers regenerating workflow_id={}", args.workflow_id);
+        regenerate_and_submit(
+            config,
+            args.workflow_id,
+            &args.output_dir,
+            args.partition.as_deref(),
+            args.walltime.as_deref(),
+        )?;
+    } else {
+        info!("Recovery reset complete workflow_id={}", args.workflow_id);
+        exec_mode.print_rerun_hint(args.workflow_id);
+    }
+
+    // Audit the recovery (choices + outcome) for later debugging. Non-interactive path, so
+    // the scheduler decision is just "regenerate" when Slurm.
+    let scheduler = exec_mode.is_slurm().then_some("regenerate");
+    record_recovery_event(
         config,
-        args.workflow_id,
-        &args.output_dir,
-        args.partition.as_deref(),
-        args.walltime.as_deref(),
-    )?;
+        args,
+        exec_mode,
+        args.memory_multiplier,
+        args.runtime_multiplier,
+        scheduler,
+        &result,
+    );
 
     Ok(result)
 }
@@ -1484,6 +1650,11 @@ fn recover_workflow_interactive(
         });
     }
 
+    // Determine how the workflow runs. Non-Slurm workflows (remote or local) have no
+    // scheduler to pick, so we skip the Slurm scheduler prompts and, after resetting jobs,
+    // point the user at `torc remote run <id>` / `torc run <id>`.
+    let exec_mode = detect_recovery_execution_mode(config, args.workflow_id)?;
+
     // --- Display summary table -----------------------------------------------
     if !oom_jobs.is_empty() {
         eprintln!(
@@ -1844,30 +2015,38 @@ fn recover_workflow_interactive(
 
     if args.dry_run {
         eprintln!("\n[DRY RUN] No changes applied.");
-        let slurm_dry_run = match get_scheduler_dry_run(
-            config,
-            args.workflow_id,
-            &args.output_dir,
-            &all_jobs_to_retry,
-        ) {
-            Ok(mut dr) => {
-                dr.would_submit = true;
-                for sched in &dr.planned_schedulers {
-                    let deps = if sched.has_dependencies {
-                        " (deferred)"
-                    } else {
-                        ""
-                    };
-                    eprintln!(
-                        "  {} - {} job(s), {} allocation(s){}",
-                        sched.name, sched.job_count, sched.num_allocations, deps
-                    );
+        let slurm_dry_run = if let Some(rerun) = exec_mode.rerun_command(args.workflow_id) {
+            eprintln!(
+                "  This workflow has no Slurm schedulers; it would be re-run with '{}'.",
+                rerun
+            );
+            None
+        } else {
+            match get_scheduler_dry_run(
+                config,
+                args.workflow_id,
+                &args.output_dir,
+                &all_jobs_to_retry,
+            ) {
+                Ok(mut dr) => {
+                    dr.would_submit = true;
+                    for sched in &dr.planned_schedulers {
+                        let deps = if sched.has_dependencies {
+                            " (deferred)"
+                        } else {
+                            ""
+                        };
+                        eprintln!(
+                            "  {} - {} job(s), {} allocation(s){}",
+                            sched.name, sched.job_count, sched.num_allocations, deps
+                        );
+                    }
+                    Some(dr)
                 }
-                Some(dr)
-            }
-            Err(e) => {
-                warn!("Could not get scheduler preview: {}", e);
-                None
+                Err(e) => {
+                    warn!("Could not get scheduler preview: {}", e);
+                    None
+                }
             }
         };
 
@@ -1882,40 +2061,53 @@ fn recover_workflow_interactive(
         });
     }
 
-    // --- Scheduler selection ----------------------------------------------------
-    eprintln!("\n--- Slurm Scheduler ---\n");
+    // --- Scheduler selection (Slurm only) ---------------------------------------
+    // Non-Slurm workflows have no scheduler to pick; we skip straight to confirmation and
+    // re-run them with `torc remote run` / `torc run` after the reset.
+    let scheduler_choice = if exec_mode.is_slurm() {
+        eprintln!("\n--- Slurm Scheduler ---\n");
+        let choice = prompt_scheduler_choice(config, args)?;
 
-    let scheduler_choice = prompt_scheduler_choice(config, args)?;
-
-    // Confirm before executing
-    match &scheduler_choice {
-        SchedulerChoice::Regenerate {
-            partition,
-            walltime,
-        } => {
-            eprintln!("\n  Scheduler: auto-generate new schedulers");
-            if let Some(p) = partition {
-                eprintln!("  Partition: {}", p);
+        // Show the chosen scheduler before confirming.
+        match &choice {
+            SchedulerChoice::Regenerate {
+                partition,
+                walltime,
+            } => {
+                eprintln!("\n  Scheduler: auto-generate new schedulers");
+                if let Some(p) = partition {
+                    eprintln!("  Partition: {}", p);
+                }
+                if let Some(w) = walltime {
+                    eprintln!("  Walltime: {}", w);
+                }
             }
-            if let Some(w) = walltime {
-                eprintln!("  Walltime: {}", w);
+            SchedulerChoice::Existing {
+                source,
+                num_allocations,
+                start_one_worker_per_node,
+            } => {
+                eprintln!(
+                    "\n  Scheduler: {}, {} allocation(s)",
+                    source.display_label(),
+                    num_allocations
+                );
+                if *start_one_worker_per_node {
+                    eprintln!("  Start one worker per node: yes");
+                }
             }
         }
-        SchedulerChoice::Existing {
-            source,
-            num_allocations,
-            start_one_worker_per_node,
-        } => {
+        Some(choice)
+    } else {
+        eprintln!("\nThis workflow has {}.", exec_mode.description());
+        if let Some(rerun) = exec_mode.rerun_command(args.workflow_id) {
             eprintln!(
-                "\n  Scheduler: {}, {} allocation(s)",
-                source.display_label(),
-                num_allocations
+                "  Recovery will reset the selected job(s); re-run them with '{}'.",
+                rerun
             );
-            if *start_one_worker_per_node {
-                eprintln!("  Start one worker per node: yes");
-            }
         }
-    }
+        None
+    };
 
     let confirm = prompt_choice("\nProceed with recovery? (y/N): ", &["y", "n"], "n")?;
     if confirm != "y" {
@@ -1956,12 +2148,12 @@ fn recover_workflow_interactive(
     info!("Reinitializing workflow...");
     reinitialize_workflow(config, args.workflow_id)?;
 
-    // Submit Slurm schedulers
+    // Submit Slurm schedulers, or — for a local workflow — skip submission entirely.
     match &scheduler_choice {
-        SchedulerChoice::Regenerate {
+        Some(SchedulerChoice::Regenerate {
             partition,
             walltime,
-        } => {
+        }) => {
             info!("Regenerating and submitting Slurm schedulers...");
             regenerate_and_submit(
                 config,
@@ -1971,11 +2163,11 @@ fn recover_workflow_interactive(
                 walltime.as_deref(),
             )?;
         }
-        SchedulerChoice::Existing {
+        Some(SchedulerChoice::Existing {
             source,
             num_allocations,
             start_one_worker_per_node,
-        } => {
+        }) => {
             // Now that the user has confirmed, materialize the scheduler (creating the
             // walltime-override clone if one was deferred — see ExistingSchedulerSource).
             let (scheduler_id, _scheduler_name) =
@@ -1999,14 +2191,25 @@ fn recover_workflow_interactive(
                 &args.output_dir,
             )?;
         }
+        None => {} // Local workflow: nothing to submit; hint printed below.
     }
 
     eprintln!(
         "\nRecovery complete. {} job(s) reset for retry.",
         all_jobs_to_retry.len()
     );
+    exec_mode.print_rerun_hint(args.workflow_id);
 
-    Ok(RecoveryResult {
+    // Summarize the scheduler decision for the audit event before the choice is dropped.
+    let scheduler_summary = match &scheduler_choice {
+        Some(SchedulerChoice::Regenerate { .. }) => Some("regenerate".to_string()),
+        Some(SchedulerChoice::Existing { source, .. }) => {
+            Some(format!("existing:{}", source.display_label()))
+        }
+        None => None,
+    };
+
+    let result = RecoveryResult {
         oom_fixed: real_result.memory_corrections,
         timeout_fixed: real_result.runtime_corrections,
         unknown_retried: unknown_job_ids.len(),
@@ -2014,7 +2217,20 @@ fn recover_workflow_interactive(
         jobs_to_retry: all_jobs_to_retry,
         adjustments: real_result.adjustments,
         slurm_dry_run: None,
-    })
+    };
+
+    // Audit the recovery (choices the user made + outcome) for later debugging.
+    record_recovery_event(
+        config,
+        args,
+        exec_mode,
+        memory_multiplier,
+        runtime_multiplier,
+        scheduler_summary.as_deref(),
+        &result,
+    );
+
+    Ok(result)
 }
 
 /// User's choice for how to handle Slurm scheduler submission.

--- a/src/client/commands/recover.rs
+++ b/src/client/commands/recover.rs
@@ -1686,14 +1686,16 @@ fn recover_workflow_interactive(
     }
 
     if !unknown_jobs.is_empty() {
-        // A recovery hook is meant to fix unknown failures, so default to retrying them
-        // when one is configured — consistent with effective_retry_unknown on the
-        // non-interactive path.
-        let unknown_default = if args.recovery_hook.is_some() {
-            "r"
-        } else {
-            "s"
-        };
+        // Default to retrying unknown failures when --retry-unknown was passed or a recovery
+        // hook is configured (the hook is meant to fix them). Routing through
+        // effective_retry_unknown keeps the wizard's default in lockstep with the
+        // non-interactive path instead of re-deriving the rule here.
+        let unknown_default =
+            if effective_retry_unknown(args.retry_unknown, args.recovery_hook.as_deref()) {
+                "r"
+            } else {
+                "s"
+            };
         let choice = prompt_choice(
             &format!(
                 "Unknown failures ({} job{}): [R]etry as-is / [S]kip (default: {}): ",

--- a/src/client/commands/watch.rs
+++ b/src/client/commands/watch.rs
@@ -12,12 +12,10 @@ use crate::client::apis;
 use crate::client::apis::configuration::Configuration;
 use crate::client::utils;
 
-// Re-export shared recovery types and functions from the recover module
-use super::recover::{
-    RecoveryResult, apply_recovery_heuristics, diagnose_failures, regenerate_and_submit,
-    reinitialize_workflow, reset_failed_jobs, run_recovery_hook,
-};
-use crate::client::report_models::ResourceUtilizationReport;
+// Shared recovery pipeline from the recover module. `torc watch --recover` delegates the
+// entire recovery sequence to recover_workflow so both surfaces share one tested code path.
+// regenerate_and_submit is still used directly by the auto-schedule logic below.
+use super::recover::{RecoverArgs, recover_workflow, regenerate_and_submit};
 
 // Use shared orphan detection logic
 use super::orphan_detection::cleanup_orphaned_jobs;
@@ -901,147 +899,41 @@ pub fn run_watch(config: &Configuration, args: &WatchArgs) {
             info!("\nAttempting automatic recovery (attempt {})", retry_count);
         }
 
-        // Step 1: Diagnose failures
-        info!("\nDiagnosing failures...");
-        let diagnosis = match diagnose_failures(config, args.workflow_id) {
-            Ok(d) => d,
-            Err(e) => {
-                warn!("Warning: Could not diagnose failures: {}", e);
-                warn!("Attempting retry without resource adjustments...");
-                ResourceUtilizationReport {
-                    workflow_id: args.workflow_id,
-                    run_id: None,
-                    total_results: 0,
-                    over_utilization_count: 0,
-                    violations: Vec::new(),
-                    within_limits: Vec::new(),
-                    resource_violations_count: 0,
-                    resource_violations: Vec::new(),
-                }
-            }
+        // Delegate the full recovery sequence (orphan cleanup, preconditions, diagnose,
+        // heuristics, recovery hook, reset, reinitialize, regenerate+submit) to the shared,
+        // well-tested recover_workflow path so watch and `torc recover` never diverge.
+        //
+        // Watch is always non-interactive and never a dry run. pending_failed/AI
+        // classification was already handled above, so ai_recovery is left off here to avoid
+        // invoking the agent twice. A --recovery-hook still implies retry-unknown inside
+        // recover_workflow (see effective_retry_unknown), matching watch's prior behavior.
+        let recover_args = RecoverArgs {
+            workflow_id: args.workflow_id,
+            output_dir: args.output_dir.clone(),
+            memory_multiplier: args.memory_multiplier,
+            runtime_multiplier: args.runtime_multiplier,
+            retry_unknown: args.retry_unknown,
+            recovery_hook: args.recovery_hook.clone(),
+            dry_run: false,
+            interactive: false,
+            ai_recovery: false,
+            ai_agent: args.ai_agent.clone(),
+            partition: args.partition.clone(),
+            walltime: args.walltime.clone(),
         };
-
-        // Step 2: Apply heuristics to adjust resources
-        info!("\nApplying recovery heuristics...");
-        // If a recovery hook is provided, treat unknown failures as retryable
-        // (the user is explicitly saying they'll handle them with their script)
-        let retry_unknown = args.retry_unknown || args.recovery_hook.is_some();
-        let recovery_result = match apply_recovery_heuristics(
-            config,
-            args.workflow_id,
-            &diagnosis,
-            args.memory_multiplier,
-            args.runtime_multiplier,
-            retry_unknown,
-            &args.output_dir,
-            false, // dry_run - always execute for watch
-        ) {
-            Ok(result) => {
-                if result.oom_fixed > 0 || result.timeout_fixed > 0 {
-                    info!(
-                        "  Applied fixes: {} OOM, {} timeout",
-                        result.oom_fixed, result.timeout_fixed
-                    );
-                }
-                if result.other_failures > 0 {
-                    if retry_unknown {
-                        if args.recovery_hook.is_some() {
-                            info!(
-                                "  {} job(s) with unknown failure cause (will run recovery hook)",
-                                result.other_failures
-                            );
-                        } else {
-                            info!(
-                                "  {} job(s) with unknown failure cause (will retry)",
-                                result.other_failures
-                            );
-                        }
-                    } else {
-                        info!(
-                            "  {} job(s) with unknown failure cause (skipped, use --retry-unknown to include)",
-                            result.other_failures
-                        );
-                    }
-                }
-                result
+        match recover_workflow(config, &recover_args) {
+            Ok(_) => {
+                info!("\nRecovery initiated. Resuming monitoring...\n");
             }
             Err(e) => {
-                warn!("Warning: Error applying heuristics: {}", e);
-                RecoveryResult {
-                    oom_fixed: 0,
-                    timeout_fixed: 0,
-                    unknown_retried: 0,
-                    other_failures: 0,
-                    jobs_to_retry: Vec::new(),
-                    adjustments: Vec::new(),
-                    slurm_dry_run: None,
-                }
-            }
-        };
-
-        // Step 2.5: Run recovery hook if there are unknown failures
-        if recovery_result.other_failures > 0
-            && let Some(ref hook_cmd) = args.recovery_hook
-        {
-            info!(
-                "\n{} job(s) with unknown failure cause - running recovery hook...",
-                recovery_result.other_failures
-            );
-            if let Err(e) = run_recovery_hook(config, args.workflow_id, hook_cmd) {
-                error!("Recovery hook failed: {}", e);
+                // recover_workflow returns Err both for hard failures and for the benign
+                // "nothing auto-recoverable" case (e.g. only unknown-cause failures without
+                // --retry-unknown). Either way watch can make no further progress, so report
+                // and exit non-zero, as the previous inline implementation did.
+                error!("Recovery failed: {}", e);
                 std::process::exit(1);
             }
         }
-
-        // Check if there are any jobs to retry
-        if recovery_result.jobs_to_retry.is_empty() {
-            warn!(
-                "\nNo auto-recoverable jobs found. {} job(s) failed with unknown causes.",
-                recovery_result.other_failures
-            );
-            warn!("Use --retry-unknown to retry jobs with unknown failure causes.");
-            warn!("Or use the Torc MCP server with your AI assistant to investigate.");
-            std::process::exit(1);
-        }
-
-        // Step 3: Reset failed jobs
-        info!(
-            "\nResetting {} job(s) for retry...",
-            recovery_result.jobs_to_retry.len()
-        );
-        match reset_failed_jobs(config, args.workflow_id, &recovery_result.jobs_to_retry) {
-            Ok(count) => {
-                info!("  Reset {} job(s)", count);
-            }
-            Err(e) => {
-                error!("Error resetting jobs: {}", e);
-                std::process::exit(1);
-            }
-        }
-
-        // Step 4: Reinitialize workflow first (before creating new allocations)
-        // Must happen before regenerate_and_submit because reset_workflow_status
-        // rejects requests when there are pending scheduled compute nodes.
-        info!("Reinitializing workflow...");
-        if let Err(e) = reinitialize_workflow(config, args.workflow_id) {
-            warn!("Error reinitializing workflow: {}", e);
-            std::process::exit(1);
-        }
-
-        // Step 5: Regenerate Slurm schedulers (this also marks old actions as executed)
-        info!("Regenerating Slurm schedulers...");
-        if let Err(e) = regenerate_and_submit(
-            config,
-            args.workflow_id,
-            &args.output_dir,
-            args.partition.as_deref(),
-            args.walltime.as_deref(),
-        ) {
-            warn!("Error regenerating schedulers: {}", e);
-            std::process::exit(1);
-        }
-
-        info!("\nRecovery initiated. Resuming monitoring...\n");
     }
 }
 

--- a/src/client/commands/watch.rs
+++ b/src/client/commands/watch.rs
@@ -856,7 +856,11 @@ pub fn run_watch(config: &Configuration, args: &WatchArgs) {
                         }
                     }
                 }
-            } else {
+            } else if !needs_recovery {
+                // Only pending_failed jobs and AI recovery is off: nothing to auto-recover,
+                // so surface the manual options and stop. When needs_recovery is also true we
+                // fall through to recover_workflow, which emits the same pending_failed notice
+                // itself — printing it here too would just duplicate that message.
                 warn!(
                     "\n{} job(s) in pending_failed status (awaiting classification)",
                     pending_failed
@@ -866,10 +870,7 @@ pub fn run_watch(config: &Configuration, args: &WatchArgs) {
                     "Or reset them manually: torc workflows reset-status {} --failed-only",
                     args.workflow_id
                 );
-                // Exit if only pending_failed jobs (no other failures to auto-recover)
-                if !needs_recovery {
-                    std::process::exit(1);
-                }
+                std::process::exit(1);
             }
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1083,7 +1083,7 @@ fn main() {
                         } else {
                             let n = result.jobs_to_retry.len();
                             match detect_recovery_execution_mode(&config, *workflow_id) {
-                                Ok(RecoveryExecutionMode::Slurm) | Err(_) => println!(
+                                Ok(RecoveryExecutionMode::Slurm) => println!(
                                     "Would reset {} job(s) and regenerate Slurm schedulers.",
                                     n
                                 ),
@@ -1095,6 +1095,8 @@ fn main() {
                                     "Would reset {} job(s); re-run with 'torc run {}'.",
                                     n, workflow_id
                                 ),
+                                // Detection failed transiently: don't claim a specific path.
+                                Err(_) => println!("Would reset {} job(s) for retry.", n),
                             }
                         }
                         println!("\nRun without --dry-run to apply these changes.");
@@ -1117,15 +1119,18 @@ fn main() {
                         } else {
                             let n = result.jobs_to_retry.len();
                             // recover_workflow already printed the re-run hint for non-Slurm
-                            // modes; the summary line just reflects what was done.
+                            // modes; the summary line just reflects what was done. On a
+                            // transient detection error, fall back to a neutral summary rather
+                            // than claiming Slurm schedulers were submitted.
                             match detect_recovery_execution_mode(&config, *workflow_id) {
-                                Ok(RecoveryExecutionMode::Slurm) | Err(_) => println!(
+                                Ok(RecoveryExecutionMode::Slurm) => println!(
                                     "Reset {} job(s). Slurm schedulers regenerated and submitted.",
                                     n
                                 ),
                                 Ok(
                                     RecoveryExecutionMode::Remote | RecoveryExecutionMode::Local,
-                                ) => {
+                                )
+                                | Err(_) => {
                                     println!("Reset {} job(s) for retry.", n)
                                 }
                             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1010,6 +1010,8 @@ fn main() {
             no_prompts,
             ai_recovery,
             ai_agent,
+            partition,
+            walltime,
         } => {
             // The interactive wizard prints prompts to stderr and reads stdin; that would block
             // and corrupt `-f json` output, which is meant for scripting. Force non-interactive
@@ -1026,6 +1028,8 @@ fn main() {
                 interactive,
                 ai_recovery: *ai_recovery,
                 ai_agent: ai_agent.clone(),
+                partition: partition.clone(),
+                walltime: walltime.clone(),
             };
 
             // For JSON output, get diagnosis data to include in the report

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,8 @@ use torc::client::commands::job_dependencies::handle_job_dependency_commands;
 use torc::client::commands::jobs::handle_job_commands;
 use torc::client::commands::logs::handle_log_commands;
 use torc::client::commands::recover::{
-    RecoverArgs, RecoveryReport, diagnose_failures, recover_workflow,
+    RecoverArgs, RecoveryExecutionMode, RecoveryReport, detect_recovery_execution_mode,
+    diagnose_failures, recover_workflow,
 };
 use torc::client::commands::remote::handle_remote_commands;
 use torc::client::commands::resource_requirements::handle_resource_requirements_commands;
@@ -1080,10 +1081,21 @@ fn main() {
                         if result.jobs_to_retry.is_empty() {
                             println!("No auto-recoverable jobs found.");
                         } else {
-                            println!(
-                                "Would reset {} job(s) and regenerate Slurm schedulers.",
-                                result.jobs_to_retry.len()
-                            );
+                            let n = result.jobs_to_retry.len();
+                            match detect_recovery_execution_mode(&config, *workflow_id) {
+                                Ok(RecoveryExecutionMode::Slurm) | Err(_) => println!(
+                                    "Would reset {} job(s) and regenerate Slurm schedulers.",
+                                    n
+                                ),
+                                Ok(RecoveryExecutionMode::Remote) => println!(
+                                    "Would reset {} job(s); re-run with 'torc remote run {}'.",
+                                    n, workflow_id
+                                ),
+                                Ok(RecoveryExecutionMode::Local) => println!(
+                                    "Would reset {} job(s); re-run with 'torc run {}'.",
+                                    n, workflow_id
+                                ),
+                            }
                         }
                         println!("\nRun without --dry-run to apply these changes.");
                     } else {
@@ -1103,10 +1115,20 @@ fn main() {
                         if result.jobs_to_retry.is_empty() {
                             println!("No auto-recoverable jobs found.");
                         } else {
-                            println!(
-                                "Reset {} job(s). Slurm schedulers regenerated and submitted.",
-                                result.jobs_to_retry.len()
-                            );
+                            let n = result.jobs_to_retry.len();
+                            // recover_workflow already printed the re-run hint for non-Slurm
+                            // modes; the summary line just reflects what was done.
+                            match detect_recovery_execution_mode(&config, *workflow_id) {
+                                Ok(RecoveryExecutionMode::Slurm) | Err(_) => println!(
+                                    "Reset {} job(s). Slurm schedulers regenerated and submitted.",
+                                    n
+                                ),
+                                Ok(
+                                    RecoveryExecutionMode::Remote | RecoveryExecutionMode::Local,
+                                ) => {
+                                    println!("Reset {} job(s) for retry.", n)
+                                }
+                            }
                         }
                     }
                 }

--- a/tests/test_recover.rs
+++ b/tests/test_recover.rs
@@ -1,9 +1,10 @@
 //! Integration tests for the `torc recover` recovery pipeline.
 //!
 //! These exercise the server-interacting recovery helpers directly against a live test
-//! server: `reset_failed_jobs` (status/ownership guards, partial success) and
+//! server: `reset_failed_jobs` (status/ownership guards, partial success),
 //! `apply_recovery_heuristics` (unknown-failure classification + retry-unknown inclusion,
-//! the mechanism behind the `--recovery-hook` implies `--retry-unknown` fix).
+//! the mechanism behind the `--recovery-hook` implies `--retry-unknown` fix), and
+//! `workflow_has_schedulers` (the local vs Slurm recovery branch).
 //!
 //! Pure decision logic (prompt parsing, violation categorization, `effective_retry_unknown`)
 //! is unit-tested in `src/client/commands/recover.rs` where no server is required.
@@ -17,7 +18,8 @@ use rstest::rstest;
 use torc::client::apis;
 use torc::client::apis::configuration::Configuration;
 use torc::client::commands::recover::{
-    apply_recovery_heuristics, diagnose_failures, reset_failed_jobs,
+    RecoveryExecutionMode, apply_recovery_heuristics, detect_recovery_execution_mode,
+    diagnose_failures, reset_failed_jobs, workflow_has_schedulers,
 };
 use torc::client::workflow_manager::WorkflowManager;
 use torc::config::TorcConfig;
@@ -345,4 +347,97 @@ fn apply_heuristics_no_failures_is_empty(start_server: &ServerProcess) {
     .expect("heuristics");
     assert_eq!(result.other_failures, 0);
     assert!(result.jobs_to_retry.is_empty());
+}
+
+// ---------------------------------------------------------------------------------------
+// workflow_has_schedulers: drives the local (no-scheduler) vs Slurm recovery branch
+// ---------------------------------------------------------------------------------------
+
+/// A workflow run locally has no Slurm schedulers; once one is created it is detected. This
+/// is the signal recover_workflow uses to skip Slurm regeneration and point the user at
+/// `torc run <id>` instead.
+#[rstest]
+fn workflow_has_schedulers_reflects_scheduler_presence(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let (workflow_id, _run_id) = init_workflow(config, "has_schedulers");
+
+    assert!(
+        !workflow_has_schedulers(config, workflow_id).expect("query schedulers"),
+        "a freshly created (locally run) workflow has no schedulers"
+    );
+
+    let scheduler = models::SlurmSchedulerModel {
+        id: None,
+        workflow_id,
+        name: Some("sched_a".to_string()),
+        account: "test_account".to_string(),
+        gres: None,
+        mem: Some("8G".to_string()),
+        nodes: 1,
+        ntasks_per_node: None,
+        partition: Some("debug".to_string()),
+        qos: None,
+        tmp: None,
+        walltime: "01:00:00".to_string(),
+        extra: None,
+    };
+    apis::slurm_schedulers_api::create_slurm_scheduler(config, scheduler)
+        .expect("create scheduler");
+
+    assert!(
+        workflow_has_schedulers(config, workflow_id).expect("query schedulers"),
+        "after creating a scheduler the workflow is detected as a Slurm workflow"
+    );
+}
+
+/// Recovery classifies a workflow as Local, Remote, or Slurm so it picks the right re-run
+/// path. With nothing configured it is Local; registering remote workers makes it Remote; a
+/// Slurm scheduler takes precedence over remote-worker rows and makes it Slurm.
+#[rstest]
+fn detect_recovery_execution_mode_distinguishes_local_remote_slurm(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let (workflow_id, _run_id) = init_workflow(config, "exec_mode");
+
+    assert_eq!(
+        detect_recovery_execution_mode(config, workflow_id).expect("detect mode"),
+        RecoveryExecutionMode::Local,
+        "no schedulers and no remote workers => local"
+    );
+
+    // Registering remote workers (stored directly via the API, no SSH) flips it to Remote.
+    apis::remote_workers_api::create_remote_workers(
+        config,
+        workflow_id,
+        vec!["tester@host1".to_string()],
+    )
+    .expect("create remote workers");
+    assert_eq!(
+        detect_recovery_execution_mode(config, workflow_id).expect("detect mode"),
+        RecoveryExecutionMode::Remote,
+        "remote workers but no schedulers => remote"
+    );
+
+    // A Slurm scheduler takes precedence even with remote-worker rows present.
+    let scheduler = models::SlurmSchedulerModel {
+        id: None,
+        workflow_id,
+        name: Some("sched_a".to_string()),
+        account: "test_account".to_string(),
+        gres: None,
+        mem: Some("8G".to_string()),
+        nodes: 1,
+        ntasks_per_node: None,
+        partition: Some("debug".to_string()),
+        qos: None,
+        tmp: None,
+        walltime: "01:00:00".to_string(),
+        extra: None,
+    };
+    apis::slurm_schedulers_api::create_slurm_scheduler(config, scheduler)
+        .expect("create scheduler");
+    assert_eq!(
+        detect_recovery_execution_mode(config, workflow_id).expect("detect mode"),
+        RecoveryExecutionMode::Slurm,
+        "schedulers take precedence over remote workers"
+    );
 }

--- a/tests/test_recover.rs
+++ b/tests/test_recover.rs
@@ -1,0 +1,348 @@
+//! Integration tests for the `torc recover` recovery pipeline.
+//!
+//! These exercise the server-interacting recovery helpers directly against a live test
+//! server: `reset_failed_jobs` (status/ownership guards, partial success) and
+//! `apply_recovery_heuristics` (unknown-failure classification + retry-unknown inclusion,
+//! the mechanism behind the `--recovery-hook` implies `--retry-unknown` fix).
+//!
+//! Pure decision logic (prompt parsing, violation categorization, `effective_retry_unknown`)
+//! is unit-tested in `src/client/commands/recover.rs` where no server is required.
+
+mod common;
+
+use common::{
+    ServerProcess, create_test_compute_node, create_test_job, create_test_workflow, start_server,
+};
+use rstest::rstest;
+use torc::client::apis;
+use torc::client::apis::configuration::Configuration;
+use torc::client::commands::recover::{
+    apply_recovery_heuristics, diagnose_failures, reset_failed_jobs,
+};
+use torc::client::workflow_manager::WorkflowManager;
+use torc::config::TorcConfig;
+use torc::models::{self, JobStatus};
+
+/// Create and initialize an (empty) workflow, returning `(workflow_id, run_id)`.
+fn init_workflow(config: &Configuration, name: &str) -> (i64, i64) {
+    let workflow = create_test_workflow(config, name);
+    let workflow_id = workflow.id.unwrap();
+    let torc_config = TorcConfig::load().unwrap_or_default();
+    let manager = WorkflowManager::new(config.clone(), torc_config, workflow);
+    manager
+        .initialize(false)
+        .expect("Failed to initialize workflow");
+    let run_id = manager.get_run_id().expect("Failed to get run_id");
+    (workflow_id, run_id)
+}
+
+/// Add a job with its own resource requirement, returning the job id. The job is created in
+/// the uninitialized state; call `initialize_jobs` afterward to make it claimable.
+fn add_job_with_rr(
+    config: &Configuration,
+    workflow_id: i64,
+    name: &str,
+    memory: &str,
+    runtime: &str,
+    cpus: i64,
+) -> i64 {
+    let mut job = create_test_job(config, workflow_id, name);
+    let mut rr = models::ResourceRequirementsModel::new(workflow_id, format!("{}_rr", name));
+    rr.memory = memory.to_string();
+    rr.runtime = runtime.to_string();
+    rr.num_cpus = cpus;
+    let created_rr = apis::resource_requirements_api::create_resource_requirements(config, rr)
+        .expect("Failed to create resource requirement");
+    let job_id = job.id.unwrap();
+    job.resource_requirements_id = Some(created_rr.id.unwrap());
+    apis::jobs_api::update_job(config, job_id, job).expect("Failed to update job");
+    job_id
+}
+
+/// Initialize jobs (ready them) and claim everything that is ready onto `compute_node_id`.
+fn claim_all_ready(config: &Configuration, workflow_id: i64) {
+    apis::workflows_api::initialize_jobs(config, workflow_id, None, None, None)
+        .expect("Failed to initialize jobs");
+    let resources = models::ComputeNodesResources::new(36, 100.0, 0, 1);
+    apis::workflows_api::claim_jobs_based_on_resources(config, workflow_id, 100, resources, None)
+        .expect("Failed to claim jobs");
+}
+
+/// Drive an already-claimed job to a terminal state by recording a result.
+#[allow(clippy::too_many_arguments)]
+fn finish_job(
+    config: &Configuration,
+    workflow_id: i64,
+    run_id: i64,
+    compute_node_id: i64,
+    job_id: i64,
+    return_code: i64,
+    status: JobStatus,
+    exec_minutes: f64,
+    peak_memory_bytes: Option<i64>,
+) {
+    apis::jobs_api::manage_status_change(config, job_id, JobStatus::Running, run_id)
+        .expect("Failed to set job running");
+    let mut result = models::ResultModel::new(
+        job_id,
+        workflow_id,
+        run_id,
+        1,
+        compute_node_id,
+        return_code,
+        exec_minutes,
+        chrono::Utc::now().to_rfc3339(),
+        status,
+    );
+    result.peak_memory_bytes = peak_memory_bytes;
+    apis::jobs_api::complete_job(config, job_id, result.status, run_id, result)
+        .expect("Failed to complete job");
+}
+
+fn job_status(config: &Configuration, job_id: i64) -> JobStatus {
+    apis::jobs_api::get_job(config, job_id)
+        .expect("Failed to fetch job")
+        .status
+        .expect("Job missing status")
+}
+
+fn output_dir_for(workflow_id: i64) -> std::path::PathBuf {
+    std::env::temp_dir().join(format!("torc_recover_test_{}", workflow_id))
+}
+
+// ---------------------------------------------------------------------------------------
+// reset_failed_jobs
+// ---------------------------------------------------------------------------------------
+
+/// A failed job is reset to uninitialized; a completed job in the same call is left alone.
+#[rstest]
+fn reset_failed_jobs_resets_failed_skips_completed(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let (workflow_id, run_id) = init_workflow(config, "reset_failed_skips_completed");
+    let compute_node_id = create_test_compute_node(config, workflow_id).id.unwrap();
+
+    let failed_id = add_job_with_rr(config, workflow_id, "will_fail", "2g", "PT1H", 1);
+    let done_id = add_job_with_rr(config, workflow_id, "will_succeed", "2g", "PT1H", 1);
+    claim_all_ready(config, workflow_id);
+
+    finish_job(
+        config,
+        workflow_id,
+        run_id,
+        compute_node_id,
+        failed_id,
+        1,
+        JobStatus::Failed,
+        5.0,
+        None,
+    );
+    finish_job(
+        config,
+        workflow_id,
+        run_id,
+        compute_node_id,
+        done_id,
+        0,
+        JobStatus::Completed,
+        5.0,
+        None,
+    );
+
+    let reset = reset_failed_jobs(config, workflow_id, &[failed_id, done_id])
+        .expect("reset should partially succeed");
+    assert_eq!(reset, 1, "only the failed job is recoverable");
+    assert_eq!(job_status(config, failed_id), JobStatus::Uninitialized);
+    assert_eq!(
+        job_status(config, done_id),
+        JobStatus::Completed,
+        "completed job must not be clobbered"
+    );
+}
+
+/// All targets are non-recoverable (completed) -> hard error, nothing reset.
+#[rstest]
+fn reset_failed_jobs_errors_when_nothing_recoverable(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let (workflow_id, run_id) = init_workflow(config, "reset_nothing_recoverable");
+    let compute_node_id = create_test_compute_node(config, workflow_id).id.unwrap();
+
+    let done_id = add_job_with_rr(config, workflow_id, "succeeds", "2g", "PT1H", 1);
+    claim_all_ready(config, workflow_id);
+    finish_job(
+        config,
+        workflow_id,
+        run_id,
+        compute_node_id,
+        done_id,
+        0,
+        JobStatus::Completed,
+        5.0,
+        None,
+    );
+
+    let err =
+        reset_failed_jobs(config, workflow_id, &[done_id]).expect_err("nothing recoverable -> Err");
+    assert!(
+        err.contains("0 of 1"),
+        "message should report nothing reset: {err}"
+    );
+}
+
+/// A job id from another workflow is refused (manage_status_change is not workflow-scoped,
+/// so reset_failed_jobs must guard ownership itself).
+#[rstest]
+fn reset_failed_jobs_refuses_foreign_workflow(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let (wf1, _run1) = init_workflow(config, "reset_owner_wf1");
+    let (wf2, run2) = init_workflow(config, "reset_owner_wf2");
+    let compute_node_id = create_test_compute_node(config, wf2).id.unwrap();
+
+    let foreign_id = add_job_with_rr(config, wf2, "foreign", "2g", "PT1H", 1);
+    claim_all_ready(config, wf2);
+    finish_job(
+        config,
+        wf2,
+        run2,
+        compute_node_id,
+        foreign_id,
+        1,
+        JobStatus::Failed,
+        5.0,
+        None,
+    );
+
+    // Ask wf1 to reset a job that actually belongs to wf2.
+    let err =
+        reset_failed_jobs(config, wf1, &[foreign_id]).expect_err("foreign job must be refused");
+    assert!(
+        err.contains("belongs to workflow"),
+        "unexpected message: {err}"
+    );
+    // The foreign job is untouched.
+    assert_eq!(job_status(config, foreign_id), JobStatus::Failed);
+}
+
+/// An empty id list is a no-op success.
+#[rstest]
+fn reset_failed_jobs_empty_list_is_ok_zero(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let (workflow_id, _run_id) = init_workflow(config, "reset_empty_list");
+    assert_eq!(reset_failed_jobs(config, workflow_id, &[]).unwrap(), 0);
+}
+
+/// Duplicate ids are deduplicated: the job is reset exactly once (count reflects unique ids).
+#[rstest]
+fn reset_failed_jobs_dedups_repeated_ids(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let (workflow_id, run_id) = init_workflow(config, "reset_dedup");
+    let compute_node_id = create_test_compute_node(config, workflow_id).id.unwrap();
+
+    let failed_id = add_job_with_rr(config, workflow_id, "fails_once", "2g", "PT1H", 1);
+    claim_all_ready(config, workflow_id);
+    finish_job(
+        config,
+        workflow_id,
+        run_id,
+        compute_node_id,
+        failed_id,
+        1,
+        JobStatus::Failed,
+        5.0,
+        None,
+    );
+
+    let reset = reset_failed_jobs(config, workflow_id, &[failed_id, failed_id, failed_id])
+        .expect("dedup reset should succeed");
+    assert_eq!(reset, 1, "duplicate ids must not double-count");
+    assert_eq!(job_status(config, failed_id), JobStatus::Uninitialized);
+}
+
+// ---------------------------------------------------------------------------------------
+// apply_recovery_heuristics: unknown-failure classification + retry-unknown
+// ---------------------------------------------------------------------------------------
+
+/// A job that failed with no resource violation (exit 1, well under memory/runtime/cpu) is an
+/// "unknown" failure: it is counted in other_failures but only joins jobs_to_retry when
+/// retry-unknown is in effect. This is the mechanism the `--recovery-hook` => retry-unknown
+/// fix relies on.
+#[rstest]
+fn apply_heuristics_unknown_failure_respects_retry_unknown(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let (workflow_id, run_id) = init_workflow(config, "heuristics_unknown_failure");
+    let compute_node_id = create_test_compute_node(config, workflow_id).id.unwrap();
+
+    // 2g / PT1H / 1 cpu, failed with exit 1, 5 min runtime, 1GB peak: no violation flags set.
+    let job_id = add_job_with_rr(config, workflow_id, "mystery_fail", "2g", "PT1H", 1);
+    claim_all_ready(config, workflow_id);
+    finish_job(
+        config,
+        workflow_id,
+        run_id,
+        compute_node_id,
+        job_id,
+        1,
+        JobStatus::Failed,
+        5.0,
+        Some(1_000_000_000),
+    );
+
+    let diagnosis = diagnose_failures(config, workflow_id).expect("diagnose");
+    let output_dir = output_dir_for(workflow_id);
+
+    // retry_unknown = false: counted as an other failure but NOT scheduled for retry.
+    let without = apply_recovery_heuristics(
+        config,
+        workflow_id,
+        &diagnosis,
+        1.5,
+        1.4,
+        false,
+        &output_dir,
+        true,
+    )
+    .expect("heuristics (no retry-unknown)");
+    assert_eq!(without.other_failures, 1, "unknown failure counted");
+    assert!(
+        without.jobs_to_retry.is_empty(),
+        "unknown failure must not be retried without retry-unknown"
+    );
+    assert_eq!(without.oom_fixed, 0);
+    assert_eq!(without.timeout_fixed, 0);
+
+    // retry_unknown = true (what --recovery-hook implies): the unknown job IS scheduled.
+    let with = apply_recovery_heuristics(
+        config,
+        workflow_id,
+        &diagnosis,
+        1.5,
+        1.4,
+        true,
+        &output_dir,
+        true,
+    )
+    .expect("heuristics (retry-unknown)");
+    assert_eq!(with.other_failures, 1);
+    assert_eq!(with.unknown_retried, 1);
+    assert_eq!(with.jobs_to_retry, vec![job_id]);
+}
+
+/// With no failed jobs at all, heuristics find nothing to do.
+#[rstest]
+fn apply_heuristics_no_failures_is_empty(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let (workflow_id, _run_id) = init_workflow(config, "heuristics_no_failures");
+    let diagnosis = diagnose_failures(config, workflow_id).expect("diagnose");
+    let result = apply_recovery_heuristics(
+        config,
+        workflow_id,
+        &diagnosis,
+        1.5,
+        1.4,
+        true,
+        &output_dir_for(workflow_id),
+        true,
+    )
+    .expect("heuristics");
+    assert_eq!(result.other_failures, 0);
+    assert!(result.jobs_to_retry.is_empty());
+}


### PR DESCRIPTION
## Summary

Fixes several `torc recover` bugs and unifies `torc watch --recover` onto the
shared, tested `recover_workflow` pipeline so the two surfaces can no longer
diverge.

- **`--recovery-hook` now implies `--retry-unknown`.** A new
  `effective_retry_unknown(retry_unknown, recovery_hook)` helper centralizes
  the rule: a hook exists to fix unknown-cause failures, so those jobs are
  added to the retry set. Previously the hook would run (with real side
  effects) and then recovery aborted with "no auto-recoverable jobs".
- **`torc watch --recover` delegates the full recovery sequence to
  `recover_workflow`** (orphan cleanup, preconditions, diagnose, heuristics,
  recovery hook, reset, reinitialize, regenerate+submit) instead of
  re-implementing it inline.
- **Interactive wizard honors `--retry-unknown`.** The unknown-failure default
  derives from `effective_retry_unknown(args.retry_unknown, recovery_hook)`
  rather than checking only the hook, matching the non-interactive path.
- **Deferred scheduler clone.** A walltime override no longer creates the
  `*_recovery` scheduler during prompting; the DB write is deferred until after
  the user confirms recovery, so declining leaves no orphaned scheduler.
- **`--partition` / `--walltime`** are now threaded through non-interactive
  recovery (`cli.rs` → `RecoverArgs` → `regenerate_and_submit`).
- **Deduped pending_failed notice.** watch only prints the "awaiting
  classification" message when it owns the exit; otherwise `recover_workflow`
  emits it once.

## Tests

- New `tests/test_recover.rs`: integration coverage for `reset_failed_jobs`
  (status/ownership guards, partial success, dedup) and
  `apply_recovery_heuristics` (unknown-failure classification + retry-unknown).
- New unit tests in `recover.rs` for `effective_retry_unknown`, the injectable
  prompt helpers, `categorize_violations`, and `summarize_not_reset`.

All checks pass: `cargo fmt --check`, `cargo clippy --all --all-targets
--all-features -- -D warnings`, `dprint check`, and the recover test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)