### PR TITLE
Add audit events for archive/process_changed_job_inputs; filter events by category

### DIFF
--- a/src/server/api/events.rs
+++ b/src/server/api/events.rs
@@ -209,8 +209,10 @@ where
             where_conditions.push("timestamp > ?".to_string());
         }
 
-        // Note: Category filtering is not implemented in current schema
-        let _category = category; // Acknowledge the parameter to avoid unused warnings
+        // Category is stored inside the JSON `data` column, so filter on the extracted value.
+        if category.is_some() {
+            where_conditions.push("json_extract(data, '$.category') = ?".to_string());
+        }
 
         let where_clause = where_conditions.join(" AND ");
         let sort_by = if let Some(ref col) = sort_by {
@@ -241,6 +243,11 @@ where
         // Bind timestamp if provided (direct integer comparison)
         if let Some(ts) = after_timestamp {
             sqlx_query = sqlx_query.bind(ts);
+        }
+
+        // Bind category if provided (must follow the WHERE condition order)
+        if let Some(ref cat) = category {
+            sqlx_query = sqlx_query.bind(cat.clone());
         }
 
         let records = match sqlx_query.fetch_all(self.context.pool.as_ref()).await {
@@ -279,6 +286,11 @@ where
         // Bind timestamp for count query if provided
         if let Some(ts) = after_timestamp {
             count_sqlx_query = count_sqlx_query.bind(ts);
+        }
+
+        // Bind category for count query if provided (must follow the WHERE condition order)
+        if let Some(ref cat) = category {
+            count_sqlx_query = count_sqlx_query.bind(cat.clone());
         }
 
         let total_count = match count_sqlx_query.fetch_one(self.context.pool.as_ref()).await {

--- a/src/server/api/events.rs
+++ b/src/server/api/events.rs
@@ -247,7 +247,7 @@ where
 
         // Bind category if provided (must follow the WHERE condition order)
         if let Some(ref cat) = category {
-            sqlx_query = sqlx_query.bind(cat.clone());
+            sqlx_query = sqlx_query.bind(cat.as_str());
         }
 
         let records = match sqlx_query.fetch_all(self.context.pool.as_ref()).await {
@@ -290,7 +290,7 @@ where
 
         // Bind category for count query if provided (must follow the WHERE condition order)
         if let Some(ref cat) = category {
-            count_sqlx_query = count_sqlx_query.bind(cat.clone());
+            count_sqlx_query = count_sqlx_query.bind(cat.as_str());
         }
 
         let total_count = match count_sqlx_query.fetch_one(self.context.pool.as_ref()).await {

--- a/src/server/http_server/jobs_transport.rs
+++ b/src/server/http_server/jobs_transport.rs
@@ -1152,9 +1152,28 @@ where
     ) -> Result<ProcessChangedJobInputsResponse, ApiError> {
         authorize_workflow!(self, id, context, ProcessChangedJobInputsResponse);
         let dry_run_value = dry_run.unwrap_or(false);
-        self.jobs_api
+        let result = self
+            .jobs_api
             .process_changed_job_inputs(id, dry_run_value, context)
-            .await
+            .await?;
+        // Record only real (non-dry-run) runs; the event captures the aggregate set of
+        // reinitialized jobs for the workflow, not one event per job.
+        if !dry_run_value
+            && let ProcessChangedJobInputsResponse::SuccessfulResponse(ref response) = result
+        {
+            self.record_user_action_event(
+                id,
+                "process_changed_job_inputs",
+                serde_json::json!({
+                    "workflow_id": id,
+                    "reinitialized_count": response.reinitialized_jobs.len(),
+                    "reinitialized_jobs": response.reinitialized_jobs,
+                }),
+                context,
+            )
+            .await;
+        }
+        Ok(result)
     }
 
     pub(super) async fn transport_retry_job(

--- a/src/server/http_server/workflows_transport.rs
+++ b/src/server/http_server/workflows_transport.rs
@@ -243,6 +243,8 @@ where
     ) -> Result<CancelWorkflowResponse, ApiError> {
         log_call!(info, context, "cancel_workflow(workflow_id={})", id);
         authorize_workflow!(self, id, context, CancelWorkflowResponse);
+        // Note: cancel_workflow already records a persistent "workflow_canceled" event inside
+        // its transaction (see workflows_api::cancel_workflow), so no event is recorded here.
         let response = self.workflows_api.cancel_workflow(id, context).await?;
         Ok(response)
     }
@@ -268,7 +270,24 @@ where
         {
             set.remove(&id);
         }
-        self.workflows_api.archive_workflow(id, body, context).await
+        let is_archived = body.is_archived;
+        let result = self
+            .workflows_api
+            .archive_workflow(id, body, context)
+            .await?;
+        if let ArchiveWorkflowResponse::SuccessfulResponse(_) = result {
+            self.record_user_action_event(
+                id,
+                "archive_workflow",
+                serde_json::json!({
+                    "workflow_id": id,
+                    "is_archived": is_archived,
+                }),
+                context,
+            )
+            .await;
+        }
+        Ok(result)
     }
 
     pub(super) async fn transport_delete_events(

--- a/tests/test_events.rs
+++ b/tests/test_events.rs
@@ -736,8 +736,6 @@ fn test_events_list_with_category_filter(start_server: &ServerProcess) {
         "system",
     ];
 
-    // This test mainly verifies that the CLI accepts the new parameter without errors
-    // The actual filtering behavior depends on the backend implementation
     let json_output = run_cli_with_json(&args, start_server, None)
         .expect("Failed to run events list command with category filter");
 
@@ -746,11 +744,36 @@ fn test_events_list_with_category_filter(start_server: &ServerProcess) {
         json_output.is_object(),
         "Events list should return an object"
     );
+    let items = json_output
+        .get("items")
+        .and_then(|i| i.as_array())
+        .expect("Response should have an 'items' array");
+
+    // The category filter is applied server-side: only the two "system" events match.
+    assert_eq!(items.len(), 2, "expected exactly two 'system' events");
     assert!(
-        json_output.get("items").is_some(),
-        "Response should have 'items' field"
+        items.iter().all(|e| e
+            .get("data")
+            .and_then(|d| d.get("category"))
+            .and_then(|c| c.as_str())
+            == Some("system")),
+        "every returned event should have category 'system': {:?}",
+        items
     );
 
-    // The command should execute without error
-    // The actual filtering depends on how the backend implements category matching
+    // Filtering by the other category returns just the single "user" event.
+    let user_args = [
+        "events",
+        "list",
+        &workflow_id.to_string(),
+        "--category",
+        "user",
+    ];
+    let user_output = run_cli_with_json(&user_args, start_server, None)
+        .expect("Failed to run events list command with category filter");
+    let user_items = user_output
+        .get("items")
+        .and_then(|i| i.as_array())
+        .expect("Response should have an 'items' array");
+    assert_eq!(user_items.len(), 1, "expected exactly one 'user' event");
 }

--- a/tests/test_workflows.rs
+++ b/tests/test_workflows.rs
@@ -1889,3 +1889,139 @@ fn test_get_running_jobs_not_found(start_server: &ServerProcess) {
     let result = apis::workflows_api::get_running_jobs(config, 999_999, None, None);
     assert!(result.is_err(), "expected error for nonexistent workflow");
 }
+
+/// List persistent events recorded for a workflow, optionally filtered server-side by category.
+fn list_events_in_category(
+    config: &Configuration,
+    workflow_id: i64,
+    category: Option<&str>,
+) -> models::ListEventsResponse {
+    apis::events_api::list_events(config, workflow_id, None, None, None, None, category, None)
+        .expect("Failed to list events")
+}
+
+/// Collect the `action` names from a set of events.
+fn action_names(events: &[models::EventModel]) -> Vec<String> {
+    events
+        .iter()
+        .filter_map(|e| {
+            e.data
+                .get("action")
+                .and_then(|a| a.as_str())
+                .map(String::from)
+        })
+        .collect()
+}
+
+/// Verifies that the `process_changed_job_inputs` and `archive_workflow` endpoints record
+/// persistent `user_action` audit events. A dry-run of `process_changed_job_inputs` must not
+/// record anything.
+#[rstest]
+fn test_lifecycle_actions_record_user_action_events(start_server: &ServerProcess) {
+    let config = &start_server.config;
+
+    let workflow = create_test_workflow(config, "lifecycle_events_test");
+    let workflow_id = workflow.id.unwrap();
+
+    // No user_action events yet (server-side category filter).
+    assert!(
+        list_events_in_category(config, workflow_id, Some("user_action"))
+            .items
+            .is_empty()
+    );
+
+    // A dry-run of process_changed_job_inputs must NOT record an event.
+    apis::workflows_api::process_changed_job_inputs(config, workflow_id, Some(true))
+        .expect("dry-run process_changed_job_inputs failed");
+    assert!(
+        list_events_in_category(config, workflow_id, Some("user_action"))
+            .items
+            .is_empty(),
+        "dry-run should not record an event"
+    );
+
+    // A real run records a single aggregated event (not one per job).
+    apis::workflows_api::process_changed_job_inputs(config, workflow_id, Some(false))
+        .expect("process_changed_job_inputs failed");
+
+    // Archiving records an event carrying the is_archived flag.
+    apis::workflows_api::archive_workflow(
+        config,
+        workflow_id,
+        torc::models::ArchiveWorkflowRequest { is_archived: true },
+    )
+    .expect("Failed to archive workflow");
+
+    // Fetch only the user_action events via the server-side category filter.
+    let response = list_events_in_category(config, workflow_id, Some("user_action"));
+    let events = response.items;
+    let actions = action_names(&events);
+    assert!(actions.contains(&"process_changed_job_inputs".to_string()));
+    assert!(actions.contains(&"archive_workflow".to_string()));
+    // Exactly the two real actions -- the dry-run is excluded. The server-side filter and the
+    // reported total_count must agree.
+    assert_eq!(
+        actions.len(),
+        2,
+        "expected exactly two user_action events, got {:?}",
+        actions
+    );
+    assert_eq!(response.total_count, 2, "filtered total_count should be 2");
+
+    // The category filter must actually constrain results: a category with no events is empty,
+    // and an unfiltered list returns at least the two user_action events.
+    assert!(
+        list_events_in_category(config, workflow_id, Some("no_such_category"))
+            .items
+            .is_empty(),
+        "unknown category should match no events"
+    );
+    assert!(
+        list_events_in_category(config, workflow_id, None)
+            .items
+            .len()
+            >= 2,
+        "unfiltered list should include all events"
+    );
+
+    // Every returned event carries the standard category/user fields.
+    for event in &events {
+        assert_eq!(
+            event.data.get("category").and_then(|c| c.as_str()),
+            Some("user_action")
+        );
+        assert!(
+            event.data.get("user").and_then(|u| u.as_str()).is_some(),
+            "event should carry a user field: {:?}",
+            event.data
+        );
+    }
+
+    // The process_changed_job_inputs event records the aggregate reinitialized count.
+    let pcji_event = events
+        .iter()
+        .find(|e| {
+            e.data.get("action").and_then(|a| a.as_str()) == Some("process_changed_job_inputs")
+        })
+        .expect("process_changed_job_inputs event not found");
+    assert_eq!(
+        pcji_event
+            .data
+            .get("reinitialized_count")
+            .and_then(|c| c.as_i64()),
+        Some(0)
+    );
+
+    // The archive event records the is_archived flag.
+    let archive_event = events
+        .iter()
+        .find(|e| e.data.get("action").and_then(|a| a.as_str()) == Some("archive_workflow"))
+        .expect("archive_workflow event not found");
+    assert_eq!(
+        archive_event
+            .data
+            .get("is_archived")
+            .and_then(|v| v.as_bool()),
+        Some(true)
+    );
+}


### PR DESCRIPTION
## Summary

Adds persistent `user_action` audit events for two workflow lifecycle endpoints that previously left no debugging trail, and makes the `list_events` `category` filter work server-side (it was silently ignored).

Persistent events are primarily a debugging aid, so this deliberately targets infrequent, workflow-level user actions and avoids anything already stored elsewhere (job completions, status changes) or already eventized.

### Changes

- **`archive_workflow`** — records an `archive_workflow` event with `is_archived`.
- **`process_changed_job_inputs`** — records a `process_changed_job_inputs` event with the aggregate `reinitialized_count` + list. This is a single workflow-level call, so the event is **aggregated, not per-job**. Dry-runs record nothing.
- **`cancel_workflow`** — intentionally left unchanged: it *already* records a `workflow_canceled` event (with `run_id` and a message) inside its own transaction, so a second event would be redundant.
- **`list_events` category filter** — previously a no-op (`let _category = category;`). Now filters server-side via `json_extract(data, '$.category') = ?`, bound in both the list and count queries so `total_count` stays consistent.

Both new events go through the existing `record_user_action_event` helper, so they carry the standard `category: "user_action"`, `action`, and `user` fields, matching the three pre-existing emitters (`reset_job_status`, `reset_workflow_status`, `update_resource_requirements`).

### Tests (API-only)

- `test_lifecycle_actions_record_user_action_events` — verifies the new events fire (dry-run excluded) and exercises the server-side category filter, asserting `total_count`, that an unknown category returns empty, and the recorded payload fields.
- `test_events_list_with_category_filter` — strengthened from "CLI accepts the param" to asserting real filtering counts (2 `system` / 1 `user`).

### Verification

- `cargo clippy --all --all-targets --all-features -- -D warnings` — clean
- `cargo fmt -- --check` / `dprint check` — clean
- Event/workflow-event tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)