### PR TITLE
Cancel queued Slurm allocations when no jobs remain (#257)

### DIFF
--- a/docs/src/specialized/fault-tolerance/automatic-recovery.md
+++ b/docs/src/specialized/fault-tolerance/automatic-recovery.md
@@ -323,6 +323,31 @@ With default settings:
 - After scheduling, the system waits 30 minutes before considering another auto-schedule
 - If fewer than 5 retry jobs are waiting for 2 hours, they're scheduled anyway (stranded timeout)
 
+## Canceling Unneeded Queued Allocations
+
+The inverse of auto-scheduling: when a workflow opens several Slurm allocations but finishes all of
+its work inside the first few, the remaining allocations can sit in the Slurm queue with nothing
+left to run. Standard orphan cleanup never touches them because Slurm still reports them as `Queued`
+(i.e. still valid).
+
+This cleanup runs automatically inside the **Slurm job runner**, so it happens for every workflow —
+no `torc watch` required. When a job runner stops (the workflow completed, or it has no more work),
+the head node of that allocation checks whether the workflow has any **runnable** jobs left — jobs
+in `Ready`, `Pending`, or `Running` status. If none remain, any still-`Queued` sibling Slurm
+allocation is unnecessary, so the runner:
+
+1. confirms the allocation is still queued in Slurm,
+2. issues `scancel` to release the queue slot,
+3. marks the corresponding scheduled compute node `canceled`, and
+4. deactivates any associated compute nodes.
+
+Allocations that have already started (`Running`) are left alone — their own job runner detects
+there is no work and exits gracefully. The check is safe to run from every finishing allocation: it
+no-ops while runnable jobs remain, `scancel` is idempotent, and the first runner to act flips the
+queued nodes to `canceled` so the rest find nothing left to cancel. This is especially helpful for
+"many small allocations" workflows, where some allocations may still be queued after the workflow's
+useful work is exhausted.
+
 ## Choosing the Right Command
 
 | Use Case                           | Command                     |

--- a/src/bin/torc-slurm-job-runner.rs
+++ b/src/bin/torc-slurm-job-runner.rs
@@ -20,6 +20,7 @@ mod unix_main {
     use std::thread;
     use torc::client::apis;
     use torc::client::apis::configuration::{Configuration, TlsConfig};
+    use torc::client::commands::orphan_detection;
     use torc::client::commands::slurm::{create_compute_node, create_node_resources};
     use torc::client::config::TorcConfig;
     use torc::client::hpc::hpc_interface::HpcInterface;
@@ -555,10 +556,33 @@ mod unix_main {
             }
         }
 
-        if slurm_interface.is_head_node()
-            && let Some(ref node) = scheduled_compute_node
-        {
-            set_scheduled_compute_node_status(&config, node, "complete");
+        if slurm_interface.is_head_node() {
+            if let Some(ref node) = scheduled_compute_node {
+                set_scheduled_compute_node_status(&config, node, "complete");
+            }
+
+            // Issue #257: once this runner stops, any sibling Slurm allocation
+            // still sitting in the queue is unnecessary if the workflow has no
+            // runnable jobs left (all work finished inside earlier allocations).
+            // Cancel those queued allocations so the workflow finishes without
+            // waiting on unneeded queue slots. Safe to run from every finishing
+            // allocation's head node: the call no-ops while runnable jobs remain,
+            // `scancel` is idempotent, and the first runner to win flips the nodes
+            // to "canceled" so the others find nothing left to cancel.
+            match orphan_detection::cancel_unneeded_pending_allocations(
+                &config,
+                args.workflow_id,
+                false,
+            ) {
+                Ok(count) if count > 0 => {
+                    info!(
+                        "Canceled {} unneeded queued Slurm allocation(s) workflow_id={}",
+                        count, args.workflow_id
+                    );
+                }
+                Ok(_) => {}
+                Err(e) => warn!("Error canceling unneeded queued allocations: {}", e),
+            }
         }
     }
 

--- a/src/bin/torc-slurm-job-runner.rs
+++ b/src/bin/torc-slurm-job-runner.rs
@@ -561,7 +561,7 @@ mod unix_main {
                 set_scheduled_compute_node_status(&config, node, "complete");
             }
 
-            // Issue #257: once this runner stops, any sibling Slurm allocation
+            // Once this runner stops, any sibling Slurm allocation
             // still sitting in the queue is unnecessary if the workflow has no
             // runnable jobs left (all work finished inside earlier allocations).
             // Cancel those queued allocations so the workflow finishes without

--- a/src/bin/torc-slurm-job-runner.rs
+++ b/src/bin/torc-slurm-job-runner.rs
@@ -568,20 +568,15 @@ mod unix_main {
             // waiting on unneeded queue slots. Safe to run from every finishing
             // allocation's head node: the call no-ops while runnable jobs remain,
             // `scancel` is idempotent, and the first runner to win flips the nodes
-            // to "canceled" so the others find nothing left to cancel.
-            match orphan_detection::cancel_unneeded_pending_allocations(
+            // to "canceled" so the others find nothing left to cancel. The call
+            // logs each cancellation and a summary itself, so only surface errors
+            // here.
+            if let Err(e) = orphan_detection::cancel_unneeded_pending_allocations(
                 &config,
                 args.workflow_id,
                 false,
             ) {
-                Ok(count) if count > 0 => {
-                    info!(
-                        "Canceled {} unneeded queued Slurm allocation(s) workflow_id={}",
-                        count, args.workflow_id
-                    );
-                }
-                Ok(_) => {}
-                Err(e) => warn!("Error canceling unneeded queued allocations: {}", e),
+                warn!("Error canceling unneeded queued allocations: {}", e);
             }
         }
     }

--- a/src/client/commands/orphan_detection.rs
+++ b/src/client/commands/orphan_detection.rs
@@ -835,9 +835,227 @@ pub fn deactivate_compute_nodes_for_scheduled_node(
     Ok(count)
 }
 
+/// Returns true if the workflow still has work that an allocation could run.
+///
+/// "Runnable" means jobs in Ready, Pending, or Running status. Blocked jobs are
+/// not runnable on their own: with no Ready/Pending/Running job left to complete
+/// and unblock them, a queued allocation would have nothing to do.
+fn has_runnable_jobs(counts: &models::JobStatusCounts) -> bool {
+    counts.ready > 0 || counts.pending > 0 || counts.running > 0
+}
+
+/// Cancel queued Slurm allocations that the workflow no longer needs.
+///
+/// Addresses the "many small allocations" case (issue #257): a workflow opens
+/// several Slurm allocations but finishes all of its work inside the first few,
+/// leaving the rest sitting in the Slurm queue with nothing left to run. The
+/// standard orphan cleanup never touches them because Slurm still reports them
+/// as `Queued` (i.e. valid), so they wait until they start or are canceled by
+/// hand.
+///
+/// This cancels pending allocations only when the workflow has no runnable jobs
+/// left (no Ready/Pending/Running jobs). For each pending Slurm scheduled
+/// compute node still `Queued` in Slurm it issues `scancel`, marks the scheduled
+/// compute node `canceled`, and deactivates any associated compute nodes (the
+/// same bookkeeping `torc cancel` performs). Allocations that have already
+/// started (`Running`) are left alone -- their job runner detects there is no
+/// work and exits gracefully on its own; allocations already gone from Slurm are
+/// handled by [`cleanup_dead_pending_slurm_jobs`].
+///
+/// If `dry_run` is true, reports what would be done without making changes.
+/// Returns the number of allocations canceled.
+pub fn cancel_unneeded_pending_allocations(
+    config: &Configuration,
+    workflow_id: i64,
+    dry_run: bool,
+) -> Result<usize, String> {
+    // Cheap guard: if any runnable jobs remain, queued allocations may still be
+    // needed, so bail before doing any per-allocation squeue work.
+    let status = apis::workflows_api::get_workflow_status(config, workflow_id)
+        .map_err(|e| format!("Failed to get workflow status: {}", e))?;
+    if has_runnable_jobs(&status.jobs_by_status) {
+        return Ok(0);
+    }
+
+    // Enumerate pending Slurm allocations.
+    let scheduled_nodes = paginate_scheduled_compute_nodes(
+        config,
+        workflow_id,
+        ScheduledComputeNodeListParams::new().with_status("pending".to_string()),
+    )
+    .map_err(|e| format!("Failed to list pending scheduled compute nodes: {}", e))?;
+
+    let slurm_nodes: Vec<_> = scheduled_nodes
+        .iter()
+        .filter(|node| node.scheduler_type.to_lowercase() == "slurm")
+        .collect();
+
+    if slurm_nodes.is_empty() {
+        return Ok(0);
+    }
+
+    // Slurm is the source of truth. If we can't talk to it, do nothing.
+    let slurm = match SlurmInterface::new() {
+        Ok(s) => s,
+        Err(e) => {
+            debug!(
+                "Could not create SlurmInterface to cancel unneeded allocations: {}",
+                e
+            );
+            return Ok(0);
+        }
+    };
+
+    let mut total_canceled = 0;
+
+    for scheduled_node in slurm_nodes {
+        let slurm_job_id = scheduled_node.scheduler_id.to_string();
+        let scheduled_compute_node_id = match scheduled_node.id {
+            Some(id) => id,
+            None => continue,
+        };
+
+        // Only cancel allocations still waiting in the queue. A Running
+        // allocation already has a job runner attached that exits cleanly once
+        // it sees there is no work; a job gone from Slurm is handled elsewhere.
+        match slurm.get_status(&slurm_job_id) {
+            Ok(info) if info.status == HpcJobStatus::Queued => {}
+            Ok(_) => continue,
+            Err(e) => {
+                debug!(
+                    "Error checking Slurm status for pending job {}: {}; leaving it untouched",
+                    slurm_job_id, e
+                );
+                continue;
+            }
+        }
+
+        if dry_run {
+            info!(
+                "[DRY RUN] Would cancel unneeded queued Slurm allocation {} (no runnable jobs remain) workflow_id={}",
+                slurm_job_id, workflow_id
+            );
+            total_canceled += 1;
+            continue;
+        }
+
+        // Cancel the queued allocation in Slurm.
+        match slurm.cancel_job(&slurm_job_id) {
+            Ok(0) => {
+                info!(
+                    "Canceled unneeded queued Slurm allocation {} (no runnable jobs remain) workflow_id={}",
+                    slurm_job_id, workflow_id
+                );
+            }
+            Ok(code) => {
+                warn!(
+                    "scancel for Slurm job {} returned non-zero code {}; skipping status update",
+                    slurm_job_id, code
+                );
+                continue;
+            }
+            Err(e) => {
+                warn!("Failed to cancel Slurm job {}: {}", slurm_job_id, e);
+                continue;
+            }
+        }
+
+        // Mark the scheduled compute node canceled so the watch loop stops
+        // treating it as a live allocation.
+        if let Err(e) = apis::scheduled_compute_nodes_api::update_scheduled_compute_node(
+            config,
+            scheduled_compute_node_id,
+            models::ScheduledComputeNodesModel::new(
+                workflow_id,
+                scheduled_node.scheduler_id,
+                scheduled_node.scheduler_config_id,
+                scheduled_node.scheduler_type.clone(),
+                "canceled".to_string(),
+            ),
+        ) {
+            warn!(
+                "Failed to update scheduled compute node {} status to canceled: {}",
+                scheduled_compute_node_id, e
+            );
+        }
+
+        // `scancel` kills any job runner ungracefully, so deactivate associated
+        // compute nodes to avoid stranding is_active=true rows (mirrors `torc
+        // cancel`). A still-queued allocation usually has none, but this keeps
+        // the bookkeeping consistent.
+        if let Err(e) = deactivate_compute_nodes_for_scheduled_node(
+            config,
+            workflow_id,
+            scheduled_compute_node_id,
+            &slurm_job_id,
+            false,
+        ) {
+            warn!(
+                "Failed to deactivate compute nodes for scheduled compute node {}: {}",
+                scheduled_compute_node_id, e
+            );
+        }
+
+        total_canceled += 1;
+    }
+
+    if total_canceled > 0 {
+        let action = if dry_run { "Would cancel" } else { "Canceled" };
+        info!(
+            "{} {} unneeded queued Slurm allocation(s) workflow_id={}",
+            action, total_canceled, workflow_id
+        );
+    }
+
+    Ok(total_canceled)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn empty_counts() -> models::JobStatusCounts {
+        models::JobStatusCounts {
+            uninitialized: 0,
+            blocked: 0,
+            ready: 0,
+            pending: 0,
+            running: 0,
+            completed: 0,
+            failed: 0,
+            canceled: 0,
+            terminated: 0,
+            disabled: 0,
+            pending_failed: 0,
+        }
+    }
+
+    #[test]
+    fn test_has_runnable_jobs() {
+        // No jobs of any status -> nothing runnable.
+        assert!(!has_runnable_jobs(&empty_counts()));
+
+        // Blocked/completed/failed jobs are not runnable on their own.
+        let mut counts = empty_counts();
+        counts.blocked = 5;
+        counts.completed = 10;
+        counts.failed = 2;
+        counts.canceled = 1;
+        assert!(!has_runnable_jobs(&counts));
+
+        // Any of Ready / Pending / Running counts as runnable.
+        let mut counts = empty_counts();
+        counts.ready = 1;
+        assert!(has_runnable_jobs(&counts));
+
+        let mut counts = empty_counts();
+        counts.pending = 1;
+        assert!(has_runnable_jobs(&counts));
+
+        let mut counts = empty_counts();
+        counts.running = 1;
+        assert!(has_runnable_jobs(&counts));
+    }
 
     #[test]
     fn test_orphan_cleanup_result_any_cleaned() {

--- a/src/client/commands/orphan_detection.rs
+++ b/src/client/commands/orphan_detection.rs
@@ -988,7 +988,7 @@ pub fn cancel_unneeded_pending_allocations(
             workflow_id,
             scheduled_compute_node_id,
             &slurm_job_id,
-            false,
+            dry_run,
         ) {
             warn!(
                 "Failed to deactivate compute nodes for scheduled compute node {}: {}",

--- a/src/client/commands/orphan_detection.rs
+++ b/src/client/commands/orphan_detection.rs
@@ -846,7 +846,7 @@ fn has_runnable_jobs(counts: &models::JobStatusCounts) -> bool {
 
 /// Cancel queued Slurm allocations that the workflow no longer needs.
 ///
-/// Addresses the "many small allocations" case (issue #257): a workflow opens
+/// Addresses the "many small allocations" case: a workflow opens
 /// several Slurm allocations but finishes all of its work inside the first few,
 /// leaving the rest sitting in the Slurm queue with nothing left to run. The
 /// standard orphan cleanup never touches them because Slurm still reports them
@@ -907,6 +907,8 @@ pub fn cancel_unneeded_pending_allocations(
     };
 
     let mut total_canceled = 0;
+    // Slurm job IDs actually canceled, used to record a single aggregate event below.
+    let mut canceled_slurm_job_ids: Vec<String> = Vec::new();
 
     for scheduled_node in slurm_nodes {
         let slurm_job_id = scheduled_node.scheduler_id.to_string();
@@ -946,6 +948,7 @@ pub fn cancel_unneeded_pending_allocations(
                     "Canceled unneeded queued Slurm allocation {} (no runnable jobs remain) workflow_id={}",
                     slurm_job_id, workflow_id
                 );
+                canceled_slurm_job_ids.push(slurm_job_id.clone());
             }
             Ok(code) => {
                 warn!(
@@ -1005,6 +1008,30 @@ pub fn cancel_unneeded_pending_allocations(
             "{} {} unneeded queued Slurm allocation(s) workflow_id={}",
             action, total_canceled, workflow_id
         );
+    }
+
+    // Record a single aggregate event for the whole batch of cancellations (not one
+    // per allocation). This surfaces in `torc events` so users can notice they are
+    // scheduling more allocations than the workflow needs. Dry runs make no changes,
+    // so they record nothing.
+    if !canceled_slurm_job_ids.is_empty() {
+        let data = serde_json::json!({
+            "category": "scheduler",
+            "action": "cancel_unneeded_pending_allocations",
+            "message": format!(
+                "Canceled {} unneeded queued Slurm allocation(s) because no runnable jobs remained",
+                canceled_slurm_job_ids.len()
+            ),
+            "num_canceled": canceled_slurm_job_ids.len(),
+            "slurm_job_ids": canceled_slurm_job_ids,
+        });
+        let event = models::EventModel::new(workflow_id, data);
+        if let Err(e) = apis::events_api::create_event(config, event) {
+            warn!(
+                "Failed to record canceled-allocations event workflow_id={}: {}",
+                workflow_id, e
+            );
+        }
     }
 
     Ok(total_canceled)

--- a/src/client/hpc/slurm_interface.rs
+++ b/src/client/hpc/slurm_interface.rs
@@ -57,6 +57,11 @@ impl SlurmInterface {
         env::var("TORC_FAKE_SBATCH").unwrap_or_else(|_| "sbatch".to_string())
     }
 
+    /// Get the scancel executable path (allows for testing with fake binary)
+    fn get_scancel_exec() -> String {
+        env::var("TORC_FAKE_SCANCEL").unwrap_or_else(|_| "scancel".to_string())
+    }
+
     /// Run a command with retries for transient errors
     fn run_command_with_retries(
         &self,
@@ -100,7 +105,8 @@ impl SlurmInterface {
 
 impl HpcInterface for SlurmInterface {
     fn cancel_job(&self, job_id: &str) -> Result<i32> {
-        let output = Command::new("scancel").arg(job_id).output()?;
+        let scancel = Self::get_scancel_exec();
+        let output = Command::new(&scancel).arg(job_id).output()?;
 
         let return_code = output.status.code().unwrap_or(-1);
         if return_code != 0 {

--- a/tests/test_orphaned_jobs.rs
+++ b/tests/test_orphaned_jobs.rs
@@ -654,7 +654,7 @@ fn complete_single_job(config: &torc::client::Configuration, workflow_id: i64, n
         .expect("complete job");
 }
 
-/// Issue #257: when the workflow has no runnable jobs left, a still-queued Slurm
+/// When the workflow has no runnable jobs left, a still-queued Slurm
 /// allocation is unnecessary and must be canceled (scancel + node -> "canceled").
 #[rstest]
 #[serial(slurm)]
@@ -707,6 +707,46 @@ fn test_cancel_unneeded_queued_allocation(start_server: &ServerProcess) {
         jobs.contains("CANCELLED"),
         "expected scancel to flip the fake job to CANCELLED, got: {jobs}"
     );
+
+    // Exactly one aggregate event is recorded for the batch of cancellations
+    // (not one per allocation), so users can see they are over-scheduling.
+    let events = apis::events_api::list_events(
+        config,
+        workflow_id,
+        None,
+        None,
+        None,
+        None,
+        Some("scheduler"),
+        None,
+    )
+    .expect("list events");
+    let cancel_events: Vec<_> = events
+        .items
+        .iter()
+        .filter(|e| {
+            e.data.get("action").and_then(|a| a.as_str())
+                == Some("cancel_unneeded_pending_allocations")
+        })
+        .collect();
+    assert_eq!(
+        cancel_events.len(),
+        1,
+        "expected exactly one aggregate cancellation event, got: {:?}",
+        events.items
+    );
+    let event = cancel_events[0];
+    assert_eq!(
+        event.data.get("num_canceled").and_then(|n| n.as_i64()),
+        Some(1)
+    );
+    let ids = event
+        .data
+        .get("slurm_job_ids")
+        .and_then(|v| v.as_array())
+        .expect("slurm_job_ids array");
+    assert_eq!(ids.len(), 1);
+    assert_eq!(ids[0].as_str(), Some(slurm_job_id.to_string().as_str()));
 }
 
 /// The cancellation must NOT fire while the workflow still has runnable jobs: a

--- a/tests/test_orphaned_jobs.rs
+++ b/tests/test_orphaned_jobs.rs
@@ -564,6 +564,202 @@ fn test_cleanup_deactivates_active_node_after_cancel(start_server: &ServerProces
     );
 }
 
+/// Path to the shared fake squeue/scancel jobs file (matches the bash scripts,
+/// which read `${TMPDIR:-/tmp}/fake_slurm_jobs.txt`).
+fn fake_jobs_file() -> std::path::PathBuf {
+    let tmpdir = std::env::var("TMPDIR").unwrap_or_else(|_| "/tmp".to_string());
+    std::path::Path::new(&tmpdir).join("fake_slurm_jobs.txt")
+}
+
+/// Register a fake Slurm job so `fake_squeue.sh` reports it with `state` (e.g.
+/// "PENDING" -> Queued) and `fake_scancel.sh` can flip it to CANCELLED.
+fn write_fake_slurm_job(slurm_job_id: i64, name: &str, state: &str) {
+    use std::io::Write;
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(fake_jobs_file())
+        .expect("open fake jobs file");
+    // Fields: job_id|name|state|start|end|account|partition|qos (only the first
+    // three matter to get_status; the rest stay empty).
+    writeln!(f, "{}|{}|{}", slurm_job_id, name, state).expect("write fake job");
+}
+
+/// Point SlurmInterface at the fake squeue/scancel scripts and ensure USER is set.
+/// Returns guards that restore the previous environment on drop.
+fn use_fake_slurm() -> Vec<EnvVarGuard> {
+    let cwd = std::env::current_dir().unwrap();
+    let fake_squeue = cwd.join("tests/scripts/fake_squeue.sh");
+    let fake_scancel = cwd.join("tests/scripts/fake_scancel.sh");
+    assert!(fake_squeue.exists(), "missing {:?}", fake_squeue);
+    assert!(fake_scancel.exists(), "missing {:?}", fake_scancel);
+
+    let _ = std::fs::remove_file(fake_jobs_file());
+
+    let mut guards = vec![
+        EnvVarGuard::set("TORC_FAKE_SQUEUE", &fake_squeue.to_string_lossy()),
+        EnvVarGuard::set("TORC_FAKE_SCANCEL", &fake_scancel.to_string_lossy()),
+    ];
+    if std::env::var("USER").is_err() && std::env::var("USERNAME").is_err() {
+        guards.push(EnvVarGuard::set("USER", "test-user"));
+    }
+    guards
+}
+
+/// Drive one job all the way to Completed so the workflow has no runnable jobs.
+fn complete_single_job(config: &torc::client::Configuration, workflow_id: i64, name: &str) {
+    let job = models::JobModel::new(workflow_id, name.to_string(), "echo done".to_string());
+    let job_id = apis::jobs_api::create_job(config, job)
+        .expect("create job")
+        .id
+        .unwrap();
+    apis::workflows_api::initialize_jobs(config, workflow_id, None, None, None)
+        .expect("initialize jobs");
+    let run_id = apis::workflows_api::get_workflow(config, workflow_id)
+        .expect("get workflow")
+        .run_id
+        .unwrap_or(0);
+
+    let compute_node = models::ComputeNodeModel::new(
+        workflow_id,
+        "test-host".to_string(),
+        std::process::id() as i64,
+        chrono::Utc::now().to_rfc3339(),
+        8,
+        16.0,
+        0,
+        1,
+        "local".to_string(),
+        None,
+    );
+    let compute_node_id = apis::compute_nodes_api::create_compute_node(config, compute_node)
+        .expect("create compute node")
+        .id
+        .unwrap();
+
+    apis::workflows_api::claim_next_jobs(config, workflow_id, Some(1)).expect("claim job");
+    apis::jobs_api::start_job(config, job_id, run_id, compute_node_id).expect("start job");
+    let result = models::ResultModel::new(
+        job_id,
+        workflow_id,
+        run_id,
+        1,
+        compute_node_id,
+        0,
+        1.0,
+        chrono::Utc::now().to_rfc3339(),
+        models::JobStatus::Completed,
+    );
+    apis::jobs_api::complete_job(config, job_id, models::JobStatus::Completed, run_id, result)
+        .expect("complete job");
+}
+
+/// Issue #257: when the workflow has no runnable jobs left, a still-queued Slurm
+/// allocation is unnecessary and must be canceled (scancel + node -> "canceled").
+#[rstest]
+#[serial(slurm)]
+fn test_cancel_unneeded_queued_allocation(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let _guards = use_fake_slurm();
+
+    let workflow = create_test_workflow(config, "test_cancel_unneeded_queued");
+    let workflow_id = workflow.id.unwrap();
+    let scheduler = create_test_slurm_scheduler(config, workflow_id, "queued_alloc_scheduler");
+    let scheduler_config_id = scheduler.id.unwrap();
+
+    // All work is done: the workflow has no Ready/Pending/Running jobs.
+    complete_single_job(config, workflow_id, "finished_job");
+
+    // A sibling allocation is still sitting in the Slurm queue (status PENDING ->
+    // Queued), recorded Torc-side as a "pending" scheduled compute node.
+    let slurm_job_id = 778899;
+    write_fake_slurm_job(slurm_job_id, "queued_alloc", "PENDING");
+    let scheduled = apis::scheduled_compute_nodes_api::create_scheduled_compute_node(
+        config,
+        models::ScheduledComputeNodesModel::new(
+            workflow_id,
+            slurm_job_id,
+            scheduler_config_id,
+            "slurm".to_string(),
+            "pending".to_string(),
+        ),
+    )
+    .expect("create scheduled compute node");
+    let scheduled_id = scheduled.id.unwrap();
+
+    let canceled = torc::client::commands::orphan_detection::cancel_unneeded_pending_allocations(
+        config,
+        workflow_id,
+        false,
+    )
+    .expect("cancel_unneeded_pending_allocations failed");
+
+    assert_eq!(canceled, 1, "the queued allocation should be canceled");
+
+    // Torc-side bookkeeping: the scheduled compute node is now "canceled".
+    let after = apis::scheduled_compute_nodes_api::get_scheduled_compute_node(config, scheduled_id)
+        .expect("get scheduled compute node");
+    assert_eq!(after.status, "canceled");
+
+    // scancel was actually invoked: the fake jobs file shows the job CANCELLED.
+    let jobs = std::fs::read_to_string(fake_jobs_file()).unwrap_or_default();
+    assert!(
+        jobs.contains("CANCELLED"),
+        "expected scancel to flip the fake job to CANCELLED, got: {jobs}"
+    );
+}
+
+/// The cancellation must NOT fire while the workflow still has runnable jobs: a
+/// queued allocation may still be needed to run them.
+#[rstest]
+#[serial(slurm)]
+fn test_cancel_skips_when_runnable_jobs_remain(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let _guards = use_fake_slurm();
+
+    let workflow = create_test_workflow(config, "test_cancel_skips_runnable");
+    let workflow_id = workflow.id.unwrap();
+    let scheduler = create_test_slurm_scheduler(config, workflow_id, "runnable_scheduler");
+    let scheduler_config_id = scheduler.id.unwrap();
+
+    // Leave a Ready job: there IS runnable work.
+    let job = models::JobModel::new(workflow_id, "ready_job".to_string(), "echo hi".to_string());
+    apis::jobs_api::create_job(config, job).expect("create job");
+    apis::workflows_api::initialize_jobs(config, workflow_id, None, None, None)
+        .expect("initialize jobs");
+
+    let slurm_job_id = 112233;
+    write_fake_slurm_job(slurm_job_id, "queued_alloc", "PENDING");
+    let scheduled = apis::scheduled_compute_nodes_api::create_scheduled_compute_node(
+        config,
+        models::ScheduledComputeNodesModel::new(
+            workflow_id,
+            slurm_job_id,
+            scheduler_config_id,
+            "slurm".to_string(),
+            "pending".to_string(),
+        ),
+    )
+    .expect("create scheduled compute node");
+    let scheduled_id = scheduled.id.unwrap();
+
+    let canceled = torc::client::commands::orphan_detection::cancel_unneeded_pending_allocations(
+        config,
+        workflow_id,
+        false,
+    )
+    .expect("cancel_unneeded_pending_allocations failed");
+
+    assert_eq!(canceled, 0, "must not cancel while runnable jobs remain");
+
+    let after = apis::scheduled_compute_nodes_api::get_scheduled_compute_node(config, scheduled_id)
+        .expect("get scheduled compute node");
+    assert_eq!(
+        after.status, "pending",
+        "allocation should be left untouched"
+    );
+}
+
 /// Test that list_jobs returns empty when filtering by non-existent active_compute_node_id
 #[rstest]
 fn test_list_jobs_no_active_compute_node(start_server: &ServerProcess) {


### PR DESCRIPTION
## Summary

Fixes #257. When a workflow opens several Slurm allocations but finishes all of its work inside the first few, the remaining allocations sit in the Slurm queue with nothing left to run. Standard orphan cleanup never touches them because Slurm still reports them as `Queued` (i.e. still valid), so they wait until they start or are canceled by hand.

This adds automatic cancellation of those unneeded queued allocations, driven by the **Slurm job runner** so it works for every workflow — no `torc watch` required.

## What changed

- **`cancel_unneeded_pending_allocations`** (new, in `orphan_detection.rs`): when the workflow has no runnable jobs left (no `Ready`/`Pending`/`Running`), it enumerates pending Slurm allocations, confirms each is still `Queued` in Slurm, issues `scancel`, marks the scheduled compute node `canceled`, and deactivates any associated compute nodes (the same bookkeeping `torc cancel` performs).
- **Wired into the Slurm job runner** (`torc-slurm-job-runner.rs`), in the post-`run_worker` head-node cleanup. Whichever runner finishes the last job is alive at completion and exits cleanly, so it performs the cancellation.
- **`SlurmInterface::cancel_job`** now routes through a new `get_scancel_exec()` helper so it honors the existing `TORC_FAKE_SCANCEL` test hook. Previously it hardcoded `scancel`, leaving the scancel path untestable (the fake script and env var already existed but were never read). No production behavior change — falls back to `scancel` when the var is unset.
- **Docs**: new "Canceling Unneeded Queued Allocations" section in `automatic-recovery.md`.

## Safety / concurrency

Safe to run from every finishing allocation's head node:
- no-ops while runnable jobs remain (so idle-timeout exits with work elsewhere don't cancel anything),
- `scancel` is idempotent,
- the first runner to act flips the queued nodes to `canceled`, so the rest find nothing left to cancel.

Allocations already `Running` are left alone — their own job runner detects there is no work and exits gracefully.

## Tests

- Unit test for the `has_runnable_jobs` guard.
- Integration tests (`tests/test_orphaned_jobs.rs`) that manufacture the scenario via the API + fake squeue/scancel:
  - queued allocation is canceled (node → `canceled`, `scancel` actually invoked) when no work remains;
  - allocation is left untouched when a `Ready` job still exists.

All checks pass: `cargo fmt --check`, `cargo clippy --all --all-targets --all-features -D warnings`, `dprint check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)