### PR TITLE
Add --status and --return-code selectors to jobs reset-status

### DIFF
--- a/docs/src/core/how-to/rerun-failed-jobs.md
+++ b/docs/src/core/how-to/rerun-failed-jobs.md
@@ -51,7 +51,7 @@ is useful when you know exactly which jobs need to be rerun without resetting th
 Jobs are selected one of three mutually exclusive ways:
 
 - **By job ID** — list explicit IDs (they must all belong to the same workflow).
-- **By status** — `--status` reset every job currently in one of the given statuses. The value is
+- **By status** — `--status` resets every job currently in one of the given statuses. The value is
   repeatable / comma-separated (e.g. `--status terminated,canceled,failed`).
 - **By return code** — `--return-code` resets every job whose **latest** result exited with the
   given code.

--- a/docs/src/core/how-to/rerun-failed-jobs.md
+++ b/docs/src/core/how-to/rerun-failed-jobs.md
@@ -48,18 +48,36 @@ Then resume execution with `torc run <workflow_id>` (local) or `torc submit <wor
 When you need to rerun only specific jobs (not all failed ones), use `torc jobs reset-status`. This
 is useful when you know exactly which jobs need to be rerun without resetting the whole workflow.
 
+Jobs are selected one of three mutually exclusive ways:
+
+- **By job ID** — list explicit IDs (they must all belong to the same workflow).
+- **By status** — `--status` reset every job currently in one of the given statuses. The value is
+  repeatable / comma-separated (e.g. `--status terminated,canceled,failed`).
+- **By return code** — `--return-code` resets every job whose **latest** result exited with the
+  given code.
+
+The `--status` and `--return-code` modes operate on a whole workflow, selected with `--workflow-id`
+(you are prompted to choose one if it is omitted). If a filter matches no jobs, the command exits
+non-zero with an error — this catches a mistaken assumption (e.g. expecting failed jobs when there
+are none) in scripts and CI.
+
 Unlike `torc workflows reset-status`, this command:
 
-- Resets only the explicitly named job IDs. Downstream dependents are **not** reset by this command
-  — it lists them for you, and they are reset transitively when you run `torc workflows reinit` (a
-  rerun job produces new outputs that consumers must consume again).
+- Resets only the selected jobs. Downstream dependents are **not** reset by this command — it lists
+  them for you, and they are reset transitively when you run `torc workflows reinit` (a rerun job
+  produces new outputs that consumers must consume again).
 - Does **not** bump the workflow `run_id` or reset workflow state — you follow up with
   `torc workflows reinit` once, which does the run_id bump exactly once.
-- All supplied job IDs must belong to the same workflow (hard error otherwise).
 
 ```bash
 # Preview what would be reset (no changes applied)
 torc jobs reset-status 101 102 --dry-run
+
+# Reset every terminated, canceled, or failed job in a workflow
+torc jobs reset-status --status terminated,canceled,failed --workflow-id <workflow_id>
+
+# Reset all jobs whose latest result exited with return code 42
+torc jobs reset-status --return-code 42 --workflow-id <workflow_id>
 
 # Reset and reinitialize in one step, then run
 torc jobs reset-status 101 102 --reinit
@@ -79,7 +97,7 @@ torc -f json jobs reset-status 101 102 --no-prompts
 ```
 
 The workflow does not need to be complete — the command can be run repeatedly (e.g. to reset
-additional jobs after an earlier reset) as long as no workers are active. If a requested job
+additional jobs after an earlier reset) as long as no workers are active. If a selected job
 completed successfully, the command warns you before resetting it, since resetting discards its
 results and reruns it.
 
@@ -95,6 +113,7 @@ allocations), and (2) the active-status guard (jobs in Running or Pending are no
 | Local workflow with failures                              | `torc workflows reset-status --failed-only`                                       |
 | Want to retry without changing resource allocations       | `torc workflows reset-status --failed-only`                                       |
 | Rerun only specific known jobs                            | `torc jobs reset-status <id>...`                                                  |
+| Rerun every job in a given status (or return code)        | `torc jobs reset-status --status <s>` / `--return-code <n>`                       |
 | Workflow ran fine but inputs changed                      | [Intelligent Restart](../concepts/intelligent-restart.md)                         |
 | Need AI-driven classification of unfamiliar failure modes | [AI-Assisted Recovery](../../specialized/fault-tolerance/ai-assisted-recovery.md) |
 

--- a/src/client/commands/jobs.rs
+++ b/src/client/commands/jobs.rs
@@ -8,7 +8,7 @@ use crate::client::apis::configuration::Configuration;
 use crate::client::commands::get_env_user_name;
 use crate::client::commands::{
     output::{print_if_json, print_json, print_json_wrapped},
-    pagination::{self, JobListParams},
+    pagination::{self, JobListParams, ResultListParams},
     print_error, select_workflow_interactively,
     table_format::{
         display_csv, display_csv_excluding, display_table_excluding, display_table_with_count,
@@ -439,12 +439,16 @@ EXAMPLES:
         #[arg()]
         workflow_id: Option<i64>,
     },
-    /// Reset specific jobs to uninitialized status for selective rerun
+    /// Reset jobs to uninitialized status for selective rerun
     ///
-    /// Resets only the given job IDs to uninitialized so they can be rerun. All jobs
-    /// must belong to the same workflow. Downstream dependents are not reset by this
-    /// command; they are reset transitively by 'torc workflows reinit' (the command
-    /// lists them for you).
+    /// Selects jobs one of three mutually exclusive ways: by explicit job IDs, by
+    /// current status (--status, repeatable), or by the return code of each job's
+    /// latest result (--return-code). The status/return-code modes target a whole
+    /// workflow, chosen with --workflow-id (or interactively when omitted). Matched
+    /// jobs are reset to uninitialized so they can be rerun.
+    ///
+    /// Downstream dependents are not reset by this command; they are reset
+    /// transitively by 'torc workflows reinit' (the command lists them for you).
     ///
     /// After resetting, run 'torc workflows reinit <workflow_id>' to rebuild
     /// dependency state (this bumps run_id exactly once), then 'torc run' or
@@ -456,6 +460,12 @@ EXAMPLES:
 EXAMPLES:
     # Reset two specific jobs for rerun (preview first)
     torc jobs reset-status 101 102 --dry-run
+
+    # Reset every terminated, canceled, or failed job in a workflow
+    torc jobs reset-status --status terminated,canceled,failed --workflow-id 42
+
+    # Reset all jobs whose latest result exited with return code 42
+    torc jobs reset-status --return-code 42 --workflow-id 42
 
     # Reset and reinitialize in one step, then run
     torc jobs reset-status 101 102 --reinit
@@ -477,9 +487,23 @@ EXAMPLES:
 "
     )]
     ResetStatus {
-        /// Job IDs to reset (must all belong to the same workflow)
-        #[arg(required = true, num_args = 1..)]
+        /// Job IDs to reset (must all belong to the same workflow).
+        /// Mutually exclusive with --status and --return-code.
+        #[arg(num_args = 1.., conflicts_with_all = ["status", "return_code", "workflow_id"])]
         job_ids: Vec<i64>,
+        /// Reset all jobs currently in one of these statuses (repeatable or
+        /// comma-separated, e.g. --status terminated,canceled,failed). Requires a
+        /// workflow (see --workflow-id).
+        #[arg(long, value_delimiter = ',', conflicts_with = "return_code")]
+        status: Vec<String>,
+        /// Reset all jobs whose latest result has this return code. Requires a
+        /// workflow (see --workflow-id).
+        #[arg(long)]
+        return_code: Option<i64>,
+        /// Workflow to target when using --status/--return-code (selected
+        /// interactively when omitted)
+        #[arg(long)]
+        workflow_id: Option<i64>,
         /// Skip precondition checks (no active workers, target jobs not running)
         #[arg(long)]
         force: bool,
@@ -1296,6 +1320,9 @@ pub fn handle_job_commands(config: &Configuration, command: &JobCommands, format
         }
         JobCommands::ResetStatus {
             job_ids,
+            status,
+            return_code,
+            workflow_id,
             force,
             dry_run,
             no_prompts,
@@ -1304,6 +1331,9 @@ pub fn handle_job_commands(config: &Configuration, command: &JobCommands, format
             handle_reset_job_status(
                 config,
                 job_ids,
+                status,
+                *return_code,
+                *workflow_id,
                 *force,
                 *dry_run,
                 *no_prompts,
@@ -1551,19 +1581,12 @@ fn require_job_id(job: &models::JobModel) -> i64 {
     })
 }
 
-#[allow(clippy::too_many_arguments)]
-fn handle_reset_job_status(
+/// Resolve explicit job IDs into JobModels, validating that they exist and all
+/// belong to the same workflow. Exits the process on any error.
+fn resolve_reset_targets_by_ids(
     config: &Configuration,
     job_ids: &[i64],
-    force: bool,
-    dry_run: bool,
-    no_prompts: bool,
-    reinit: bool,
-    format: &str,
-) {
-    // -----------------------------------------------------------------------
-    // 1. Fetch and validate: all IDs must exist and belong to the same workflow
-    // -----------------------------------------------------------------------
+) -> (i64, Vec<models::JobModel>) {
     let mut fetched: Vec<models::JobModel> = Vec::with_capacity(job_ids.len());
     for &id in job_ids {
         match apis::jobs_api::get_job(config, id) {
@@ -1603,6 +1626,185 @@ fn handle_reset_job_status(
             eprintln!("  job {} belongs to workflow {}", id, wf);
         }
         eprintln!("Nothing was reset.");
+        std::process::exit(1);
+    }
+
+    (workflow_id, unique_jobs)
+}
+
+/// Resolve all jobs in `workflow_id` whose current status is one of
+/// `status_filters` (parsed, de-duplicated). Exits the process on any error.
+fn resolve_reset_targets_by_status(
+    config: &Configuration,
+    workflow_id: i64,
+    status_filters: &[String],
+) -> Vec<models::JobModel> {
+    // Parse and de-duplicate the requested statuses.
+    let mut statuses: Vec<models::JobStatus> = Vec::new();
+    let mut seen_status: HashSet<String> = HashSet::new();
+    for raw in status_filters {
+        let normalized = raw.trim().to_lowercase();
+        if normalized.is_empty() {
+            continue;
+        }
+        match normalized.parse::<models::JobStatus>() {
+            Ok(status) => {
+                if seen_status.insert(normalized) {
+                    statuses.push(status);
+                }
+            }
+            Err(_) => {
+                eprintln!(
+                    "Error: invalid status '{}'. Valid values are: uninitialized, blocked, \
+                     ready, pending, running, completed, failed, canceled, terminated, disabled, \
+                     pending_failed.",
+                    raw.trim()
+                );
+                std::process::exit(1);
+            }
+        }
+    }
+
+    let mut seen_ids: HashSet<i64> = HashSet::new();
+    let mut unique_jobs: Vec<models::JobModel> = Vec::new();
+    for status in statuses {
+        let params = JobListParams::new().with_status(status);
+        let jobs = match pagination::paginate_jobs(config, workflow_id, params) {
+            Ok(jobs) => jobs,
+            Err(e) => {
+                eprintln!("Error: failed to list {} jobs: {}", status, e);
+                std::process::exit(1);
+            }
+        };
+        for job in jobs {
+            let id = require_job_id(&job);
+            if seen_ids.insert(id) {
+                unique_jobs.push(job);
+            }
+        }
+    }
+    unique_jobs
+}
+
+/// Resolve all jobs in `workflow_id` whose latest result has the given
+/// `return_code`. Exits the process on any error.
+fn resolve_reset_targets_by_return_code(
+    config: &Configuration,
+    workflow_id: i64,
+    return_code: i64,
+) -> Vec<models::JobModel> {
+    // Default all_runs=false → server returns only the latest result per job.
+    let params = ResultListParams::new().with_return_code(return_code);
+    let results = match pagination::paginate_results(config, workflow_id, params) {
+        Ok(results) => results,
+        Err(e) => {
+            eprintln!(
+                "Error: failed to list results with return code {}: {}",
+                return_code, e
+            );
+            std::process::exit(1);
+        }
+    };
+
+    // Fetch the current JobModel for each matched job (results carry job_id but
+    // not the live job state the rest of the reset flow needs).
+    let mut seen_ids: HashSet<i64> = HashSet::new();
+    let mut unique_jobs: Vec<models::JobModel> = Vec::new();
+    for result in results {
+        if !seen_ids.insert(result.job_id) {
+            continue;
+        }
+        match apis::jobs_api::get_job(config, result.job_id) {
+            Ok(job) => unique_jobs.push(job),
+            Err(e) => {
+                eprintln!("Error: job {} not found: {}", result.job_id, e);
+                std::process::exit(1);
+            }
+        }
+    }
+    unique_jobs
+}
+
+#[allow(clippy::too_many_arguments)]
+fn handle_reset_job_status(
+    config: &Configuration,
+    job_ids: &[i64],
+    status_filters: &[String],
+    return_code: Option<i64>,
+    workflow_id_arg: Option<i64>,
+    force: bool,
+    dry_run: bool,
+    no_prompts: bool,
+    reinit: bool,
+    format: &str,
+) {
+    // -----------------------------------------------------------------------
+    // 1. Resolve the target jobs and their workflow.
+    //
+    // Exactly one selection mode is used: explicit job IDs, --status, or
+    // --return-code. clap's conflicts_with enforces that the modes are not
+    // combined; here we only need to ensure at least one was supplied.
+    // -----------------------------------------------------------------------
+    let by_ids = !job_ids.is_empty();
+    let by_status = !status_filters.is_empty();
+    let by_return_code = return_code.is_some();
+    if !by_ids && !by_status && !by_return_code {
+        eprintln!(
+            "Error: nothing selected. Pass job IDs, --status, or --return-code. \
+             See 'torc jobs reset-status --help'."
+        );
+        std::process::exit(1);
+    }
+
+    let (workflow_id, unique_jobs): (i64, Vec<models::JobModel>) = if by_ids {
+        resolve_reset_targets_by_ids(config, job_ids)
+    } else {
+        // Filter modes target a whole workflow, chosen explicitly or interactively.
+        let workflow_id = match workflow_id_arg {
+            Some(id) => id,
+            None => {
+                let user_name = get_env_user_name();
+                match select_workflow_interactively(config, &user_name) {
+                    Ok(id) => id,
+                    Err(e) => {
+                        eprintln!("Error selecting workflow: {}", e);
+                        std::process::exit(1);
+                    }
+                }
+            }
+        };
+        let jobs = if by_status {
+            resolve_reset_targets_by_status(config, workflow_id, status_filters)
+        } else {
+            resolve_reset_targets_by_return_code(config, workflow_id, return_code.unwrap())
+        };
+        (workflow_id, jobs)
+    };
+
+    // A filter that matches nothing is treated as a failure: the caller asked to
+    // reset jobs in a particular state and none were found, which usually signals
+    // a mistaken assumption (and lets scripts/CI detect it via the exit code).
+    if unique_jobs.is_empty() {
+        let selection = if by_status {
+            format!("status in [{}]", status_filters.join(", "))
+        } else {
+            format!("return code {}", return_code.unwrap())
+        };
+        if format == "json" {
+            let response = serde_json::json!({
+                "status": "error",
+                "workflow_id": workflow_id,
+                "reset_count": 0,
+                "reset_job_ids": [],
+                "error": format!("No jobs in workflow {} match {}.", workflow_id, selection),
+            });
+            println!("{}", serde_json::to_string_pretty(&response).unwrap());
+        } else {
+            eprintln!(
+                "Error: no jobs in workflow {} match {}. Nothing to reset.",
+                workflow_id, selection
+            );
+        }
         std::process::exit(1);
     }
 

--- a/tests/test_full_workflows.rs
+++ b/tests/test_full_workflows.rs
@@ -1431,7 +1431,7 @@ fn test_cancel_on_blocking_job_failure_false_runs_downstream_anyway(start_server
 
     let yaml_content = r#"name: no_cascade_workflow
 user: test_user
-description: Test that cancel_on_blocking_job_failure=false leaves downstream blocked
+description: Test that cancel_on_blocking_job_failure=false runs downstream anyway after an upstream failure
 
 jobs:
   - name: producer

--- a/tests/test_jobs_reset_status.rs
+++ b/tests/test_jobs_reset_status.rs
@@ -1260,3 +1260,687 @@ fn test_reset_status_completed_job_warning(start_server: &ServerProcess) {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// Test 14: Select by --status — reset every job in a given status, leaving
+//          jobs in other statuses untouched.
+// ---------------------------------------------------------------------------
+#[rstest]
+fn test_reset_status_by_status_filter(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let workflow = create_test_workflow(config, "reset_by_status");
+    let workflow_id = workflow.id.unwrap();
+
+    let failed1 = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(workflow_id, "failed1".to_string(), "false".to_string()),
+    )
+    .expect("create failed1");
+    let failed1_id = failed1.id.unwrap();
+    let failed2 = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(workflow_id, "failed2".to_string(), "false".to_string()),
+    )
+    .expect("create failed2");
+    let failed2_id = failed2.id.unwrap();
+    let completed = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(workflow_id, "ok".to_string(), "echo ok".to_string()),
+    )
+    .expect("create completed");
+    let completed_id = completed.id.unwrap();
+
+    let run_id = initialize_workflow(config, &workflow);
+    let cn_id = create_test_compute_node(config, workflow_id).id.unwrap();
+
+    for &id in &[failed1_id, failed2_id, completed_id] {
+        apis::jobs_api::manage_status_change(config, id, JobStatus::Running, run_id)
+            .unwrap_or_else(|e| panic!("set {} running: {}", id, e));
+    }
+    complete_job(
+        config,
+        failed1_id,
+        workflow_id,
+        cn_id,
+        run_id,
+        1,
+        JobStatus::Failed,
+    );
+    complete_job(
+        config,
+        failed2_id,
+        workflow_id,
+        cn_id,
+        run_id,
+        1,
+        JobStatus::Failed,
+    );
+    complete_job(
+        config,
+        completed_id,
+        workflow_id,
+        cn_id,
+        run_id,
+        0,
+        JobStatus::Completed,
+    );
+
+    let json = run_cli_with_json(
+        &[
+            "jobs",
+            "reset-status",
+            "--no-prompts",
+            "--status",
+            "failed",
+            "--workflow-id",
+            &workflow_id.to_string(),
+        ],
+        start_server,
+        None,
+    )
+    .expect("reset-status --status should succeed");
+
+    assert_eq!(json["status"], "success");
+    assert_eq!(json["workflow_id"], workflow_id);
+    let reset_ids: Vec<i64> = json["reset_job_ids"]
+        .as_array()
+        .expect("reset_job_ids array")
+        .iter()
+        .map(|v| v.as_i64().unwrap())
+        .collect();
+    assert_eq!(reset_ids.len(), 2, "exactly the two failed jobs reset");
+    assert!(reset_ids.contains(&failed1_id) && reset_ids.contains(&failed2_id));
+
+    for &id in &[failed1_id, failed2_id] {
+        assert_eq!(
+            apis::jobs_api::get_job(config, id).unwrap().status.unwrap(),
+            JobStatus::Uninitialized,
+            "failed job {} should be Uninitialized",
+            id
+        );
+    }
+    assert_eq!(
+        apis::jobs_api::get_job(config, completed_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Completed,
+        "completed job should be untouched"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 15: Select by multiple --status values (comma-separated) — union of
+//          all matching statuses is reset.
+// ---------------------------------------------------------------------------
+#[rstest]
+fn test_reset_status_by_multiple_statuses(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let workflow = create_test_workflow(config, "reset_by_multi_status");
+    let workflow_id = workflow.id.unwrap();
+
+    let failed = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(workflow_id, "f".to_string(), "false".to_string()),
+    )
+    .expect("create failed");
+    let failed_id = failed.id.unwrap();
+    let terminated = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(workflow_id, "t".to_string(), "sleep 1".to_string()),
+    )
+    .expect("create terminated");
+    let terminated_id = terminated.id.unwrap();
+    let completed = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(workflow_id, "c".to_string(), "echo c".to_string()),
+    )
+    .expect("create completed");
+    let completed_id = completed.id.unwrap();
+
+    let run_id = initialize_workflow(config, &workflow);
+    let cn_id = create_test_compute_node(config, workflow_id).id.unwrap();
+
+    for &id in &[failed_id, terminated_id, completed_id] {
+        apis::jobs_api::manage_status_change(config, id, JobStatus::Running, run_id)
+            .unwrap_or_else(|e| panic!("set {} running: {}", id, e));
+    }
+    complete_job(
+        config,
+        failed_id,
+        workflow_id,
+        cn_id,
+        run_id,
+        1,
+        JobStatus::Failed,
+    );
+    complete_job(
+        config,
+        terminated_id,
+        workflow_id,
+        cn_id,
+        run_id,
+        1,
+        JobStatus::Terminated,
+    );
+    complete_job(
+        config,
+        completed_id,
+        workflow_id,
+        cn_id,
+        run_id,
+        0,
+        JobStatus::Completed,
+    );
+
+    let json = run_cli_with_json(
+        &[
+            "jobs",
+            "reset-status",
+            "--no-prompts",
+            "--status",
+            "failed,terminated",
+            "--workflow-id",
+            &workflow_id.to_string(),
+        ],
+        start_server,
+        None,
+    )
+    .expect("reset-status --status failed,terminated should succeed");
+
+    assert_eq!(json["status"], "success");
+    let reset_ids: Vec<i64> = json["reset_job_ids"]
+        .as_array()
+        .expect("reset_job_ids array")
+        .iter()
+        .map(|v| v.as_i64().unwrap())
+        .collect();
+    assert_eq!(reset_ids.len(), 2);
+    assert!(reset_ids.contains(&failed_id) && reset_ids.contains(&terminated_id));
+    assert_eq!(
+        apis::jobs_api::get_job(config, completed_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Completed,
+        "completed job should be untouched"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 16: Select by --return-code — reset jobs whose latest result has the
+//          given return code.
+// ---------------------------------------------------------------------------
+#[rstest]
+fn test_reset_status_by_return_code(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let workflow = create_test_workflow(config, "reset_by_return_code");
+    let workflow_id = workflow.id.unwrap();
+
+    let rc42_a = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(workflow_id, "rc42a".to_string(), "false".to_string()),
+    )
+    .expect("create rc42a");
+    let rc42_a_id = rc42_a.id.unwrap();
+    let rc42_b = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(workflow_id, "rc42b".to_string(), "false".to_string()),
+    )
+    .expect("create rc42b");
+    let rc42_b_id = rc42_b.id.unwrap();
+    let rc0 = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(workflow_id, "rc0".to_string(), "echo ok".to_string()),
+    )
+    .expect("create rc0");
+    let rc0_id = rc0.id.unwrap();
+
+    let run_id = initialize_workflow(config, &workflow);
+    let cn_id = create_test_compute_node(config, workflow_id).id.unwrap();
+
+    for &id in &[rc42_a_id, rc42_b_id, rc0_id] {
+        apis::jobs_api::manage_status_change(config, id, JobStatus::Running, run_id)
+            .unwrap_or_else(|e| panic!("set {} running: {}", id, e));
+    }
+    complete_job(
+        config,
+        rc42_a_id,
+        workflow_id,
+        cn_id,
+        run_id,
+        42,
+        JobStatus::Failed,
+    );
+    complete_job(
+        config,
+        rc42_b_id,
+        workflow_id,
+        cn_id,
+        run_id,
+        42,
+        JobStatus::Failed,
+    );
+    complete_job(
+        config,
+        rc0_id,
+        workflow_id,
+        cn_id,
+        run_id,
+        0,
+        JobStatus::Completed,
+    );
+
+    let json = run_cli_with_json(
+        &[
+            "jobs",
+            "reset-status",
+            "--no-prompts",
+            "--return-code",
+            "42",
+            "--workflow-id",
+            &workflow_id.to_string(),
+        ],
+        start_server,
+        None,
+    )
+    .expect("reset-status --return-code should succeed");
+
+    assert_eq!(json["status"], "success");
+    let reset_ids: Vec<i64> = json["reset_job_ids"]
+        .as_array()
+        .expect("reset_job_ids array")
+        .iter()
+        .map(|v| v.as_i64().unwrap())
+        .collect();
+    assert_eq!(reset_ids.len(), 2, "both return-code-42 jobs reset");
+    assert!(reset_ids.contains(&rc42_a_id) && reset_ids.contains(&rc42_b_id));
+    for &id in &[rc42_a_id, rc42_b_id] {
+        assert_eq!(
+            apis::jobs_api::get_job(config, id).unwrap().status.unwrap(),
+            JobStatus::Uninitialized,
+            "rc42 job {} should be Uninitialized",
+            id
+        );
+    }
+    assert_eq!(
+        apis::jobs_api::get_job(config, rc0_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Completed,
+        "return-code-0 job should be untouched"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 17: Filter modes that match nothing fail with a non-zero exit (the
+//          caller expected matching jobs and none were found), and reset nothing.
+// ---------------------------------------------------------------------------
+#[rstest]
+fn test_reset_status_filter_no_match(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let workflow = create_test_workflow(config, "reset_no_match");
+    let workflow_id = workflow.id.unwrap();
+
+    let job = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(workflow_id, "j".to_string(), "echo j".to_string()),
+    )
+    .expect("create job");
+    let job_id = job.id.unwrap();
+    initialize_workflow(config, &workflow);
+
+    let result = run_cli_with_json(
+        &[
+            "jobs",
+            "reset-status",
+            "--no-prompts",
+            "--status",
+            "terminated",
+            "--workflow-id",
+            &workflow_id.to_string(),
+        ],
+        start_server,
+        None,
+    );
+    assert!(
+        result.is_err(),
+        "reset-status with no matches should fail with a non-zero exit"
+    );
+
+    // The non-matching job must be untouched.
+    assert_eq!(
+        apis::jobs_api::get_job(config, job_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Ready,
+        "job should remain Ready (nothing reset)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 18: Selection modes are mutually exclusive — combining job IDs with
+//          --status is a usage error (enforced by clap).
+// ---------------------------------------------------------------------------
+#[rstest]
+fn test_reset_status_modes_mutually_exclusive(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let workflow = create_test_workflow(config, "reset_mutex");
+    let workflow_id = workflow.id.unwrap();
+
+    let job = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(workflow_id, "j".to_string(), "echo j".to_string()),
+    )
+    .expect("create job");
+    let job_id = job.id.unwrap();
+    initialize_workflow(config, &workflow);
+
+    let result = run_cli_with_json(
+        &[
+            "jobs",
+            "reset-status",
+            "--no-prompts",
+            &job_id.to_string(),
+            "--status",
+            "failed",
+        ],
+        start_server,
+        None,
+    );
+    assert!(
+        result.is_err(),
+        "combining job IDs with --status should be rejected"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 19: Invalid --status value → clear error, nothing reset.
+// ---------------------------------------------------------------------------
+#[rstest]
+fn test_reset_status_invalid_status_value(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let workflow = create_test_workflow(config, "reset_bad_status");
+    let workflow_id = workflow.id.unwrap();
+    initialize_workflow(config, &workflow);
+
+    let result = run_cli_with_json(
+        &[
+            "jobs",
+            "reset-status",
+            "--no-prompts",
+            "--status",
+            "bogus",
+            "--workflow-id",
+            &workflow_id.to_string(),
+        ],
+        start_server,
+        None,
+    );
+    assert!(result.is_err(), "invalid status should be rejected");
+}
+
+// ---------------------------------------------------------------------------
+// Test 20: --return-code matches only the LATEST result per job. A job that
+//          failed with rc=42 and was then rerun to success (rc=0) must NOT be
+//          matched by `--return-code 42`, but MUST be matched by
+//          `--return-code 0`.
+// ---------------------------------------------------------------------------
+#[rstest]
+fn test_reset_status_return_code_uses_latest_result(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let workflow = create_test_workflow(config, "reset_rc_latest");
+    let workflow_id = workflow.id.unwrap();
+
+    let job = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(workflow_id, "reran".to_string(), "echo x".to_string()),
+    )
+    .expect("create job");
+    let job_id = job.id.unwrap();
+
+    // Run 1: fail with return code 42.
+    let run_id1 = initialize_workflow(config, &workflow);
+    let cn_id = create_test_compute_node(config, workflow_id).id.unwrap();
+    apis::jobs_api::manage_status_change(config, job_id, JobStatus::Running, run_id1)
+        .expect("set running (run 1)");
+    complete_job(
+        config,
+        job_id,
+        workflow_id,
+        cn_id,
+        run_id1,
+        42,
+        JobStatus::Failed,
+    );
+
+    // Reset the job and reinitialize to bump run_id, mimicking a real rerun.
+    apis::jobs_api::manage_status_change(config, job_id, JobStatus::Uninitialized, run_id1)
+        .expect("reset to uninitialized");
+    let torc_config = TorcConfig::load().unwrap_or_default();
+    let updated_wf = apis::workflows_api::get_workflow(config, workflow_id).unwrap();
+    let manager = WorkflowManager::new(config.clone(), torc_config, updated_wf);
+    manager.reinitialize(false, false).expect("reinitialize");
+    let run_id2 = apis::workflows_api::get_workflow(config, workflow_id)
+        .unwrap()
+        .run_id
+        .unwrap();
+    assert_eq!(run_id2, run_id1 + 1, "run_id should be bumped once");
+
+    // Run 2: succeed with return code 0 (now the latest result).
+    wait_for_status(config, job_id, JobStatus::Ready);
+    apis::jobs_api::manage_status_change(config, job_id, JobStatus::Running, run_id2)
+        .expect("set running (run 2)");
+    complete_job(
+        config,
+        job_id,
+        workflow_id,
+        cn_id,
+        run_id2,
+        0,
+        JobStatus::Completed,
+    );
+
+    // --return-code 42 must NOT match: the stale failure is not the latest result.
+    let json_42 = run_cli_with_json(
+        &[
+            "jobs",
+            "reset-status",
+            "--no-prompts",
+            "--force",
+            "--return-code",
+            "42",
+            "--workflow-id",
+            &workflow_id.to_string(),
+        ],
+        start_server,
+        None,
+    )
+    .expect("reset-status --return-code 42 should succeed (no match)");
+    assert_eq!(json_42["status"], "success");
+    assert_eq!(
+        json_42["reset_count"], 0,
+        "stale rc=42 from a previous run must not match"
+    );
+    assert_eq!(
+        apis::jobs_api::get_job(config, job_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Completed,
+        "job should be untouched by the non-matching return code"
+    );
+
+    // --return-code 0 must match the latest (successful) result.
+    let json_0 = run_cli_with_json(
+        &[
+            "jobs",
+            "reset-status",
+            "--no-prompts",
+            "--force",
+            "--return-code",
+            "0",
+            "--workflow-id",
+            &workflow_id.to_string(),
+        ],
+        start_server,
+        None,
+    )
+    .expect("reset-status --return-code 0 should succeed");
+    let reset_ids: Vec<i64> = json_0["reset_job_ids"]
+        .as_array()
+        .expect("reset_job_ids array")
+        .iter()
+        .map(|v| v.as_i64().unwrap())
+        .collect();
+    assert_eq!(reset_ids, vec![job_id], "latest rc=0 should match");
+    assert_eq!(
+        apis::jobs_api::get_job(config, job_id)
+            .unwrap()
+            .status
+            .unwrap(),
+        JobStatus::Uninitialized,
+        "job should be reset when its latest result matches"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 21: --status may be passed as repeated flags (not just comma-separated);
+//          the union of matching jobs is reset.
+// ---------------------------------------------------------------------------
+#[rstest]
+fn test_reset_status_repeated_status_flag(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let workflow = create_test_workflow(config, "reset_repeated_flag");
+    let workflow_id = workflow.id.unwrap();
+
+    let failed = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(workflow_id, "f".to_string(), "false".to_string()),
+    )
+    .expect("create failed");
+    let failed_id = failed.id.unwrap();
+    let terminated = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(workflow_id, "t".to_string(), "sleep 1".to_string()),
+    )
+    .expect("create terminated");
+    let terminated_id = terminated.id.unwrap();
+
+    let run_id = initialize_workflow(config, &workflow);
+    let cn_id = create_test_compute_node(config, workflow_id).id.unwrap();
+    for &id in &[failed_id, terminated_id] {
+        apis::jobs_api::manage_status_change(config, id, JobStatus::Running, run_id)
+            .unwrap_or_else(|e| panic!("set {} running: {}", id, e));
+    }
+    complete_job(
+        config,
+        failed_id,
+        workflow_id,
+        cn_id,
+        run_id,
+        1,
+        JobStatus::Failed,
+    );
+    complete_job(
+        config,
+        terminated_id,
+        workflow_id,
+        cn_id,
+        run_id,
+        1,
+        JobStatus::Terminated,
+    );
+
+    let json = run_cli_with_json(
+        &[
+            "jobs",
+            "reset-status",
+            "--no-prompts",
+            "--status",
+            "failed",
+            "--status",
+            "terminated",
+            "--workflow-id",
+            &workflow_id.to_string(),
+        ],
+        start_server,
+        None,
+    )
+    .expect("repeated --status flags should succeed");
+
+    assert_eq!(json["status"], "success");
+    let reset_ids: Vec<i64> = json["reset_job_ids"]
+        .as_array()
+        .expect("reset_job_ids array")
+        .iter()
+        .map(|v| v.as_i64().unwrap())
+        .collect();
+    assert_eq!(reset_ids.len(), 2);
+    assert!(reset_ids.contains(&failed_id) && reset_ids.contains(&terminated_id));
+}
+
+// ---------------------------------------------------------------------------
+// Test 22: Remaining mutually-exclusive selection-mode combinations are all
+//          rejected by clap: --status + --return-code, job IDs + --return-code,
+//          and job IDs + --workflow-id.
+// ---------------------------------------------------------------------------
+#[rstest]
+fn test_reset_status_other_mutex_combinations(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let workflow = create_test_workflow(config, "reset_other_mutex");
+    let workflow_id = workflow.id.unwrap();
+    let job = apis::jobs_api::create_job(
+        config,
+        models::JobModel::new(workflow_id, "j".to_string(), "echo j".to_string()),
+    )
+    .expect("create job");
+    let job_id = job.id.unwrap();
+    initialize_workflow(config, &workflow);
+    let wf = workflow_id.to_string();
+    let jid = job_id.to_string();
+
+    let cases: &[Vec<&str>] = &[
+        // --status + --return-code
+        vec![
+            "jobs",
+            "reset-status",
+            "--no-prompts",
+            "--status",
+            "failed",
+            "--return-code",
+            "1",
+            "--workflow-id",
+            &wf,
+        ],
+        // job IDs + --return-code
+        vec![
+            "jobs",
+            "reset-status",
+            "--no-prompts",
+            &jid,
+            "--return-code",
+            "1",
+        ],
+        // job IDs + --workflow-id
+        vec![
+            "jobs",
+            "reset-status",
+            "--no-prompts",
+            &jid,
+            "--workflow-id",
+            &wf,
+        ],
+    ];
+
+    for args in cases {
+        let result = run_cli_with_json(args, start_server, None);
+        assert!(
+            result.is_err(),
+            "mutually exclusive combination should be rejected: {:?}",
+            args
+        );
+    }
+}

--- a/tests/test_jobs_reset_status.rs
+++ b/tests/test_jobs_reset_status.rs
@@ -1743,8 +1743,9 @@ fn test_reset_status_return_code_uses_latest_result(start_server: &ServerProcess
         JobStatus::Completed,
     );
 
-    // --return-code 42 must NOT match: the stale failure is not the latest result.
-    let json_42 = run_cli_with_json(
+    // --return-code 42 must NOT match: the stale failure is not the latest
+    // result. A filter that matches nothing exits non-zero.
+    let result_42 = run_cli_with_json(
         &[
             "jobs",
             "reset-status",
@@ -1757,12 +1758,10 @@ fn test_reset_status_return_code_uses_latest_result(start_server: &ServerProcess
         ],
         start_server,
         None,
-    )
-    .expect("reset-status --return-code 42 should succeed (no match)");
-    assert_eq!(json_42["status"], "success");
-    assert_eq!(
-        json_42["reset_count"], 0,
-        "stale rc=42 from a previous run must not match"
+    );
+    assert!(
+        result_42.is_err(),
+        "stale rc=42 from a previous run must not match (no-match should fail)"
     );
     assert_eq!(
         apis::jobs_api::get_job(config, job_id)


### PR DESCRIPTION
Previously `torc jobs reset-status` required explicit job IDs. Add two filter-based selection modes for common bulk-reset workflows:

  torc jobs reset-status --status terminated,canceled,failed --workflow-id 42
  torc jobs reset-status --return-code 42 --workflow-id 42

- --status: reset all jobs currently in one of the given statuses (repeatable / comma-separated).
- --return-code: reset all jobs whose latest result has the given code (uses the server's latest-result-per-job view).
- The three selection modes (job IDs, --status, --return-code) are mutually exclusive (enforced by clap). Filter modes target a workflow via --workflow-id, or interactive selection when omitted.
- A filter matching zero jobs exits non-zero so scripts/CI can detect a mistaken assumption.

Selection is resolved up front into a job set; the existing preconditions, downstream-closure, dry-run, confirmation, apply, and reinit pipeline is unchanged. Adds tests covering each mode, latest-result semantics, repeated --status, mutual exclusion, and the no-match error.