### PR TITLE
Add confirmation prompt to cancel; standardize on --no-prompts

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -842,12 +842,18 @@ EXAMPLES:
 
     # Get JSON status of cancellation
     torc -f json cancel 123
+
+    # Cancel without confirmation (use with caution)
+    torc cancel --no-prompts 123
 "
     )]
     Cancel {
         /// ID of the workflow to cancel (optional - will prompt if not provided)
         #[arg()]
         workflow_id: Option<i64>,
+        /// Skip confirmation prompt
+        #[arg(long)]
+        no_prompts: bool,
     },
     /// Show workflow status and job summary
     ///
@@ -882,7 +888,7 @@ EXAMPLES:
     torc delete 123 456 789
 
     # Delete without confirmation (use with caution)
-    torc delete --force 123
+    torc delete --no-prompts 123
 "
     )]
     Delete {
@@ -890,8 +896,8 @@ EXAMPLES:
         #[arg(required = true)]
         workflow_ids: Vec<i64>,
         /// Skip confirmation prompt
-        #[arg(long)]
-        force: bool,
+        #[arg(long, alias = "force")]
+        no_prompts: bool,
     },
     /// Interactive terminal UI for managing workflows
     #[command(

--- a/src/client/commands/jobs.rs
+++ b/src/client/commands/jobs.rs
@@ -363,12 +363,18 @@ EXAMPLES:
 EXAMPLES:
     # Delete all jobs from a workflow
     torc jobs delete-all 123
+
+    # Delete all jobs without confirmation (use with caution)
+    torc jobs delete-all --no-prompts 123
 "
     )]
     DeleteAll {
         /// Workflow ID to delete all jobs from (optional - will prompt if not provided)
         #[arg()]
         workflow_id: Option<i64>,
+        /// Skip confirmation prompt
+        #[arg(long)]
+        no_prompts: bool,
     },
     /// List jobs with their resource requirements
     #[command(
@@ -925,7 +931,10 @@ pub fn handle_job_commands(config: &Configuration, command: &JobCommands, format
                 }
             }
         }
-        JobCommands::DeleteAll { workflow_id } => {
+        JobCommands::DeleteAll {
+            workflow_id,
+            no_prompts,
+        } => {
             let user_name = get_env_user_name();
             let selected_workflow_id = match workflow_id {
                 Some(id) => *id,
@@ -965,7 +974,7 @@ pub fn handle_job_commands(config: &Configuration, command: &JobCommands, format
                     }
 
                     // Confirm deletion
-                    if format != "json" {
+                    if !no_prompts && format != "json" {
                         println!(
                             "About to delete {} job(s) from workflow ID: {}",
                             job_count, selected_workflow_id

--- a/src/client/commands/jobs.rs
+++ b/src/client/commands/jobs.rs
@@ -980,10 +980,16 @@ pub fn handle_job_commands(config: &Configuration, command: &JobCommands, format
                             job_count, selected_workflow_id
                         );
                         print!("Are you sure? (y/N): ");
-                        io::stdout().flush().unwrap();
+                        if let Err(e) = io::stdout().flush() {
+                            eprintln!("Failed to write prompt: {}", e);
+                            std::process::exit(1);
+                        }
 
                         let mut input = String::new();
-                        io::stdin().read_line(&mut input).unwrap();
+                        if let Err(e) = io::stdin().read_line(&mut input) {
+                            eprintln!("Failed to read input: {}", e);
+                            std::process::exit(1);
+                        }
 
                         if !input.trim().eq_ignore_ascii_case("y") {
                             println!("Deletion cancelled");

--- a/src/client/commands/user_data.rs
+++ b/src/client/commands/user_data.rs
@@ -1,5 +1,6 @@
 use clap::Subcommand;
 use serde_json;
+use std::io::{self, Write};
 
 use crate::client::apis;
 use crate::client::apis::configuration::Configuration;
@@ -120,6 +121,9 @@ EXAMPLES:
     DeleteAll {
         /// Workflow ID
         workflow_id: i64,
+        /// Skip confirmation prompt
+        #[arg(long)]
+        no_prompts: bool,
     },
     /// List missing user data for a workflow
     ListMissing {
@@ -370,7 +374,52 @@ pub fn handle_user_data_commands(config: &Configuration, command: &UserDataComma
                 }
             }
         }
-        UserDataCommands::DeleteAll { workflow_id } => {
+        UserDataCommands::DeleteAll {
+            workflow_id,
+            no_prompts,
+        } => {
+            // Show how many records will be deleted and confirm before proceeding
+            if !no_prompts && format != "json" {
+                let count = match apis::user_data_api::list_user_data(
+                    config,
+                    *workflow_id,
+                    None,    // consumer_job_id
+                    None,    // producer_job_id
+                    Some(0), // offset
+                    Some(1), // limit (we just need the total count)
+                    None,    // sort_by
+                    None,    // reverse_sort
+                    None,    // name
+                    None,    // is_ephemeral
+                ) {
+                    Ok(response) => response.total_count,
+                    Err(e) => {
+                        print_error("counting user data", &e);
+                        std::process::exit(1);
+                    }
+                };
+
+                if count == 0 {
+                    println!("No user data found for workflow ID: {}", workflow_id);
+                    return;
+                }
+
+                println!(
+                    "About to delete {} user data record(s) from workflow ID: {}",
+                    count, workflow_id
+                );
+                print!("Are you sure? (y/N): ");
+                io::stdout().flush().unwrap();
+
+                let mut input = String::new();
+                io::stdin().read_line(&mut input).unwrap();
+
+                if !input.trim().eq_ignore_ascii_case("y") {
+                    println!("Deletion cancelled");
+                    return;
+                }
+            }
+
             match apis::user_data_api::delete_all_user_data(config, *workflow_id) {
                 Ok(response) => {
                     if format == "json" {

--- a/src/client/commands/user_data.rs
+++ b/src/client/commands/user_data.rs
@@ -409,10 +409,16 @@ pub fn handle_user_data_commands(config: &Configuration, command: &UserDataComma
                     count, workflow_id
                 );
                 print!("Are you sure? (y/N): ");
-                io::stdout().flush().unwrap();
+                if let Err(e) = io::stdout().flush() {
+                    eprintln!("Failed to write prompt: {}", e);
+                    std::process::exit(1);
+                }
 
                 let mut input = String::new();
-                io::stdin().read_line(&mut input).unwrap();
+                if let Err(e) = io::stdin().read_line(&mut input) {
+                    eprintln!("Failed to read input: {}", e);
+                    std::process::exit(1);
+                }
 
                 if !input.trim().eq_ignore_ascii_case("y") {
                     println!("Deletion cancelled");

--- a/src/client/commands/workflows.rs
+++ b/src/client/commands/workflows.rs
@@ -1439,13 +1439,59 @@ fn handle_correct_resources(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn handle_cancel(config: &Configuration, workflow_id: &Option<i64>, format: &str) {
+pub fn handle_cancel(
+    config: &Configuration,
+    workflow_id: &Option<i64>,
+    no_prompts: bool,
+    format: &str,
+) {
     let user_name = get_env_user_name();
 
     let selected_workflow_id = match workflow_id {
         Some(id) => *id,
         None => select_workflow_interactively(config, &user_name).unwrap(),
     };
+
+    // Unless skipping prompts, show what will be canceled and ask for confirmation
+    if !no_prompts && format != "json" {
+        let workflow = match apis::workflows_api::get_workflow(config, selected_workflow_id) {
+            Ok(wf) => wf,
+            Err(e) => {
+                print_error("getting workflow", &e);
+                std::process::exit(1);
+            }
+        };
+
+        println!("\nWarning: You are about to cancel the following workflow:");
+        println!("  ID: {}", workflow.id.unwrap_or(-1));
+        println!("  Name: {}", workflow.name);
+        println!("  User: {}", workflow.user);
+        if let Some(desc) = &workflow.description {
+            println!("  Description: {}", desc);
+        }
+        println!("\nThis will cancel running jobs and any associated Slurm allocations.");
+        println!("Workflow state is preserved and can be resumed after reinitialization.");
+        print!("\nAre you sure you want to cancel this workflow? (y/N): ");
+        io::stdout().flush().unwrap();
+
+        let mut input = String::new();
+        match io::stdin().read_line(&mut input) {
+            Ok(_) => {
+                let response = input.trim().to_lowercase();
+                if response != "y" && response != "yes" {
+                    println!(
+                        "Cancellation aborted for workflow {}.",
+                        selected_workflow_id
+                    );
+                    return;
+                }
+            }
+            Err(e) => {
+                eprintln!("Failed to read input: {}", e);
+                std::process::exit(1);
+            }
+        }
+    }
 
     match apis::workflows_api::cancel_workflow(config, selected_workflow_id) {
         Ok(_) => {

--- a/src/client/commands/workflows.rs
+++ b/src/client/commands/workflows.rs
@@ -1463,7 +1463,7 @@ pub fn handle_cancel(
         };
 
         println!("\nWarning: You are about to cancel the following workflow:");
-        println!("  ID: {}", workflow.id.unwrap_or(-1));
+        println!("  ID: {}", selected_workflow_id);
         println!("  Name: {}", workflow.name);
         println!("  User: {}", workflow.user);
         if let Some(desc) = &workflow.description {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1155,20 +1155,23 @@ fn main() {
                 }
             }
         }
-        Commands::Cancel { workflow_id } => {
-            handle_cancel(&config, workflow_id, &format);
+        Commands::Cancel {
+            workflow_id,
+            no_prompts,
+        } => {
+            handle_cancel(&config, workflow_id, *no_prompts, &format);
         }
         Commands::Status { workflow_id } => {
             torc::client::commands::reports::generate_summary(&config, *workflow_id, &format);
         }
         Commands::Delete {
             workflow_ids,
-            force,
+            no_prompts,
         } => {
             torc::client::commands::workflows::handle_delete(
                 &config,
                 workflow_ids,
-                *force,
+                *no_prompts,
                 &format,
             );
         }


### PR DESCRIPTION
## Summary

`torc cancel <id>` did not prompt for confirmation. This adds one, matching the existing `torc delete <id>` behavior, and standardizes the prompt-skip flag across all confirmation-gated commands.

## Changes

- **`cancel`**: now prompts before canceling, showing the workflow ID/name/user and noting that state is preserved and can be resumed after reinitialization. Skipped with `--no-prompts` or `-f json`.
- **`user-data delete-all`**: previously deleted all user data for a workflow with **no** confirmation; now shows the record count and prompts (matching `jobs delete-all`).
- **Flag consistency**: standardized the prompt-skip flag on `--no-prompts` across `cancel`, `delete`, `jobs delete-all`, and `user-data delete-all`.
  - `delete` keeps `--force` as a hidden alias so existing `torc delete --force` scripts keep working.
  - `reset-status` commands already used `--no-prompts`; their separate `--force` flag (reset semantics, not prompting) is unchanged.

## Behavior notes

- All prompts default to "no" on empty/non-`y` input.
- JSON output format (`-f json`) skips prompts for non-interactive scripting, consistent with existing commands.

## Testing

- `cargo build`, `cargo fmt -- --check`, and `cargo clippy --all-features -- -D warnings` all pass.
- Verified `--no-prompts` appears in `--help` for all four commands and that `delete --force` still parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)