### PR TITLE
Fix recover re-arming satisfied job-gated schedule_nodes actions

### DIFF
--- a/src/client/commands/recover.rs
+++ b/src/client/commands/recover.rs
@@ -2485,11 +2485,13 @@ fn schedule_action_already_satisfied(action: &crate::models::WorkflowActionModel
         return false;
     }
     match action.trigger_type.as_str() {
-        // Fires as soon as the workflow starts — always immediately satisfied.
-        "on_workflow_start" => true,
+        // Fire as soon as the workflow/worker starts — always immediately satisfied. The server
+        // activates both (`trigger_count = required_triggers`) and the job runner executes them
+        // before its main loop (`execute_workflow_start_actions` / `execute_worker_start_actions`).
+        "on_workflow_start" | "on_worker_start" => true,
         // Job-gated — satisfied only if the required jobs are already in the target state.
         "on_jobs_ready" | "on_jobs_complete" => action.trigger_count >= action.required_triggers,
-        // Other triggers (e.g. on_worker_start, on_workflow_complete) are not handled here.
+        // Other triggers (e.g. on_workflow_complete, on_worker_complete) are not handled here.
         _ => false,
     }
 }
@@ -2505,6 +2507,10 @@ fn schedule_action_already_satisfied(action: &crate::models::WorkflowActionModel
 /// in a prior run. Claiming those actions here marks them executed and prevents the duplicate,
 /// action-defined submission. The `regenerate` path performs the equivalent step inside
 /// `handle_regenerate`. Recovery actions (`is_recovery`) are left untouched.
+///
+/// Persistent actions cannot be suppressed this way: the server's claim logic deliberately leaves
+/// their `executed` flag at 0 so multiple workers can each claim them, so claiming would not stop
+/// them re-firing. Those are surfaced as a warning instead.
 pub fn mark_satisfied_schedule_actions_executed(
     config: &Configuration,
     workflow_id: i64,
@@ -2513,36 +2519,53 @@ pub fn mark_satisfied_schedule_actions_executed(
         .map_err(|e| format!("Failed to list workflow actions: {}", e))?;
 
     for action in actions {
-        if schedule_action_already_satisfied(&action)
-            && let Some(action_id) = action.id
-        {
-            // Delegate to the shared helper, which treats a 409 Conflict (already claimed by
-            // another process) as `Ok(false)` and surfaces any other failure as an error. We
-            // propagate that error rather than logging and continuing: if the claim genuinely
-            // fails, the action stays armed and would re-fire on a compute node, reintroducing
-            // the duplicate-allocation bug — better to stop and report it.
-            match crate::client::utils::claim_action(
-                config,
-                workflow_id,
-                action_id,
-                None, // login-node submission, no compute node
-                WAIT_FOR_HEALTHY_DATABASE_MINUTES,
-            ) {
-                Ok(true) => {
-                    info!(
-                        "Marked already-satisfied {} schedule_nodes action {} as executed to avoid duplicate allocations",
-                        action.trigger_type, action_id
-                    );
-                }
-                Ok(false) => {
-                    debug!("Action {} already claimed", action_id);
-                }
-                Err(e) => {
-                    return Err(format!(
-                        "Failed to mark {} schedule_nodes action {} as executed: {}",
-                        action.trigger_type, action_id, e
-                    ));
-                }
+        if !schedule_action_already_satisfied(&action) {
+            continue;
+        }
+        let Some(action_id) = action.id else {
+            continue;
+        };
+
+        // Claiming a persistent action does NOT clear its armed state — the server keeps
+        // `executed = 0` for persistent actions so multiple workers can claim them. Claiming here
+        // would log a misleading "marked executed" while the action stays armed and re-fires. We
+        // can't suppress it automatically, so warn the user to remove/disable it instead.
+        if action.persistent {
+            warn!(
+                "Persistent {} schedule_nodes action {} is already satisfied and will re-fire \
+                 after recovery, submitting its own allocations; it cannot be suppressed \
+                 automatically. Remove or disable it if you do not want those allocations.",
+                action.trigger_type, action_id
+            );
+            continue;
+        }
+
+        // Delegate to the shared helper, which treats a 409 Conflict (already claimed by another
+        // process) as `Ok(false)` and surfaces any other failure as an error. We propagate that
+        // error rather than logging and continuing: if the claim genuinely fails, the action stays
+        // armed and would re-fire on a compute node, reintroducing the duplicate-allocation bug —
+        // better to stop and report it.
+        match crate::client::utils::claim_action(
+            config,
+            workflow_id,
+            action_id,
+            None, // login-node submission, no compute node
+            WAIT_FOR_HEALTHY_DATABASE_MINUTES,
+        ) {
+            Ok(true) => {
+                info!(
+                    "Marked already-satisfied {} schedule_nodes action {} as executed to avoid duplicate allocations",
+                    action.trigger_type, action_id
+                );
+            }
+            Ok(false) => {
+                debug!("Action {} already claimed", action_id);
+            }
+            Err(e) => {
+                return Err(format!(
+                    "Failed to mark {} schedule_nodes action {} as executed: {}",
+                    action.trigger_type, action_id, e
+                ));
             }
         }
     }

--- a/src/client/commands/recover.rs
+++ b/src/client/commands/recover.rs
@@ -2177,11 +2177,13 @@ fn recover_workflow_interactive(
             let (scheduler_id, _scheduler_name) =
                 resolve_existing_scheduler_source(config, source)?;
 
-            // Reinitialization above re-armed the workflow's on_workflow_start schedule_nodes
-            // action. Mark it executed before submitting so it doesn't re-fire on the first
-            // compute node and submit the action's original allocation count instead of the
-            // user's choice. (The Regenerate path does the equivalent inside handle_regenerate.)
-            mark_on_workflow_start_schedule_actions_executed(config, args.workflow_id)?;
+            // Reinitialization above re-armed the workflow's schedule_nodes actions. Mark the
+            // already-satisfied ones (the on_workflow_start action plus any job-gated action whose
+            // gating jobs already completed in a prior run) executed before submitting, so they
+            // don't re-fire on the first compute node and submit their original allocation count
+            // instead of the user's choice. (The Regenerate path does the equivalent inside
+            // handle_regenerate.)
+            mark_satisfied_schedule_actions_executed(config, args.workflow_id)?;
             info!(
                 "Submitting {} allocation(s) with scheduler ID {}...",
                 num_allocations, scheduler_id
@@ -2464,16 +2466,46 @@ fn prompt_scheduler_choice(
     }
 }
 
-/// Mark the workflow's `on_workflow_start` `schedule_nodes` actions as executed.
+/// Returns `true` when `action` is a non-recovery, not-yet-executed `schedule_nodes` action whose
+/// trigger condition is *already satisfied* — i.e. it would fire immediately, without any further
+/// job progress, as soon as a compute node starts.
 ///
-/// `reinitialize_workflow` re-arms these actions (the server clears their `executed` flag and
-/// re-triggers them). When recovery reuses an existing scheduler and submits a user-chosen number
-/// of allocations directly via `torc slurm schedule-nodes`, a re-armed action would otherwise fire
-/// again on the first compute node that starts and submit the action's original `num_allocations`,
-/// ignoring the user's entry. Claiming the actions here marks them executed and prevents that
-/// duplicate, action-defined submission. The `regenerate` path performs the equivalent step inside
+/// `reinitialize_workflow` re-arms every action (the server clears `executed` and recomputes
+/// `trigger_count` from the current job state). An already-satisfied `schedule_nodes` action would
+/// then re-submit its own original allocation count when recovery reuses an existing scheduler and
+/// the user submits a chosen number of allocations directly — exactly the duplicate we want to
+/// suppress.
+///
+/// Job-gated triggers (`on_jobs_ready` / `on_jobs_complete`) count as satisfied only when their
+/// gating jobs already completed in a prior run (`trigger_count >= required_triggers`). A job-gated
+/// action still waiting on jobs that will run during recovery is intentionally left armed so it can
+/// fire legitimately when those jobs finish.
+fn schedule_action_already_satisfied(action: &crate::models::WorkflowActionModel) -> bool {
+    if action.action_type != "schedule_nodes" || action.is_recovery || action.executed {
+        return false;
+    }
+    match action.trigger_type.as_str() {
+        // Fires as soon as the workflow starts — always immediately satisfied.
+        "on_workflow_start" => true,
+        // Job-gated — satisfied only if the required jobs are already in the target state.
+        "on_jobs_ready" | "on_jobs_complete" => action.trigger_count >= action.required_triggers,
+        // Other triggers (e.g. on_worker_start, on_workflow_complete) are not handled here.
+        _ => false,
+    }
+}
+
+/// Mark already-satisfied `schedule_nodes` actions as executed before a recovery submission.
+///
+/// When recovery reuses an existing scheduler and submits a user-chosen number of allocations
+/// directly via `torc slurm schedule-nodes`, any action re-armed by `reinitialize_workflow` that
+/// is already satisfied (see [`schedule_action_already_satisfied`]) would otherwise fire again on
+/// the first compute node that starts and submit the action's own `num_allocations`, ignoring the
+/// user's entry. The originally reported case was the `on_workflow_start` action, but the same
+/// re-arm re-fires job-gated actions (e.g. `on_jobs_complete`) whose gating jobs already completed
+/// in a prior run. Claiming those actions here marks them executed and prevents the duplicate,
+/// action-defined submission. The `regenerate` path performs the equivalent step inside
 /// `handle_regenerate`. Recovery actions (`is_recovery`) are left untouched.
-pub fn mark_on_workflow_start_schedule_actions_executed(
+pub fn mark_satisfied_schedule_actions_executed(
     config: &Configuration,
     workflow_id: i64,
 ) -> Result<(), String> {
@@ -2481,10 +2513,7 @@ pub fn mark_on_workflow_start_schedule_actions_executed(
         .map_err(|e| format!("Failed to list workflow actions: {}", e))?;
 
     for action in actions {
-        if action.trigger_type == "on_workflow_start"
-            && action.action_type == "schedule_nodes"
-            && !action.is_recovery
-            && !action.executed
+        if schedule_action_already_satisfied(&action)
             && let Some(action_id) = action.id
         {
             // Delegate to the shared helper, which treats a 409 Conflict (already claimed by
@@ -2501,8 +2530,8 @@ pub fn mark_on_workflow_start_schedule_actions_executed(
             ) {
                 Ok(true) => {
                     info!(
-                        "Marked on_workflow_start schedule_nodes action {} as executed to avoid duplicate allocations",
-                        action_id
+                        "Marked already-satisfied {} schedule_nodes action {} as executed to avoid duplicate allocations",
+                        action.trigger_type, action_id
                     );
                 }
                 Ok(false) => {
@@ -2510,8 +2539,8 @@ pub fn mark_on_workflow_start_schedule_actions_executed(
                 }
                 Err(e) => {
                     return Err(format!(
-                        "Failed to mark on_workflow_start schedule_nodes action {} as executed: {}",
-                        action_id, e
+                        "Failed to mark {} schedule_nodes action {} as executed: {}",
+                        action.trigger_type, action_id, e
                     ));
                 }
             }

--- a/tests/test_workflow_actions.rs
+++ b/tests/test_workflow_actions.rs
@@ -861,6 +861,22 @@ fn test_mark_satisfied_schedule_actions_executed(start_server: &ServerProcess) {
             .expect("Failed to create satisfied on_jobs_complete action");
     let satisfied_id = satisfied.id.unwrap();
 
+    // Target 3: on_worker_start + schedule_nodes — fires immediately at worker startup, so it is
+    // always satisfied and must be marked executed.
+    let worker_start = apis::workflow_actions_api::create_workflow_action(
+        config,
+        workflow_id,
+        workflow_action(
+            workflow_id,
+            "on_worker_start",
+            "schedule_nodes",
+            schedule_config.clone(),
+            None,
+        ),
+    )
+    .expect("Failed to create on_worker_start action");
+    let worker_start_id = worker_start.id.unwrap();
+
     // Decoy 1: on_workflow_start + run_commands — wrong action_type, must be left alone.
     let run_cmd = apis::workflow_actions_api::create_workflow_action(
         config,
@@ -897,7 +913,7 @@ fn test_mark_satisfied_schedule_actions_executed(start_server: &ServerProcess) {
         workflow_id,
         "on_workflow_start",
         "schedule_nodes",
-        schedule_config,
+        schedule_config.clone(),
         None,
     );
     recovery_body.is_recovery = true;
@@ -905,6 +921,22 @@ fn test_mark_satisfied_schedule_actions_executed(start_server: &ServerProcess) {
         apis::workflow_actions_api::create_workflow_action(config, workflow_id, recovery_body)
             .expect("Failed to create recovery action");
     let recovery_id = recovery.id.unwrap();
+
+    // Decoy 4: persistent on_workflow_start + schedule_nodes — satisfied, but claiming a persistent
+    // action does not clear its armed state (the server keeps executed=0 for persistent actions),
+    // so the helper must leave it untouched (and warn) rather than falsely mark it executed.
+    let mut persistent_body = workflow_action(
+        workflow_id,
+        "on_workflow_start",
+        "schedule_nodes",
+        schedule_config,
+        None,
+    );
+    persistent_body.persistent = true;
+    let persistent =
+        apis::workflow_actions_api::create_workflow_action(config, workflow_id, persistent_body)
+            .expect("Failed to create persistent action");
+    let persistent_id = persistent.id.unwrap();
 
     // Run the fix under test.
     torc::client::commands::recover::mark_satisfied_schedule_actions_executed(config, workflow_id)
@@ -921,6 +953,14 @@ fn test_mark_satisfied_schedule_actions_executed(start_server: &ServerProcess) {
     assert!(
         find(satisfied_id).executed,
         "satisfied on_jobs_complete schedule_nodes action should be marked executed"
+    );
+    assert!(
+        find(worker_start_id).executed,
+        "on_worker_start schedule_nodes action should be marked executed"
+    );
+    assert!(
+        !find(persistent_id).executed,
+        "persistent schedule_nodes action should be left untouched (claim cannot suppress it)"
     );
     assert!(
         !find(run_cmd_id).executed,

--- a/tests/test_workflow_actions.rs
+++ b/tests/test_workflow_actions.rs
@@ -811,16 +811,18 @@ fn test_action_executed_flag_reset_on_reinitialize(start_server: &ServerProcess)
 
 /// Regression test for the recover wizard re-submitting the action-defined allocation count.
 ///
-/// After reinitialization re-arms the workflow's `on_workflow_start` `schedule_nodes` action, the
-/// recover wizard's "reuse existing scheduler" path calls
-/// `mark_on_workflow_start_schedule_actions_executed` before submitting the user's chosen number of
-/// allocations. This prevents the re-armed action from firing again on the first compute node and
-/// submitting its own (original) `num_allocations`. The helper must mark exactly the matching
-/// actions executed and leave everything else untouched.
+/// After reinitialization re-arms the workflow's `schedule_nodes` actions, the recover wizard's
+/// "reuse existing scheduler" path calls `mark_satisfied_schedule_actions_executed` before
+/// submitting the user's chosen number of allocations. This prevents any *already-satisfied*
+/// re-armed action — the `on_workflow_start` action, plus job-gated actions (e.g.
+/// `on_jobs_complete`) whose gating jobs already completed in a prior run — from firing again on
+/// the first compute node and submitting its own (original) `num_allocations`. The helper must mark
+/// exactly the satisfied `schedule_nodes` actions executed and leave everything else (including
+/// job-gated actions still waiting on their jobs) untouched.
 #[rstest]
-fn test_mark_on_workflow_start_schedule_actions_executed(start_server: &ServerProcess) {
+fn test_mark_satisfied_schedule_actions_executed(start_server: &ServerProcess) {
     let config = &start_server.config;
-    let workflow = create_test_workflow(config, "mark_on_start_schedule_workflow");
+    let workflow = create_test_workflow(config, "mark_satisfied_schedule_workflow");
     let workflow_id = workflow.id.unwrap();
 
     let schedule_config = json!({
@@ -829,7 +831,7 @@ fn test_mark_on_workflow_start_schedule_actions_executed(start_server: &ServerPr
         "num_allocations": 5,
     });
 
-    // Target: on_workflow_start + schedule_nodes (non-recovery) — should be marked executed.
+    // Target 1: on_workflow_start + schedule_nodes (non-recovery) — always satisfied, marked.
     let target = apis::workflow_actions_api::create_workflow_action(
         config,
         workflow_id,
@@ -843,6 +845,21 @@ fn test_mark_on_workflow_start_schedule_actions_executed(start_server: &ServerPr
     )
     .expect("Failed to create target action");
     let target_id = target.id.unwrap();
+
+    // Target 2: on_jobs_complete + schedule_nodes whose gating jobs already completed
+    // (trigger_count >= required_triggers) — this is the reported bug; must be marked executed.
+    let mut satisfied_body = workflow_action(
+        workflow_id,
+        "on_jobs_complete",
+        "schedule_nodes",
+        schedule_config.clone(),
+        Some(vec![1]), // required_triggers becomes 1 (one gating job)
+    );
+    satisfied_body.trigger_count = 1; // already satisfied: trigger_count >= required_triggers
+    let satisfied =
+        apis::workflow_actions_api::create_workflow_action(config, workflow_id, satisfied_body)
+            .expect("Failed to create satisfied on_jobs_complete action");
+    let satisfied_id = satisfied.id.unwrap();
 
     // Decoy 1: on_workflow_start + run_commands — wrong action_type, must be left alone.
     let run_cmd = apis::workflow_actions_api::create_workflow_action(
@@ -859,20 +876,21 @@ fn test_mark_on_workflow_start_schedule_actions_executed(start_server: &ServerPr
     .expect("Failed to create run_commands action");
     let run_cmd_id = run_cmd.id.unwrap();
 
-    // Decoy 2: on_jobs_ready + schedule_nodes — wrong trigger_type, must be left alone.
-    let other_trigger = apis::workflow_actions_api::create_workflow_action(
+    // Decoy 2: on_jobs_complete + schedule_nodes still waiting on its job
+    // (trigger_count < required_triggers) — left armed so it can fire legitimately in recovery.
+    let unsatisfied = apis::workflow_actions_api::create_workflow_action(
         config,
         workflow_id,
         workflow_action(
             workflow_id,
-            "on_jobs_ready",
+            "on_jobs_complete",
             "schedule_nodes",
             schedule_config.clone(),
-            None,
+            Some(vec![2]), // required_triggers=1, trigger_count defaults to 0 → unsatisfied
         ),
     )
-    .expect("Failed to create on_jobs_ready action");
-    let other_trigger_id = other_trigger.id.unwrap();
+    .expect("Failed to create unsatisfied on_jobs_complete action");
+    let unsatisfied_id = unsatisfied.id.unwrap();
 
     // Decoy 3: on_workflow_start + schedule_nodes but is_recovery=true — must be left alone.
     let mut recovery_body = workflow_action(
@@ -889,11 +907,8 @@ fn test_mark_on_workflow_start_schedule_actions_executed(start_server: &ServerPr
     let recovery_id = recovery.id.unwrap();
 
     // Run the fix under test.
-    torc::client::commands::recover::mark_on_workflow_start_schedule_actions_executed(
-        config,
-        workflow_id,
-    )
-    .expect("mark_on_workflow_start_schedule_actions_executed failed");
+    torc::client::commands::recover::mark_satisfied_schedule_actions_executed(config, workflow_id)
+        .expect("mark_satisfied_schedule_actions_executed failed");
 
     let actions = apis::workflow_actions_api::get_workflow_actions(config, workflow_id)
         .expect("Failed to get workflow actions");
@@ -904,12 +919,16 @@ fn test_mark_on_workflow_start_schedule_actions_executed(start_server: &ServerPr
         "on_workflow_start schedule_nodes action should be marked executed"
     );
     assert!(
+        find(satisfied_id).executed,
+        "satisfied on_jobs_complete schedule_nodes action should be marked executed"
+    );
+    assert!(
         !find(run_cmd_id).executed,
         "run_commands action should be left untouched"
     );
     assert!(
-        !find(other_trigger_id).executed,
-        "on_jobs_ready schedule_nodes action should be left untouched"
+        !find(unsatisfied_id).executed,
+        "unsatisfied on_jobs_complete schedule_nodes action should be left untouched"
     );
     assert!(
         !find(recovery_id).executed,


### PR DESCRIPTION
## Problem

`torc recover` was re-arming a workflow's `on_jobs_complete` `schedule_nodes` action, causing it to re-submit its own `num_allocations` after recovery — node allocations the user didn't ask for.

### Root cause

`recover` calls `reinitialize_workflow`, which re-arms **every** `schedule_nodes` action: it clears `executed` and recomputes `trigger_count` from the current job state. If the action's gating jobs already completed in a prior run (e.g. an `on_jobs_complete` action targeting a job that passed and isn't being retried), the recomputed `trigger_count` immediately meets `required_triggers`. The action is now armed **and** already satisfied, so it re-fires on the first compute node and re-submits its allocations.

The existing-scheduler recovery path already guarded against this — but only for `on_workflow_start` actions (`mark_on_workflow_start_schedule_actions_executed`), so job-gated actions slipped through. (The `regenerate` path didn't have the bug because it blanket-marks all `schedule_nodes` actions executed.)

## Fix

`src/client/commands/recover.rs`:
- Added `schedule_action_already_satisfied()` — a non-recovery, unexecuted `schedule_nodes` action counts as already-satisfied when it would fire immediately: `on_workflow_start` always, and `on_jobs_ready`/`on_jobs_complete` only when `trigger_count >= required_triggers`.
- Renamed `mark_on_workflow_start_schedule_actions_executed` → `mark_satisfied_schedule_actions_executed`, broadened to claim any already-satisfied action.

This is **precise, not blanket**: a job-gated action still waiting on jobs that *will* run during recovery (`trigger_count < required_triggers`) is left armed, so legitimate next-phase scheduling still works.

## Tests

`tests/test_workflow_actions.rs`: renamed the regression test and added two cases — a satisfied `on_jobs_complete` action that must be marked executed (the reported bug), and an unsatisfied one that must be left armed.

Verified: `cargo build`, `cargo clippy --all --all-targets --all-features -- -D warnings`, `cargo fmt --check`, and the workflow-actions + recover test suites all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)