### PR TITLE
feat(submit): support on_jobs_ready scheduling for selective re-runs

### DIFF
--- a/docs/src/core/reference/workflow-spec.md
+++ b/docs/src/core/reference/workflow-spec.md
@@ -487,6 +487,14 @@ Defines conditional actions triggered by workflow or job state changes.
 | `max_parallel_jobs`         | integer  | none       | For `schedule_nodes`: maximum parallel jobs                                                               |
 | `persistent`                | boolean  | false      | Whether the action persists and can be claimed by multiple workers                                        |
 
+For `schedule_nodes`, prefer `on_jobs_ready` (gated on the jobs the allocation runs) over
+`on_workflow_start`, even for root jobs — root jobs are ready at init, so the action still fires at
+the start, but tying it to the jobs makes a selective re-run
+(`torc jobs reset-status <ids> --reinit` then `torc submit`) re-schedule only the reset jobs.
+`on_workflow_start` `schedule_nodes` is kept on reinitialize and `torc submit` cannot re-fire it.
+See
+[Re-running part of a workflow](../../specialized/hpc/slurm-workflows.md#re-running-part-of-a-workflow).
+
 ## ResourceMonitorConfig
 
 Configuration for resource usage monitoring.

--- a/docs/src/core/workflows/creating-workflows.md
+++ b/docs/src/core/workflows/creating-workflows.md
@@ -265,7 +265,7 @@ Components to be created:
   Slurm schedulers: 2
   Workflow actions: 3
 
-Submission: Ready for scheduler submission (has on_workflow_start schedule_nodes action)
+Submission: Ready for scheduler submission (has a schedule_nodes action)
 
 Validation: PASSED
 ```

--- a/docs/src/specialized/design/workflow-actions.md
+++ b/docs/src/specialized/design/workflow-actions.md
@@ -27,11 +27,13 @@ actions:
 
 #### `on_workflow_start`
 
-Executes once, at the workflow's first initialization.
+Executes when the workflow is initialized from the top.
 
-**When it fires**: During the first `initialize_jobs`, after jobs are transitioned from
-uninitialized to ready/blocked states. It does **not** fire again on reinitialize — a reinit is not
-a new start (see [Workflow Reinitialization](#workflow-reinitialization)).
+**When it fires**: During a full `initialize_jobs` (the first initialize, or `torc workflows init`,
+which resets every job), after jobs are transitioned from uninitialized to ready/blocked states. It
+does **not** fire again on a _partial_ reinitialize (`torc workflows reinit`,
+`torc jobs reset-status --reinit`, `recover`) — a partial reinit is not a new start (see
+[Workflow Reinitialization](#workflow-reinitialization)).
 
 **Typical use cases**:
 
@@ -376,12 +378,19 @@ flowchart TD
     style terminal fill:#cce5ff,stroke:#004085,color:#004085
 ```
 
-Per trigger:
+The keep logic below applies to a **partial** reinitialize (`reinit`, `reset-status --reinit`,
+`recover`, `regenerate`, `watch`). A **full** initialize — `torc workflows init`, which first resets
+every job — is a clean slate and re-arms **every** action, including `on_workflow_start`; otherwise
+re-running `workflows init` on a workflow that already ran would leave its start actions suppressed
+forever. (The server distinguishes the two by `only_uninitialized`: `false` = full, `true` =
+partial.)
 
-- **`on_workflow_start` → keep.** The workflow starts exactly once in its lifetime; a reinitialize
-  is not a new start. This is what stops plain `reinit` / `reset-status --reinit` from re-running
-  start-time setup or re-submitting the original node count. (A never-fired action keeps
-  `executed = 0` and still fires, so a first real initialize is unaffected.)
+Per trigger (partial reinitialize):
+
+- **`on_workflow_start` → keep.** A partial reinit is not a new start, so this stops plain `reinit`
+  / `reset-status --reinit` from re-running start-time setup or re-submitting the original node
+  count. (A never-fired action keeps `executed = 0` and still fires, so a first real initialize is
+  unaffected; a full `workflows init` re-arms it as noted above.)
 - **`on_jobs_ready` / `on_jobs_complete` → keep iff the gating jobs are still all terminal.** That
   is the _subset_ re-run (the gates were untouched, so the event already happened and is not
   recurring). Re-arm when any gate was reset — the _full_ re-run, where that job will run again and
@@ -418,9 +427,17 @@ _Full re-run_ (the gate itself is re-run):
 With multiple gating jobs, the action is only kept executed when **all** of them remain terminal;
 resetting any one of them re-arms it.
 
-The client-side `recover`/`regenerate` guards (`mark_satisfied_schedule_actions_executed`) remain as
-defense in depth, but the server is now the single point that prevents reinit from resurrecting an
-already-satisfied action, so all entry points are covered uniformly.
+The `recover`/`regenerate` paths keep their own `mark_satisfied_schedule_actions_executed` guard,
+and it is **load-bearing, not just redundant**: those paths take over allocation themselves (they
+submit the user's chosen count, or regenerate recovery actions and submit). After they reset the
+failed jobs and reinitialize, the server _correctly_ re-arms those jobs' `on_jobs_ready` actions
+(right for plain `reinit`, where they should fire), but the reset gate is now `Ready`, so the action
+is satisfied and would fire on the first worker and submit a second allocation. `mark_satisfied`
+marks those satisfied actions executed so recover's own submission is not duplicated. The server
+cannot do this — it can't tell "recover is about to allocate these jobs itself" from "plain reinit,
+the action should fire." For the `on_workflow_start` and already-terminal-gated cases the guard is
+now a no-op (the server already keeps those executed, and `mark_satisfied` skips already-executed
+actions); the reset-`on_jobs_ready` case is the one it still handles.
 
 ### Re-running a Slurm workflow
 

--- a/docs/src/specialized/design/workflow-actions.md
+++ b/docs/src/specialized/design/workflow-actions.md
@@ -267,6 +267,20 @@ Dynamically allocate compute resources from a Slurm scheduler.
 - Cost optimization (allocate only when needed)
 - Separating workflow phases with different resource requirements
 
+**Recommended: tie `schedule_nodes` to jobs with `on_jobs_ready`.** Prefer `on_jobs_ready` (gated on
+the jobs the allocation will run) over `on_workflow_start` for scheduling — even for root jobs,
+which are `Ready` at init so the action fires at the same moment. The reason is re-run safety: when
+you reset a subset of jobs and reinitialize, a job-gated action whose jobs were reset is re-armed,
+so the next `torc submit` re-schedules exactly those jobs (see
+[Re-running on Slurm](#re-running-a-slurm-workflow)). An `on_workflow_start` action is kept
+(suppressed) on reinitialize and cannot be re-fired by `submit`, so the reset job would have no
+allocation. `torc slurm generate` now emits `on_jobs_ready[root_jobs]` for no-dependency jobs for
+this reason.
+
+`on_workflow_start` `schedule_nodes` is still valid when a single allocation serves the whole
+workflow (it can't be gated on jobs that aren't all ready at once), but that allocation is not
+selectively re-run-safe — re-run it with `torc recover` or a manual `torc slurm schedule-nodes`.
+
 ## Complete Examples
 
 Refer to this
@@ -407,6 +421,32 @@ resetting any one of them re-arms it.
 The client-side `recover`/`regenerate` guards (`mark_satisfied_schedule_actions_executed`) remain as
 defense in depth, but the server is now the single point that prevents reinit from resurrecting an
 already-satisfied action, so all entry points are covered uniformly.
+
+### Re-running a Slurm workflow
+
+`torc submit` fires **every pending Slurm `schedule_nodes` action**, regardless of trigger type
+(`on_workflow_start` to bootstrap, plus `on_jobs_ready`/`on_jobs_complete` whose gating jobs are
+ready). Combined with the re-arm logic above, this gives a clean selective re-run:
+
+```bash
+torc jobs reset-status <id1> <id2> ... --reinit   # reset the jobs to re-run + reinitialize
+torc submit <workflow_id>                          # re-schedule exactly those jobs
+```
+
+Because reinitialize re-arms only the job-gated actions whose jobs were reset (untouched stages stay
+suppressed), the re-armed actions for the reset jobs become pending and `submit` schedules just
+their allocations — nothing for the stages that did not change. Worked example: a workflow with
+separate `on_jobs_ready` `schedule_nodes` actions for regular, big-memory, and GPU job classes;
+reset only the GPU and big-memory jobs and reinitialize, and `submit` re-schedules only the GPU and
+big-memory allocations. Downstream actions (e.g. a postprocess gated on all classes) are not yet
+pending — they fire later, from a running worker, once their jobs become ready
+(`job_runner::check_and_execute_actions`).
+
+This is why job-gated scheduling is recommended over `on_workflow_start` (which `submit` cannot
+re-fire once kept). `submit` itself is one-shot: it submits the currently-pending allocations and
+returns. For an unattended multi-stage re-run, follow it with `torc watch` so that if every worker
+exits (e.g. Slurm walltime) before a later stage's action fires, the stranded action is picked up
+(`torc watch --auto-schedule`).
 
 ## Limitations
 

--- a/docs/src/specialized/design/workflow-actions.md
+++ b/docs/src/specialized/design/workflow-actions.md
@@ -465,6 +465,14 @@ returns. For an unattended multi-stage re-run, follow it with `torc watch` so th
 exits (e.g. Slurm walltime) before a later stage's action fires, the stranded action is picked up
 (`torc watch --auto-schedule`).
 
+`submit` re-fires each action's `num_allocations` **verbatim** — it does not right-size the re-run.
+So the re-run granularity is the action granularity: per-stage/per-class actions reschedule only the
+affected subset, but a single large fan-in action (e.g. one `on_jobs_ready` gating 100k jobs with
+`num_allocations: 500`) re-arms as a whole when any subset is reset, and `submit` re-submits its
+full count even if only a handful of jobs need to re-run. For a right-sized partial re-run of such a
+stage, use `torc recover`, which regenerates `schedule_nodes` actions sized to the actually-pending
+jobs (and suppresses the spec's full-size action via `mark_satisfied_schedule_actions_executed`).
+
 ## Limitations
 
 1. **No Action Dependencies**: Actions cannot depend on other actions completing

--- a/docs/src/specialized/hpc/slurm-workflows.md
+++ b/docs/src/specialized/hpc/slurm-workflows.md
@@ -104,19 +104,27 @@ Each job gets its own Slurm scheduler configuration based on its resource requir
 
 ### 2. Staged Resource Allocation
 
-Torc analyzes job dependencies and creates **staged workflow actions**:
+Torc analyzes job dependencies and creates **staged workflow actions**. Every scheduler is tied to
+the jobs it runs via an `on_jobs_ready` action:
 
-- **Jobs without dependencies** trigger `on_workflow_start` — resources are allocated immediately
-- **Jobs with dependencies** trigger `on_jobs_ready` — resources are allocated only when the job
-  becomes ready to run
+- **Jobs without dependencies** — `on_jobs_ready` gated on those (root) jobs. They are ready as soon
+  as the workflow is initialized, so their resources are allocated immediately, just as the workflow
+  starts.
+- **Jobs with dependencies** — `on_jobs_ready` gated on those jobs, so resources are allocated only
+  when the jobs become ready to run.
 
 This prevents wasting allocation time on resources that aren't needed yet. For example, in the
 workflow above:
 
-- `preprocess` resources are allocated at workflow start
+- `preprocess` resources are allocated at workflow start (it is a root job)
 - `train_model` resources are allocated when `preprocess` completes
 - `evaluate` resources are allocated when `train_model` completes
 - `generate_report` resources are allocated when `evaluate` completes
+
+Tying every scheduler to its jobs (rather than scheduling root jobs with `on_workflow_start`) also
+makes re-runs work: if you reset a subset of jobs and reinitialize, only those jobs' actions are
+re-armed, so a follow-up `torc submit` re-schedules exactly the jobs being re-run. See
+[Re-running part of a workflow](#re-running-part-of-a-workflow) below.
 
 ### 3. Walltime Calculation
 
@@ -370,8 +378,9 @@ slurm_schedulers:
   # ... more schedulers ...
 
 actions:
-  - trigger_type: on_workflow_start
+  - trigger_type: on_jobs_ready
     action_type: schedule_nodes
+    jobs: [preprocess]
     scheduler: preprocess_scheduler
     scheduler_type: slurm
     num_allocations: 1
@@ -386,11 +395,51 @@ actions:
   # ... more actions ...
 ```
 
+Every scheduler is gated on the jobs it runs with `on_jobs_ready` — including root jobs like
+`preprocess`, which are ready at workflow start. This is what makes a re-run reschedule only the
+affected jobs.
+
 Save the output to inspect or modify before submission:
 
 ```bash
 torc slurm generate --account myproject workflow.yaml -o workflow_with_schedulers.yaml
 ```
+
+## Re-running part of a workflow
+
+Because every scheduler is tied to its jobs with `on_jobs_ready`, you can re-run a subset of a
+finished (or partially failed) workflow and have only the affected allocations re-submitted:
+
+```bash
+# Reset the jobs you want to re-run (downstream jobs reset automatically), then reinitialize:
+torc jobs reset-status <id1> <id2> ... --reinit
+
+# Re-submit: only the reset jobs' allocations are scheduled.
+torc submit <workflow_id>
+```
+
+How it works: `reinitialize` re-arms only the actions whose jobs were reset; actions for untouched
+jobs stay suppressed (so they are not re-scheduled and do not submit duplicate allocations).
+`torc submit` then fires every pending `schedule_nodes` action — which is exactly the reset jobs'
+actions. Downstream actions whose jobs aren't ready yet are fired later by a running worker, as
+their dependencies complete.
+
+For example, with separate job classes each on their own partition (see
+[`examples/yaml/workflow_actions_multi_class_slurm.yaml`](https://github.com/NatLabRockies/torc/blob/main/examples/yaml/workflow_actions_multi_class_slurm.yaml)),
+resetting only the GPU and big-memory jobs re-schedules only the GPU and big-memory allocations; the
+regular-job allocations are left alone.
+
+> **Note:** `torc submit` is one-shot — it submits the currently-pending allocations and returns.
+> For an unattended multi-stage re-run, follow it with `torc watch` so that if every worker exits
+> (e.g. Slurm walltime) before a later stage's action fires, the stranded action is picked up. For a
+> guided re-run that also sizes allocations from prior runs, use
+> [`torc recover`](../fault-tolerance/automatic-recovery.md).
+
+> **Tip:** This is why auto-generated and recommended specs use `on_jobs_ready` (tied to jobs)
+> rather than `on_workflow_start` for `schedule_nodes`. An `on_workflow_start` action is kept (not
+> re-armed) on reinitialize and `torc submit` cannot re-fire it, so a reset root job would have no
+> allocation. `on_workflow_start` `schedule_nodes` is still fine for a single allocation that serves
+> the whole workflow, but such an allocation isn't selectively re-run-safe.
 
 ## Torc Server Considerations
 

--- a/docs/src/specialized/hpc/slurm-workflows.md
+++ b/docs/src/specialized/hpc/slurm-workflows.md
@@ -429,6 +429,22 @@ For example, with separate job classes each on their own partition (see
 resetting only the GPU and big-memory jobs re-schedules only the GPU and big-memory allocations; the
 regular-job allocations are left alone.
 
+> **Important — `submit` does not right-size the re-run.** `torc submit` re-fires each pending
+> action with the `num_allocations` from its spec, **verbatim**. The granularity of a re-run is
+> therefore the granularity of your actions:
+>
+> - With **per-stage / per-class** actions (as above), resetting a subset re-arms only the matching
+>   actions, so `submit` schedules only those — the common, efficient case.
+> - With a **single large fan-in** action (e.g. one `on_jobs_ready` action gating 100k jobs with
+>   `num_allocations: 500`), resetting _any_ subset re-arms that one action, and `submit` submits
+>   its full `num_allocations` (500) — even if only 100 jobs need to re-run. The jobs still run (the
+>   surplus workers find no claimable work and idle out), but it badly over-allocates.
+>
+> For a right-sized partial re-run of a large fan-in stage, use
+> [`torc recover`](../fault-tolerance/automatic-recovery.md) instead: it regenerates
+> `schedule_nodes` actions sized to the jobs that are actually pending (and suppresses the spec's
+> full-size action), so it allocates for the 100 jobs rather than the whole stage.
+
 > **Note:** `torc submit` is one-shot — it submits the currently-pending allocations and returns.
 > For an unattended multi-stage re-run, follow it with `torc watch` so that if every worker exits
 > (e.g. Slurm walltime) before a later stage's action fires, the stranded action is picked up. For a

--- a/docs/src/specialized/hpc/slurm-workflows.md
+++ b/docs/src/specialized/hpc/slurm-workflows.md
@@ -457,6 +457,43 @@ regular-job allocations are left alone.
 > allocation. `on_workflow_start` `schedule_nodes` is still fine for a single allocation that serves
 > the whole workflow, but such an allocation isn't selectively re-run-safe.
 
+### Manually scheduling a re-run with `torc slurm schedule-nodes`
+
+If you want to provide the compute yourself instead of letting `submit` fire the actions — for
+example "run my 10 reset jobs on 1 node" — use `torc slurm schedule-nodes`:
+
+```bash
+torc jobs reset-status <id1> ... <id10> --reinit
+torc slurm schedule-nodes -n1 <workflow_id>
+```
+
+A worker started this way still claims the workflow's own **pending** `schedule_nodes` actions and
+submits their allocations. So if the reinit left a coarse action re-armed (e.g. an `on_jobs_ready`
+action gating the whole stage), that worker would fire its full `num_allocations` on top of the one
+you requested. To prevent surprises, `schedule-nodes` checks for pending `schedule_nodes` actions
+and **prompts** you to suppress them, proceed (let them fire), or cancel. For non-interactive use:
+
+- `--suppress-actions` — mark the pending actions executed first, so only your `-n` request is
+  submitted.
+- `--no-prompts` — skip the prompt and proceed (let the actions fire); the historical behavior.
+
+(`torc recover` does the suppression automatically and additionally right-sizes the allocation to
+the pending jobs, so it is usually the better tool for a partial re-run.)
+
+### Choosing a stage's scheduler trigger: upstream vs. the stage's own jobs
+
+For `schedule_nodes`, **what you gate the action on** determines how subset re-runs behave:
+
+- **Gate on the stage's own jobs** (`on_jobs_ready[<this stage's jobs>]`) — resetting any of them
+  re-arms the action, so `submit` re-schedules them automatically. Best for **per-class /
+  per-stage** actions where auto re-run at the action's `num_allocations` is what you want.
+- **Gate on the upstream job** whose completion unlocks the stage (`on_jobs_complete[<upstream>]`) —
+  resetting the stage's own jobs leaves the upstream terminal, so the action stays **suppressed**
+  and does not re-fire. Best for a **large fan-in stage** you expect to re-run in subsets: the
+  coarse action won't over-allocate, and you provide the compute with `torc slurm schedule-nodes` or
+  `torc recover`. The trade-off is that reinit won't auto-reschedule the reset jobs — which for a
+  coarse stage is what you want anyway.
+
 ## Torc Server Considerations
 
 The Torc server must be accessible to compute nodes. Options include:

--- a/docs/src/specialized/hpc/slurm.md
+++ b/docs/src/specialized/hpc/slurm.md
@@ -88,12 +88,12 @@ actions:
 
 ### Action Trigger Types
 
-| Trigger                | Description                             |
-| ---------------------- | --------------------------------------- |
-| `on_workflow_start`    | Fires once at the workflow's first init |
-| `on_jobs_ready`        | Fires when specified jobs become ready  |
-| `on_jobs_complete`     | Fires when specified jobs complete      |
-| `on_workflow_complete` | Fires when all jobs complete            |
+| Trigger                | Description                                                                                                                   |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `on_workflow_start`    | Fires at the workflow's first init, and again on a full re-init (`torc workflows init`); a partial reinit keeps it suppressed |
+| `on_jobs_ready`        | Fires when specified jobs become ready                                                                                        |
+| `on_jobs_complete`     | Fires when specified jobs complete                                                                                            |
+| `on_workflow_complete` | Fires when all jobs complete                                                                                                  |
 
 > **Recommended for `schedule_nodes`: use `on_jobs_ready` gated on the jobs the allocation runs**,
 > even for root jobs (which are ready at init, so it still fires at the start). This ties each

--- a/docs/src/specialized/hpc/slurm.md
+++ b/docs/src/specialized/hpc/slurm.md
@@ -88,12 +88,20 @@ actions:
 
 ### Action Trigger Types
 
-| Trigger                | Description                            |
-| ---------------------- | -------------------------------------- |
-| `on_workflow_start`    | Fires when workflow is submitted       |
-| `on_jobs_ready`        | Fires when specified jobs become ready |
-| `on_jobs_complete`     | Fires when specified jobs complete     |
-| `on_workflow_complete` | Fires when all jobs complete           |
+| Trigger                | Description                             |
+| ---------------------- | --------------------------------------- |
+| `on_workflow_start`    | Fires once at the workflow's first init |
+| `on_jobs_ready`        | Fires when specified jobs become ready  |
+| `on_jobs_complete`     | Fires when specified jobs complete      |
+| `on_workflow_complete` | Fires when all jobs complete            |
+
+> **Recommended for `schedule_nodes`: use `on_jobs_ready` gated on the jobs the allocation runs**,
+> even for root jobs (which are ready at init, so it still fires at the start). This ties each
+> allocation to its jobs, so a selective re-run (`torc jobs reset-status <ids> --reinit` then
+> `torc submit`) re-schedules only the reset jobs. An `on_workflow_start` `schedule_nodes` action is
+> kept (not re-armed) on reinitialize and `torc submit` cannot re-fire it, so a reset job would have
+> no allocation. `on_workflow_start` is still fine for a single allocation serving the whole
+> workflow.
 
 ### Assigning Jobs to Schedulers
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -62,6 +62,10 @@ examples/
   actions
 - **`workflow_actions_simple_slurm`** - Multi-stage workflow with automated Slurm node scheduling
   per stage
+- **`workflow_actions_multi_class_slurm`** (YAML) - Three job classes (regular, big-memory, GPU),
+  each scheduled on its own partition via an `on_jobs_ready` action, plus a postprocess job. Shows
+  the re-run-safe pattern: reset a subset of jobs + `--reinit`, then `torc submit` re-schedules only
+  those classes
 - **`workflow_actions_data_pipeline`** - Data pipeline with automated resource management
 - **`workflow_actions_ml_training`** - ML training with dynamic GPU allocation using on_jobs_ready
   actions

--- a/examples/json/workflow_actions_simple_slurm.json5
+++ b/examples/json/workflow_actions_simple_slurm.json5
@@ -74,8 +74,12 @@
   // Workflow actions
   "actions": [
     {
-      "trigger_type": "on_workflow_start",
+      // Tied to the setup job via on_jobs_ready (not on_workflow_start) so the allocation is
+      // re-run-safe: resetting setup + reinitializing re-schedules it on the next `torc submit`.
+      // setup is a root job, so this fires at init just like on_workflow_start would.
+      "trigger_type": "on_jobs_ready",
       "action_type": "schedule_nodes",
+      "jobs": ["setup"],
       "scheduler": "setup_scheduler",
       "scheduler_type": "slurm",
       "num_allocations": 1

--- a/examples/json/workflow_actions_simple_slurm.json5
+++ b/examples/json/workflow_actions_simple_slurm.json5
@@ -76,7 +76,6 @@
     {
       // Tied to the setup job via on_jobs_ready (not on_workflow_start) so the allocation is
       // re-run-safe: resetting setup + reinitializing re-schedules it on the next `torc submit`.
-      // setup is a root job, so this fires at init just like on_workflow_start would.
       "trigger_type": "on_jobs_ready",
       "action_type": "schedule_nodes",
       "jobs": ["setup"],

--- a/examples/kdl/workflow_actions_simple_slurm.kdl
+++ b/examples/kdl/workflow_actions_simple_slurm.kdl
@@ -61,10 +61,12 @@ job "finalize" {
 
 // Actions
 
-// Allocate resources for setup stage
+// Allocate resources for the setup stage. Tied to the setup job via on_jobs_ready (not
+// on_workflow_start) so the allocation is re-run-safe; setup is a root job, so it fires at init.
 action {
-    trigger_type "on_workflow_start"
+    trigger_type "on_jobs_ready"
     action_type "schedule_nodes"
+    job "setup"
     scheduler "setup_scheduler"
     scheduler_type "slurm"
     num_allocations 1

--- a/examples/subgraphs/subgraphs_workflow.json5
+++ b/examples/subgraphs/subgraphs_workflow.json5
@@ -162,9 +162,10 @@
   // ACTIONS - Schedule compute nodes when jobs become ready
   // ============================================================================
   actions: [
-    // Stage 1: Triggered at workflow start
+    // Stage 1: prep jobs are roots (Ready at init). Tied to them via on_jobs_ready (not
+    // on_workflow_start) so resetting prep + reinitializing re-schedules on the next `torc submit`.
     {
-      trigger_type: "on_workflow_start",
+      trigger_type: "on_jobs_ready",
       action_type: "schedule_nodes",
       scheduler: "prep_sched",
       scheduler_type: "slurm",

--- a/examples/subgraphs/subgraphs_workflow.kdl
+++ b/examples/subgraphs/subgraphs_workflow.kdl
@@ -207,9 +207,10 @@ job "final" {
 // ACTIONS - Schedule compute nodes when jobs become ready
 // ==========================================================================
 
-// Stage 1: Triggered at workflow start
+// Stage 1: prep jobs are roots (Ready at init). Tied to them via on_jobs_ready (not
+// on_workflow_start) so resetting prep + reinitializing re-schedules on the next `torc submit`.
 action {
-    trigger_type "on_workflow_start"
+    trigger_type "on_jobs_ready"
     action_type "schedule_nodes"
     scheduler "prep_sched"
     scheduler_type "slurm"

--- a/examples/subgraphs/subgraphs_workflow.yaml
+++ b/examples/subgraphs/subgraphs_workflow.yaml
@@ -196,8 +196,9 @@ slurm_schedulers:
 # ACTIONS - Schedule compute nodes when jobs become ready
 # ==============================================================================
 actions:
-  # Stage 1: Triggered at workflow start
-  - trigger_type: on_workflow_start
+  # Stage 1: prep jobs are roots (Ready at init). Tied to them via on_jobs_ready (not
+  # on_workflow_start) so resetting prep + reinitializing re-schedules on the next `torc submit`.
+  - trigger_type: on_jobs_ready
     action_type: schedule_nodes
     scheduler: prep_sched
     scheduler_type: slurm

--- a/examples/yaml/workflow_actions_multi_class_slurm.yaml
+++ b/examples/yaml/workflow_actions_multi_class_slurm.yaml
@@ -1,0 +1,127 @@
+name: "Multi-Class Slurm Workflow"
+description: >
+  Three classes of jobs that each need a different Slurm partition, plus a single
+  postprocess job that depends on all of them. Each class is scheduled by its own
+  on_jobs_ready schedule_nodes action.
+
+  Why on_jobs_ready (not on_workflow_start): tying each allocation to the jobs it
+  runs makes selective re-runs work. If a later problem means only some classes
+  must re-run, reset just those jobs and reinitialize, then submit again:
+
+      torc jobs reset-status <gpu/bigmem job ids> --reinit
+      torc submit <workflow_id>
+
+  reinitialize re-arms only the actions whose jobs were reset, so `torc submit`
+  re-schedules exactly those classes. Untouched classes stay suppressed (no
+  duplicate allocations), and the postprocess action fires later, from a running
+  worker, once its dependencies complete. (For an unattended multi-stage re-run,
+  follow `submit` with `torc watch`.)
+
+# 10 jobs per class via parameter expansion (regular_01..10, bigmem_01..10, gpu_01..10).
+jobs:
+  # Regular CPU jobs: two per compute node (each requests half the node's CPUs).
+  - name: "regular_{i:02d}"
+    command: "echo 'regular work {i}' && sleep 5"
+    resource_requirements: "regular"
+    parameters:
+      i: "1:10"
+
+  # Big-memory jobs: one per node on a high-memory partition.
+  - name: "bigmem_{i:02d}"
+    command: "echo 'big-memory work {i}' && sleep 5"
+    resource_requirements: "bigmem"
+    parameters:
+      i: "1:10"
+
+  # GPU jobs: one per node on a GPU partition.
+  - name: "gpu_{i:02d}"
+    command: "echo 'gpu work {i}' && sleep 5"
+    resource_requirements: "gpu"
+    parameters:
+      i: "1:10"
+
+  # Aggregates results from every class once all of them complete.
+  - name: "postprocess"
+    command: "echo 'aggregate results' && sleep 2"
+    resource_requirements: "regular"
+    depends_on_regexes:
+      - "regular_.*"
+      - "bigmem_.*"
+      - "gpu_.*"
+
+resource_requirements:
+  # Half a 36-CPU node, so two regular jobs pack onto one node.
+  - name: "regular"
+    num_cpus: 18
+    num_gpus: 0
+    num_nodes: 1
+    memory: "32g"
+    runtime: "PT30M"
+
+  - name: "bigmem"
+    num_cpus: 36
+    num_gpus: 0
+    num_nodes: 1
+    memory: "360g"
+    runtime: "PT1H"
+
+  - name: "gpu"
+    num_cpus: 16
+    num_gpus: 2
+    num_nodes: 1
+    memory: "64g"
+    runtime: "PT1H"
+
+slurm_schedulers:
+  - name: "regular_scheduler"
+    account: "demo_project"
+    nodes: 1
+    walltime: "00:30:00"
+
+  - name: "bigmem_scheduler"
+    account: "demo_project"
+    nodes: 1
+    walltime: "01:00:00"
+
+  - name: "gpu_scheduler"
+    account: "demo_project"
+    nodes: 1
+    walltime: "01:00:00"
+
+  - name: "postprocess_scheduler"
+    account: "demo_project"
+    nodes: 1
+    walltime: "00:30:00"
+
+actions:
+  # One allocation per pair of regular jobs (10 jobs, 2 per node => 5 allocations).
+  - trigger_type: "on_jobs_ready"
+    action_type: "schedule_nodes"
+    job_name_regexes: ["regular_.*"]
+    scheduler: "regular_scheduler"
+    scheduler_type: "slurm"
+    num_allocations: 5
+
+  # One allocation per big-memory job.
+  - trigger_type: "on_jobs_ready"
+    action_type: "schedule_nodes"
+    job_name_regexes: ["bigmem_.*"]
+    scheduler: "bigmem_scheduler"
+    scheduler_type: "slurm"
+    num_allocations: 10
+
+  # One allocation per GPU job.
+  - trigger_type: "on_jobs_ready"
+    action_type: "schedule_nodes"
+    job_name_regexes: ["gpu_.*"]
+    scheduler: "gpu_scheduler"
+    scheduler_type: "slurm"
+    num_allocations: 10
+
+  # Single allocation for postprocess once all classes complete.
+  - trigger_type: "on_jobs_ready"
+    action_type: "schedule_nodes"
+    jobs: ["postprocess"]
+    scheduler: "postprocess_scheduler"
+    scheduler_type: "slurm"
+    num_allocations: 1

--- a/examples/yaml/workflow_actions_simple_slurm.yaml
+++ b/examples/yaml/workflow_actions_simple_slurm.yaml
@@ -61,9 +61,13 @@ slurm_schedulers:
     walltime: "00:30:00"
 
 actions:
-  # Allocate resources for setup stage
-  - trigger_type: "on_workflow_start"
+  # Allocate resources for the setup stage. Tied to the setup job via on_jobs_ready (rather than
+  # on_workflow_start) so the allocation is re-run-safe: resetting setup and reinitializing re-arms
+  # this action, and the next `torc submit` re-schedules it. (setup is a root job, so on_jobs_ready
+  # fires at init, exactly like on_workflow_start would.)
+  - trigger_type: "on_jobs_ready"
     action_type: "schedule_nodes"
+    jobs: ["setup"]
     scheduler: "setup_scheduler"
     scheduler_type: "slurm"
     num_allocations: 1

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -462,6 +462,11 @@ EXAMPLES:
         /// generated Slurm submission scripts as `--claim-backoff-max-secs`.
         #[arg(long, value_parser = crate::client::utils::parse_finite_non_negative_secs)]
         claim_backoff_max_secs: Option<f64>,
+        /// Do not prompt to review pending schedule_nodes actions on a re-submission; proceed and
+        /// fire them with their configured allocation counts. Use for non-interactive/scripted runs.
+        /// A non-TTY stdin implies this automatically.
+        #[arg(long, default_value = "false")]
+        no_prompts: bool,
     },
     /// Watch a workflow and automatically recover from failures
     ///

--- a/src/client/commands/slurm.rs
+++ b/src/client/commands/slurm.rs
@@ -1705,6 +1705,10 @@ pub fn handle_pending_schedule_actions(
              you requested.",
             count, total, requested_allocations
         );
+        eprintln!(
+            "  See them with: torc workflows list-actions {}",
+            workflow_id
+        );
     };
 
     let do_suppress = if suppress_actions {

--- a/src/client/commands/slurm.rs
+++ b/src/client/commands/slurm.rs
@@ -1691,10 +1691,12 @@ pub fn handle_pending_schedule_actions(
     let total: i64 = firable
         .iter()
         .map(|a| {
+            // Missing num_allocations defaults to 1 at execution time (see workflow_manager.rs /
+            // job_runner.rs); count it the same here so the warning doesn't understate the total.
             a.action_config
                 .get("num_allocations")
                 .and_then(|v| v.as_i64())
-                .unwrap_or(0)
+                .unwrap_or(1)
         })
         .sum();
 
@@ -1744,10 +1746,22 @@ pub fn handle_pending_schedule_actions(
             config,
             workflow_id,
         )?;
+        // Persistent actions intentionally cannot be suppressed (mark_satisfied_... leaves them
+        // armed so multiple workers can claim them); don't count them as suppressed, and tell the
+        // user they will still re-fire.
+        let persistent_count = firable.iter().filter(|a| a.persistent).count();
+        let suppressed = count - persistent_count;
         eprintln!(
             "Suppressed {} pending schedule_nodes action(s) so the worker(s) started here will not re-fire them.",
-            count
+            suppressed
         );
+        if persistent_count > 0 {
+            eprintln!(
+                "  Note: {} persistent action(s) cannot be suppressed and will still re-fire, \
+                 submitting their own allocations. Remove or disable them to avoid duplicates.",
+                persistent_count
+            );
+        }
     }
     Ok(())
 }

--- a/src/client/commands/slurm.rs
+++ b/src/client/commands/slurm.rs
@@ -1916,6 +1916,14 @@ pub fn review_submit_pending_actions(
             a.action_type == "schedule_nodes"
                 && !a.is_recovery
                 && !a.executed
+                // Restrict to the trigger types `start()` actually fires from the login node (see
+                // its get_pending_actions call). A schedule_nodes action with another trigger type
+                // (e.g. on_worker_start) is never fired by submit, so listing it here -- and letting
+                // the user disable/override it -- would be misleading.
+                && matches!(
+                    a.trigger_type.as_str(),
+                    "on_workflow_start" | "on_jobs_ready" | "on_jobs_complete"
+                )
                 && a.action_config
                     .get("scheduler_type")
                     .and_then(|v| v.as_str())
@@ -2090,7 +2098,18 @@ pub fn review_submit_pending_actions(
             continue;
         }
         match crate::client::utils::claim_action(config, workflow_id, *id, None, 20) {
-            Ok(_) => {}
+            // Claimed by us -> suppressed as intended.
+            Ok(true) => {}
+            // claim_action returns Ok(false) on a 409: the action was already claimed by a
+            // concurrent submitter or a worker, who will fire it. We could not disable it, so warn
+            // instead of silently reporting it disabled.
+            Ok(false) => {
+                eprintln!(
+                    "  Warning: could not disable action {} -- it was already claimed by another \
+                     submitter or worker and may still fire.",
+                    id
+                );
+            }
             Err(e) => {
                 return Err(format!(
                     "failed to disable (claim) action {}: {}; aborting so it does not fire unexpectedly",

--- a/src/client/commands/slurm.rs
+++ b/src/client/commands/slurm.rs
@@ -439,6 +439,20 @@ EXAMPLES:
         /// Scheduler config ID (ignored if --auto is set)
         #[arg(long)]
         scheduler_config_id: Option<i64>,
+        /// Mark the workflow's already-pending `schedule_nodes` actions executed before submitting,
+        /// so the worker(s) started here do not also fire them and submit their own allocations.
+        ///
+        /// Use this when manually scheduling a re-run (e.g. after `jobs reset-status --reinit`):
+        /// without it, a pending action re-armed by the reinit is claimed by the new worker and
+        /// submits its full `num_allocations` on top of what you requested. `torc recover` does this
+        /// suppression automatically (and right-sizes the allocation). Implies a non-interactive
+        /// "suppress" answer, so no prompt is shown.
+        #[arg(long, default_value = "false")]
+        suppress_actions: bool,
+        /// Do not prompt about pending `schedule_nodes` actions; proceed and let the worker(s) fire
+        /// them (unless `--suppress-actions` is also given). Use for non-interactive/scripted runs.
+        #[arg(long, default_value = "false")]
+        no_prompts: bool,
     },
     /// Parse Slurm log files for known error messages
     #[command(
@@ -1318,6 +1332,8 @@ pub fn handle_slurm_commands(config: &Configuration, command: &SlurmCommands, fo
             poll_interval,
             claim_backoff_max_secs,
             scheduler_config_id,
+            suppress_actions,
+            no_prompts,
         } => {
             let user_name = get_env_user_name();
             let wf_id = workflow_id.unwrap_or_else(|| {
@@ -1388,6 +1404,23 @@ pub fn handle_slurm_commands(config: &Configuration, command: &SlurmCommands, fo
                     std::process::exit(1);
                 })
             });
+
+            // A worker started here claims the workflow's own pending schedule_nodes actions and
+            // submits their allocations. After `jobs reset-status --reinit`, a re-armed action can be
+            // pending again, so it would fire its full num_allocations on top of what is requested
+            // here. Detect that and let the user decide: suppress those actions, proceed anyway, or
+            // cancel. `--suppress-actions` answers "suppress"; `--no-prompts` (or a non-interactive
+            // stdin) answers "proceed" unless `--suppress-actions` is set.
+            if let Err(e) = handle_pending_schedule_actions(
+                config,
+                wf_id,
+                *num_hpc_jobs,
+                *suppress_actions,
+                *no_prompts,
+            ) {
+                eprintln!("Error: {}", e);
+                std::process::exit(1);
+            }
 
             // Use poll_interval from CLI arg, or fall back to config file value
             let torc_config = TorcConfig::load().unwrap_or_default();
@@ -1619,6 +1652,100 @@ where
     E: std::fmt::Display,
 {
     result.map_err(|err| Box::new(RetryApiError(err.to_string())) as Box<dyn std::error::Error>)
+}
+
+/// Handle the workflow's own pending `schedule_nodes` actions before a manual `schedule-nodes`
+/// submission.
+///
+/// A worker started by `schedule-nodes` claims pending `on_jobs_ready`/`on_jobs_complete`
+/// `schedule_nodes` actions and submits their allocations. After `jobs reset-status --reinit` a
+/// re-armed action can be pending again, so it would fire its full `num_allocations` on top of what
+/// the user asked for here. This surfaces that:
+///
+/// - `suppress_actions` → mark those actions executed (so they don't fire), no prompt.
+/// - non-interactive (`no_prompts`, or stdin is not a TTY) → warn and proceed (let them fire), the
+///   historical behavior; pass `--suppress-actions` to prevent it.
+/// - interactive → prompt the user to suppress / proceed / cancel.
+///
+/// Returns `Err` if the pending-actions check or the suppression fails; cancellation exits the
+/// process.
+pub fn handle_pending_schedule_actions(
+    config: &Configuration,
+    workflow_id: i64,
+    requested_allocations: i32,
+    suppress_actions: bool,
+    no_prompts: bool,
+) -> Result<(), String> {
+    use std::io::{IsTerminal, Write};
+
+    let pending = apis::workflow_actions_api::get_pending_actions(config, workflow_id, None)
+        .map_err(|e| format!("could not check for pending schedule_nodes actions: {}", e))?;
+    let firable: Vec<_> = pending
+        .into_iter()
+        .filter(|a| a.action_type == "schedule_nodes" && !a.is_recovery)
+        .collect();
+    if firable.is_empty() {
+        return Ok(());
+    }
+    let count = firable.len();
+    let total: i64 = firable
+        .iter()
+        .map(|a| {
+            a.action_config
+                .get("num_allocations")
+                .and_then(|v| v.as_i64())
+                .unwrap_or(0)
+        })
+        .sum();
+
+    let warn = || {
+        eprintln!(
+            "Warning: {} pending schedule_nodes action(s) (~{} allocation(s) total) will be claimed \
+             by the worker(s) this command starts and submit their own allocations, on top of the {} \
+             you requested.",
+            count, total, requested_allocations
+        );
+    };
+
+    let do_suppress = if suppress_actions {
+        true
+    } else if no_prompts || !std::io::stdin().is_terminal() {
+        // Non-interactive: warn and proceed (let the actions fire) — the historical behavior.
+        warn();
+        eprintln!("  Proceeding without suppressing; pass --suppress-actions to prevent this.");
+        false
+    } else {
+        // Interactive: let the user choose.
+        warn();
+        eprint!(
+            "Suppress these actions ([s]), proceed and let them fire ([p]), or cancel ([c])? [s/p/c]: "
+        );
+        let _ = std::io::stderr().flush();
+        let mut input = String::new();
+        std::io::stdin()
+            .read_line(&mut input)
+            .map_err(|e| format!("failed to read input: {}", e))?;
+        match input.trim().to_lowercase().as_str() {
+            "s" | "suppress" => true,
+            "p" | "proceed" => false,
+            _ => {
+                eprintln!("Cancelled.");
+                std::process::exit(0);
+            }
+        }
+    };
+
+    if do_suppress {
+        crate::client::commands::recover::mark_satisfied_schedule_actions_executed(
+            config,
+            workflow_id,
+        )?;
+        eprintln!(
+            "Suppressed {} pending schedule_nodes action(s) so the worker(s) started here will not re-fire them.",
+            count
+        );
+    }
+    Ok(())
 }
 
 /// Result indicating success or failure

--- a/src/client/commands/slurm.rs
+++ b/src/client/commands/slurm.rs
@@ -4899,6 +4899,43 @@ pub struct SchedulerInfo {
     pub has_dependencies: bool,
 }
 
+/// Fire every pending `schedule_nodes` action for the workflow via `WorkflowManager::start` --
+/// the same path `torc submit` uses -- and return the number of Slurm allocations submitted.
+///
+/// `handle_regenerate --submit` calls this instead of scheduling allocations directly, so recovery
+/// schedules nodes exclusively through actions. The workflow is already initialized at this point,
+/// so `start` skips initialization and only claims/executes the pending (ready-now) recovery
+/// actions; deferred recovery actions remain Waiting for a worker to fire later.
+fn fire_pending_schedule_nodes_actions(
+    config: &Configuration,
+    workflow_id: i64,
+    output_dir: &Path,
+    poll_interval: Option<i32>,
+) -> Result<i64, String> {
+    let workflow = utils::send_with_retries(
+        config,
+        || apis::workflows_api::get_workflow(config, workflow_id),
+        WAIT_FOR_HEALTHY_DATABASE_MINUTES,
+    )
+    .map_err(|e| format!("Failed to fetch workflow {}: {}", workflow_id, e))?;
+
+    let torc_config = TorcConfig::load().unwrap_or_default();
+    let workflow_manager = WorkflowManager::new(config.clone(), torc_config, workflow);
+
+    let outcome = workflow_manager
+        .start(
+            false, // force
+            None,  // max_parallel_jobs_override
+            output_dir.to_str().unwrap_or("torc_output"),
+            poll_interval,
+            None, // claim_backoff_max_secs_override
+            &std::collections::HashMap::new(),
+        )
+        .map_err(|e| format!("Failed to fire schedule_nodes actions: {}", e))?;
+
+    Ok(outcome.allocations_submitted as i64)
+}
+
 /// Handle the regenerate command - regenerates Slurm schedulers for pending jobs
 #[allow(clippy::too_many_arguments, clippy::result_large_err)]
 fn handle_regenerate(
@@ -4921,7 +4958,6 @@ fn handle_regenerate(
 ) {
     // Load HPC config and registry
     let torc_config = TorcConfig::load().unwrap_or_default();
-    let effective_poll_interval = poll_interval.unwrap_or(torc_config.client.slurm.poll_interval);
     let registry = create_registry_with_config_public(&torc_config.client.hpc);
 
     // Get the HPC profile
@@ -5375,7 +5411,17 @@ fn handle_regenerate(
         }
     }
 
-    // Create recovery actions for deferred groups (from planned actions with is_recovery=true)
+    // Map each created scheduler to whether its jobs still depend on unfinished work. A ready-now
+    // scheduler (no pending dependencies) gets a Pending recovery action that the submit path below
+    // fires immediately; a deferred scheduler gets a Waiting action that a running worker fires once
+    // the gate jobs complete.
+    let scheduler_has_deps: HashMap<&str, bool> = schedulers_created
+        .iter()
+        .map(|s| (s.name.as_str(), s.has_dependencies))
+        .collect();
+
+    // Create recovery actions tying each generated scheduler to its jobs (one per generated
+    // scheduler, from planned actions with is_recovery=true).
     for action in &plan.actions {
         if !action.is_recovery {
             continue; // Skip non-recovery actions
@@ -5422,6 +5468,20 @@ fn handle_regenerate(
             "num_allocations": action.num_allocations,
         });
 
+        let has_dependencies = scheduler_has_deps
+            .get(action.scheduler_name.as_str())
+            .copied()
+            .unwrap_or(false);
+        // A ready-now action's gate jobs are all satisfied (Ready) right now, so arm it to Pending:
+        // trigger_count == required_triggers, which the server sets to job_ids.len() for job-gated
+        // triggers. A deferred action stays Waiting (0) until its gate jobs complete and a worker
+        // fires it.
+        let trigger_count = if has_dependencies {
+            0
+        } else {
+            job_ids.len() as i64
+        };
+
         let action_body = models::WorkflowActionModel {
             id: None,
             workflow_id,
@@ -5429,7 +5489,7 @@ fn handle_regenerate(
             action_type: "schedule_nodes".to_string(),
             action_config,
             job_ids: Some(job_ids.clone()),
-            trigger_count: 0,
+            trigger_count,
             required_triggers: 1,
             executed: false,
             executed_at: None,
@@ -5481,45 +5541,32 @@ fn handle_regenerate(
             std::process::exit(1);
         }
 
+        // Deferred schedulers (jobs still gated on unfinished dependencies) keep their on_jobs_ready
+        // recovery action in the Waiting state; a running worker fires it once the gate jobs
+        // complete. Only report them here -- there is nothing to submit yet.
         for scheduler_info in &schedulers_created {
-            // Skip schedulers for jobs with dependencies - they will be submitted
-            // when their on_jobs_ready action fires
             if scheduler_info.has_dependencies {
                 println!(
-                    "  Deferring scheduler '{}' ({} allocation(s)) - will submit via on_jobs_ready action",
+                    "  Deferring scheduler '{}' ({} allocation(s)) - will submit via on_jobs_ready action when dependencies complete",
                     scheduler_info.name, scheduler_info.num_allocations
                 );
                 allocations_deferred += scheduler_info.num_allocations;
-                continue;
             }
+        }
 
-            match schedule_slurm_nodes(
-                config,
-                workflow_id,
-                scheduler_info.id,
-                scheduler_info.num_allocations as i32,
-                false, // start_one_worker_per_node
-                "",
-                output_dir.to_str().unwrap_or("torc_output"),
-                effective_poll_interval,
-                None,  // max_parallel_jobs
-                false, // keep_submission_scripts
-                None,  // claim_backoff_max_secs (rely on runner-side config)
-            ) {
-                Ok(()) => {
-                    println!(
-                        "  Submitted {} allocation(s) for scheduler '{}'",
-                        scheduler_info.num_allocations, scheduler_info.name
-                    );
-                    allocations_submitted += scheduler_info.num_allocations;
-                }
-                Err(e) => {
-                    eprintln!(
-                        "Error submitting allocations for scheduler '{}': {}",
-                        scheduler_info.name, e
-                    );
-                    std::process::exit(1);
-                }
+        // Submit the ready-now allocations through the SAME path `torc submit` uses: fire every
+        // pending schedule_nodes action. The recovery actions for ready-now schedulers were created
+        // Pending above, so this claims and executes them (marking each Executed). We deliberately do
+        // NOT call schedule_slurm_nodes directly here: scheduling exclusively through actions keeps
+        // action state honest -- no action is left in a perpetual Waiting state after its allocation
+        // was already submitted out-of-band -- and routes all scheduling through one code path.
+        match fire_pending_schedule_nodes_actions(config, workflow_id, output_dir, poll_interval) {
+            Ok(submitted_count) => {
+                allocations_submitted = submitted_count;
+            }
+            Err(e) => {
+                eprintln!("Error submitting allocations: {}", e);
+                std::process::exit(1);
             }
         }
         submitted = true;

--- a/src/client/commands/slurm.rs
+++ b/src/client/commands/slurm.rs
@@ -1766,6 +1766,343 @@ pub fn handle_pending_schedule_actions(
     Ok(())
 }
 
+/// Effective allocation count for a `schedule_nodes` action: the per-submission override if the
+/// user set one, else the action's configured count (missing defaults to 1, matching
+/// workflow_manager / job_runner / list-actions).
+fn action_alloc_count(action: &models::WorkflowActionModel, overrides: &HashMap<i64, i32>) -> i64 {
+    if let Some(id) = action.id
+        && let Some(count) = overrides.get(&id)
+    {
+        return *count as i64;
+    }
+    action
+        .action_config
+        .get("num_allocations")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(1)
+}
+
+/// Human-readable label for the gating jobs of an action (`job_ids` resolved to names where known),
+/// truncated so a wide fan-out stays on one line.
+fn gate_label(action: &models::WorkflowActionModel, job_names: &HashMap<i64, String>) -> String {
+    let Some(ids) = action.job_ids.as_ref().filter(|ids| !ids.is_empty()) else {
+        return "(all jobs)".to_string();
+    };
+    let shown: Vec<String> = ids
+        .iter()
+        .take(3)
+        .map(|id| {
+            job_names
+                .get(id)
+                .cloned()
+                .unwrap_or_else(|| format!("job {}", id))
+        })
+        .collect();
+    if ids.len() > shown.len() {
+        format!("{}, +{} more", shown.join(", "), ids.len() - shown.len())
+    } else {
+        shown.join(", ")
+    }
+}
+
+/// Scheduler label for an action: its name when resolvable from `scheduler_id`, else `id=<n>`.
+fn scheduler_label(
+    action: &models::WorkflowActionModel,
+    scheduler_names: &HashMap<i64, String>,
+) -> String {
+    match action
+        .action_config
+        .get("scheduler_id")
+        .and_then(|v| v.as_i64())
+    {
+        Some(id) => scheduler_names
+            .get(&id)
+            .cloned()
+            .unwrap_or_else(|| format!("id={}", id)),
+        None => "-".to_string(),
+    }
+}
+
+/// Print the "submit now" group (the actions submit fires immediately), reflecting the user's
+/// in-progress disable/override choices, and the running total of allocations.
+fn render_now_group(
+    now: &[models::WorkflowActionModel],
+    disabled: &std::collections::HashSet<i64>,
+    overrides: &HashMap<i64, i32>,
+    scheduler_names: &HashMap<i64, String>,
+    job_names: &HashMap<i64, String>,
+) {
+    eprintln!("Will submit now ({} action(s)):", now.len());
+    if now.is_empty() {
+        eprintln!("  (none)");
+    }
+    let mut total = 0i64;
+    for a in now {
+        let id = a.id.unwrap_or(-1);
+        if disabled.contains(&id) {
+            eprintln!(
+                "  [disabled] id={:<4} {:<16} {}",
+                id,
+                a.trigger_type,
+                scheduler_label(a, scheduler_names),
+            );
+            continue;
+        }
+        let allocs = action_alloc_count(a, overrides);
+        total += allocs;
+        let changed = if a.id.is_some_and(|id| overrides.contains_key(&id)) {
+            " (changed)"
+        } else {
+            ""
+        };
+        eprintln!(
+            "  id={:<4} {:<16} sched={:<16} allocations={}{:<10} gates: {}",
+            id,
+            a.trigger_type,
+            scheduler_label(a, scheduler_names),
+            allocs,
+            changed,
+            gate_label(a, job_names),
+        );
+    }
+    eprintln!("  → {} Slurm allocation(s) will be submitted now.", total);
+}
+
+/// Review the `schedule_nodes` actions `torc submit` will fire, on a re-submission, and let the user
+/// adjust them before submitting.
+///
+/// On the first run (`run_id <= 1`) there is nothing to reconcile -- the pending actions are exactly
+/// what the spec declared -- so this returns an empty override map without prompting.
+///
+/// On a re-submission the reinitialize re-arm logic (see `reset_actions_for_reinitialize`) can leave
+/// `schedule_nodes` actions pending whose allocation counts no longer match what the user wants this
+/// run. Scoped to the slurm `schedule_nodes` actions submit itself fires from the login node, this
+/// prints two groups:
+///
+/// - **Will submit now**: pending (`trigger_count >= required_triggers`) actions submit fires
+///   immediately. The user can disable one (suppressed via claim, so it submits nothing) or override
+///   its allocation count for this submission only.
+/// - **Will submit later**: deferred actions (gates not yet satisfied) that running workers fire as
+///   later stages complete. Listed for visibility; not adjustable here.
+///
+/// Returns a map of action id -> allocation count to apply for this submission (empty unless the
+/// user changed something; never persisted to `action_config`). Disabled actions are claimed in here
+/// so they are absent from the pending set `start()` later reads. `--no-prompts` or a non-TTY stdin
+/// prints the summary and proceeds with the configured counts. Returns `Err` on API failure;
+/// cancellation exits the process.
+pub fn review_submit_pending_actions(
+    config: &Configuration,
+    workflow_id: i64,
+    run_id: i64,
+    no_prompts: bool,
+) -> Result<HashMap<i64, i32>, String> {
+    use std::collections::HashSet;
+    use std::io::{IsTerminal, Write};
+
+    let mut overrides: HashMap<i64, i32> = HashMap::new();
+
+    // First run: the pending actions are exactly what the spec declared; nothing to reconcile.
+    if run_id <= 1 {
+        return Ok(overrides);
+    }
+
+    // Only slurm schedule_nodes actions that have not executed and are not recovery actions are
+    // candidates -- those are exactly what submit fires from the login node.
+    let actions = apis::workflow_actions_api::get_workflow_actions(config, workflow_id)
+        .map_err(|e| format!("could not list workflow actions: {}", e))?;
+    let (now, later): (Vec<_>, Vec<_>) = actions
+        .into_iter()
+        .filter(|a| {
+            a.action_type == "schedule_nodes"
+                && !a.is_recovery
+                && !a.executed
+                && a.action_config
+                    .get("scheduler_type")
+                    .and_then(|v| v.as_str())
+                    == Some("slurm")
+        })
+        // "now" = pending (gates satisfied); "later" = deferred (gates not yet satisfied).
+        .partition(|a| a.trigger_count >= a.required_triggers);
+
+    if now.is_empty() && later.is_empty() {
+        return Ok(overrides);
+    }
+
+    // Best-effort name resolution for display; fall back to ids on any error.
+    let scheduler_names: HashMap<i64, String> =
+        match apis::slurm_schedulers_api::list_slurm_schedulers(
+            config,
+            workflow_id,
+            None,
+            None,
+            None,
+            None,
+        ) {
+            Ok(resp) => resp
+                .items
+                .into_iter()
+                .filter_map(|s| Some((s.id?, s.name?)))
+                .collect(),
+            Err(_) => HashMap::new(),
+        };
+    let job_names: HashMap<i64, String> = match apis::jobs_api::list_jobs(
+        config,
+        workflow_id,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    ) {
+        Ok(resp) => resp
+            .items
+            .into_iter()
+            .filter_map(|j| j.id.map(|id| (id, j.name)))
+            .collect(),
+        Err(_) => HashMap::new(),
+    };
+
+    eprintln!();
+    eprintln!(
+        "Workflow {} (run #{}) — re-submission. Review what `torc submit` will schedule:",
+        workflow_id, run_id
+    );
+
+    let mut disabled: HashSet<i64> = HashSet::new();
+    render_now_group(&now, &disabled, &overrides, &scheduler_names, &job_names);
+
+    // Deferred actions: informational only.
+    if !later.is_empty() {
+        eprintln!(
+            "Will submit later ({} action(s), fired by workers as their gating jobs become ready/complete):",
+            later.len()
+        );
+        for a in &later {
+            eprintln!(
+                "  id={:<4} {:<16} sched={:<16} allocations={:<4} gates: {}",
+                a.id.unwrap_or(-1),
+                a.trigger_type,
+                scheduler_label(a, &scheduler_names),
+                action_alloc_count(a, &overrides),
+                gate_label(a, &job_names),
+            );
+        }
+        eprintln!(
+            "  (these run from compute nodes with their configured counts; not adjustable here)"
+        );
+    }
+
+    // A non-interactive run prints the summary and proceeds with configured counts.
+    if no_prompts || !std::io::stdin().is_terminal() {
+        eprintln!(
+            "Proceeding with the configured allocation counts (--no-prompts or non-interactive stdin)."
+        );
+        return Ok(overrides);
+    }
+
+    // Index now-actions by id for validation and persistent-flag lookups.
+    let now_by_id: HashMap<i64, &models::WorkflowActionModel> =
+        now.iter().filter_map(|a| a.id.map(|id| (id, a))).collect();
+
+    loop {
+        eprint!(
+            "Options: [p]roceed, [d]isable <id>, [n]um <id> <count> (0 = disable), [c]ancel\n> "
+        );
+        let _ = std::io::stderr().flush();
+        let mut input = String::new();
+        let bytes = std::io::stdin()
+            .read_line(&mut input)
+            .map_err(|e| format!("failed to read input: {}", e))?;
+        if bytes == 0 {
+            // EOF (e.g. Ctrl-D): treat as cancel rather than looping forever.
+            eprintln!("\nCancelled (EOF). No allocations submitted.");
+            std::process::exit(0);
+        }
+        let tokens: Vec<&str> = input.split_whitespace().collect();
+        match tokens.first().map(|t| t.to_lowercase()).as_deref() {
+            // Require an explicit "p" to proceed; a bare Enter re-prompts so a stray keypress can't
+            // submit allocations.
+            None => continue,
+            Some("p") | Some("proceed") => break,
+            Some("c") | Some("cancel") | Some("q") => {
+                eprintln!("Cancelled. No allocations submitted.");
+                std::process::exit(0);
+            }
+            Some("d") | Some("disable") => {
+                match tokens.get(1).and_then(|s| s.parse::<i64>().ok()) {
+                    Some(id) if now_by_id.contains_key(&id) => {
+                        disabled.insert(id);
+                        overrides.remove(&id);
+                        eprintln!("Action {} disabled — it will submit nothing this run.", id);
+                        render_now_group(&now, &disabled, &overrides, &scheduler_names, &job_names);
+                    }
+                    _ => eprintln!(
+                        "  Usage: d <id>, where <id> is one of the 'will submit now' actions."
+                    ),
+                }
+            }
+            Some("n") | Some("num") | Some("allocations") => {
+                match (
+                    tokens.get(1).and_then(|s| s.parse::<i64>().ok()),
+                    tokens.get(2).and_then(|s| s.parse::<i32>().ok()),
+                ) {
+                    (Some(id), Some(count)) if now_by_id.contains_key(&id) && count >= 0 => {
+                        if count == 0 {
+                            disabled.insert(id);
+                            overrides.remove(&id);
+                            eprintln!("Action {} set to 0 allocations — disabled this run.", id);
+                        } else {
+                            disabled.remove(&id);
+                            overrides.insert(id, count);
+                            eprintln!(
+                                "Action {} will submit {} allocation(s) this submission.",
+                                id, count
+                            );
+                        }
+                        render_now_group(&now, &disabled, &overrides, &scheduler_names, &job_names);
+                    }
+                    _ => eprintln!(
+                        "  Usage: n <id> <count>, where <id> is a 'will submit now' action and <count> >= 0."
+                    ),
+                }
+            }
+            _ => eprintln!("  Unrecognized input. Use p / d <id> / n <id> <count> / c."),
+        }
+    }
+
+    // Apply disables now (only on proceed, so a cancel leaves the workflow untouched). Claiming
+    // marks the action executed so the workers started by this submission do not fire it either.
+    for id in &disabled {
+        let action = now_by_id.get(id);
+        if action.is_some_and(|a| a.persistent) {
+            eprintln!(
+                "  Note: action {} is persistent and cannot be disabled by suppression; it will \
+                 still re-fire from a worker. Remove or disable it in the spec to avoid that.",
+                id
+            );
+            continue;
+        }
+        match crate::client::utils::claim_action(config, workflow_id, *id, None, 20) {
+            Ok(_) => {}
+            Err(e) => {
+                return Err(format!(
+                    "failed to disable (claim) action {}: {}; aborting so it does not fire unexpectedly",
+                    id, e
+                ));
+            }
+        }
+    }
+
+    Ok(overrides)
+}
+
 /// Result indicating success or failure
 #[allow(clippy::too_many_arguments)]
 pub fn schedule_slurm_nodes(

--- a/src/client/commands/workflows.rs
+++ b/src/client/commands/workflows.rs
@@ -1071,13 +1071,15 @@ fn handle_list_actions(
 
                         // For schedule_nodes actions, surface num_allocations (how many Slurm
                         // allocations this action submits when it fires); blank for other types.
+                        // A missing value defaults to 1 at execution time (see workflow_manager.rs /
+                        // job_runner.rs), so show that effective default rather than a misleading "?".
                         let allocations = if action.action_type == "schedule_nodes" {
                             action
                                 .action_config
                                 .get("num_allocations")
                                 .and_then(|v| v.as_i64())
-                                .map(|n| n.to_string())
-                                .unwrap_or_else(|| "?".to_string())
+                                .unwrap_or(1)
+                                .to_string()
                         } else {
                             "-".to_string()
                         };

--- a/src/client/commands/workflows.rs
+++ b/src/client/commands/workflows.rs
@@ -141,6 +141,8 @@ struct WorkflowActionTableRow {
     trigger_type: String,
     #[tabled(rename = "Action")]
     action_type: String,
+    #[tabled(rename = "Allocations")]
+    allocations: String,
     #[tabled(rename = "Progress")]
     progress: String,
     #[tabled(rename = "Status")]
@@ -1067,10 +1069,24 @@ fn handle_list_actions(
                             _ => "(all jobs)".to_string(),
                         };
 
+                        // For schedule_nodes actions, surface num_allocations (how many Slurm
+                        // allocations this action submits when it fires); blank for other types.
+                        let allocations = if action.action_type == "schedule_nodes" {
+                            action
+                                .action_config
+                                .get("num_allocations")
+                                .and_then(|v| v.as_i64())
+                                .map(|n| n.to_string())
+                                .unwrap_or_else(|| "?".to_string())
+                        } else {
+                            "-".to_string()
+                        };
+
                         WorkflowActionTableRow {
                             id: action.id.unwrap_or(-1),
                             trigger_type: action.trigger_type.clone(),
                             action_type: action.action_type.clone(),
+                            allocations,
                             progress,
                             status,
                             executed_at: action.executed_at.as_deref().unwrap_or("-").to_string(),

--- a/src/client/commands/workflows.rs
+++ b/src/client/commands/workflows.rs
@@ -2925,12 +2925,10 @@ pub fn handle_create(
 
             if summary.has_schedule_nodes_action {
                 println!(
-                    "Submission: Ready for scheduler submission (has on_workflow_start schedule_nodes action)"
+                    "Submission: Ready for scheduler submission (has a schedule_nodes action)"
                 );
             } else {
-                println!(
-                    "Submission: Local execution only (no on_workflow_start schedule_nodes action)"
-                );
+                println!("Submission: Local execution only (no schedule_nodes action)");
             }
             println!();
 

--- a/src/client/execution_plan.rs
+++ b/src/client/execution_plan.rs
@@ -90,9 +90,11 @@ impl ExecutionPlan {
         let root_jobs: Vec<String> = graph.roots().iter().map(|s| s.to_string()).collect();
 
         // Find scheduler allocations that fire at workflow start: on_workflow_start actions, plus
-        // on_jobs_ready actions gated on root jobs (root jobs are Ready immediately after init, so
-        // their schedulers are submitted at submit time). The scheduler generator now ties root-job
-        // schedulers to on_jobs_ready[root_jobs] for re-run safety, so both must appear here.
+        // on_jobs_ready actions gated ENTIRELY on root jobs (root jobs are Ready immediately after
+        // init, so their schedulers are submitted at submit time). The scheduler generator now ties
+        // root-job schedulers to on_jobs_ready[root_jobs] for re-run safety, so both must appear
+        // here. An action that also gates on a non-root job only becomes pending once that job is
+        // Ready (required_triggers counts every gating job), so it fires at a later event, not start.
         let mut start_allocations = Vec::new();
         if let Some(ref actions) = spec.actions {
             for action in actions {
@@ -102,7 +104,17 @@ impl ExecutionPlan {
                     start_allocations.push(alloc);
                 }
             }
+            let non_root_jobs: Vec<String> = graph
+                .job_names()
+                .filter(|j| !root_jobs.contains(*j))
+                .cloned()
+                .collect();
+            let matches_non_root = graph.matching_actions(&non_root_jobs, actions);
             for action in graph.matching_actions(&root_jobs, actions) {
+                // Skip actions that also gate on a non-root job; they fire at a later event.
+                if matches_non_root.iter().any(|a| std::ptr::eq(*a, action)) {
+                    continue;
+                }
                 if let Some(alloc) = build_scheduler_allocation(spec, action)? {
                     start_allocations.push(alloc);
                 }
@@ -286,8 +298,10 @@ impl ExecutionPlan {
             .collect();
 
         // Find scheduler allocations that fire at workflow start: on_workflow_start actions, plus
-        // on_jobs_ready actions gated on root jobs (Ready at init). The scheduler generator now ties
-        // root-job schedulers to on_jobs_ready[root_jobs] for re-run safety, so both appear here.
+        // on_jobs_ready actions gated ENTIRELY on root jobs (Ready at init). The scheduler generator
+        // now ties root-job schedulers to on_jobs_ready[root_jobs] for re-run safety, so both appear
+        // here. An action gating on any non-root job becomes pending only when that job is Ready
+        // (required_triggers counts every gating job), so it fires at a later event, not start.
         let mut start_allocations = Vec::new();
         for action in actions {
             if action.trigger_type == "on_workflow_start"
@@ -305,7 +319,8 @@ impl ExecutionPlan {
             if action.trigger_type == "on_jobs_ready" {
                 let empty_vec = vec![];
                 let action_job_ids = action.job_ids.as_ref().unwrap_or(&empty_vec);
-                if action_job_ids.iter().any(|id| root_job_ids.contains(id))
+                if !action_job_ids.is_empty()
+                    && action_job_ids.iter().all(|id| root_job_ids.contains(id))
                     && let Some(alloc) = build_scheduler_allocation_from_db_action(
                         action,
                         jobs,

--- a/src/client/execution_plan.rs
+++ b/src/client/execution_plan.rs
@@ -89,13 +89,21 @@ impl ExecutionPlan {
         // Event 0: Workflow start - root jobs become ready
         let root_jobs: Vec<String> = graph.roots().iter().map(|s| s.to_string()).collect();
 
-        // Find on_workflow_start scheduler allocations
+        // Find scheduler allocations that fire at workflow start: on_workflow_start actions, plus
+        // on_jobs_ready actions gated on root jobs (root jobs are Ready immediately after init, so
+        // their schedulers are submitted at submit time). The scheduler generator now ties root-job
+        // schedulers to on_jobs_ready[root_jobs] for re-run safety, so both must appear here.
         let mut start_allocations = Vec::new();
         if let Some(ref actions) = spec.actions {
             for action in actions {
                 if action.trigger_type == "on_workflow_start"
                     && let Some(alloc) = build_scheduler_allocation(spec, action)?
                 {
+                    start_allocations.push(alloc);
+                }
+            }
+            for action in graph.matching_actions(&root_jobs, actions) {
+                if let Some(alloc) = build_scheduler_allocation(spec, action)? {
                     start_allocations.push(alloc);
                 }
             }
@@ -277,7 +285,9 @@ impl ExecutionPlan {
             })
             .collect();
 
-        // Find on_workflow_start scheduler allocations
+        // Find scheduler allocations that fire at workflow start: on_workflow_start actions, plus
+        // on_jobs_ready actions gated on root jobs (Ready at init). The scheduler generator now ties
+        // root-job schedulers to on_jobs_ready[root_jobs] for re-run safety, so both appear here.
         let mut start_allocations = Vec::new();
         for action in actions {
             if action.trigger_type == "on_workflow_start"
@@ -285,6 +295,25 @@ impl ExecutionPlan {
                     build_scheduler_allocation_from_db_action(action, jobs, &scheduler_id_to_name)?
             {
                 start_allocations.push(alloc);
+            }
+        }
+        let root_job_ids: HashSet<i64> = root_jobs
+            .iter()
+            .filter_map(|n| job_name_to_id.get(n).copied())
+            .collect();
+        for action in actions {
+            if action.trigger_type == "on_jobs_ready" {
+                let empty_vec = vec![];
+                let action_job_ids = action.job_ids.as_ref().unwrap_or(&empty_vec);
+                if action_job_ids.iter().any(|id| root_job_ids.contains(id))
+                    && let Some(alloc) = build_scheduler_allocation_from_db_action(
+                        action,
+                        jobs,
+                        &scheduler_id_to_name,
+                    )?
+                {
+                    start_allocations.push(alloc);
+                }
             }
         }
 

--- a/src/client/execution_plan.rs
+++ b/src/client/execution_plan.rs
@@ -104,9 +104,10 @@ impl ExecutionPlan {
                     start_allocations.push(alloc);
                 }
             }
+            let root_job_set: HashSet<&String> = root_jobs.iter().collect();
             let non_root_jobs: Vec<String> = graph
                 .job_names()
-                .filter(|j| !root_jobs.contains(*j))
+                .filter(|j| !root_job_set.contains(*j))
                 .cloned()
                 .collect();
             let matches_non_root = graph.matching_actions(&non_root_jobs, actions);

--- a/src/client/scheduler_plan.rs
+++ b/src/client/scheduler_plan.rs
@@ -16,8 +16,11 @@ use serde::{Deserialize, Serialize};
 ///
 /// When using `--group-by partition`, if a partition has both deferred (jobs with dependencies)
 /// and non-deferred (jobs without dependencies) groups, and their combined allocation count
-/// is at or below this threshold, they are merged into a single scheduler whose `on_jobs_ready`
-/// action is gated on the merged job set. This reduces the number of Slurm job submissions.
+/// is at or below this threshold, they are merged into a single scheduler. The scheduler serves
+/// both groups' jobs, but its `on_jobs_ready` action is gated on the non-deferred (root) jobs only
+/// (`gate_job_names`) so it fires at workflow start; gating on the dependent jobs too would never
+/// become pending (they are not Ready until the root jobs run). This reduces the number of Slurm
+/// job submissions.
 ///
 /// When both groups exist, each needs at least 1 allocation, so the minimum total is 2.
 /// A threshold of 2 means we merge when exactly 2 allocations are needed (the minimum case).

--- a/src/client/scheduler_plan.rs
+++ b/src/client/scheduler_plan.rs
@@ -16,8 +16,8 @@ use serde::{Deserialize, Serialize};
 ///
 /// When using `--group-by partition`, if a partition has both deferred (jobs with dependencies)
 /// and non-deferred (jobs without dependencies) groups, and their combined allocation count
-/// is at or below this threshold, they are merged into a single scheduler with an
-/// `on_workflow_start` trigger. This reduces the number of Slurm job submissions.
+/// is at or below this threshold, they are merged into a single scheduler whose `on_jobs_ready`
+/// action is gated on the merged job set. This reduces the number of Slurm job submissions.
 ///
 /// When both groups exist, each needs at least 1 allocation, so the minimum total is 2.
 /// A threshold of 2 means we merge when exactly 2 allocations are needed (the minimum case).
@@ -523,21 +523,19 @@ fn process_scheduler_group<RR: ResourceRequirements>(
 
     // Create action if requested
     let action = if add_actions {
-        // For jobs with dependencies, we need to specify which jobs trigger the action.
-        // Use job_names (exact names) instead of job_name_patterns (regexes) because
-        // after parameter expansion, each job has an exact name and using regexes
-        // with individual exact-match patterns is wasteful and confusing.
-        let (trigger_type, job_names, job_name_patterns) = if group.has_dependencies {
-            ("on_jobs_ready", Some(group.job_names.clone()), None)
-        } else {
-            ("on_workflow_start", None, None)
-        };
-
+        // Tie every generated scheduler to its jobs via on_jobs_ready, including no-dependency
+        // (root) jobs. Root jobs are Ready right after initialize, so on_jobs_ready[root_jobs]
+        // fires at the same moment on_workflow_start would, but it is re-run-safe: resetting those
+        // jobs and reinitializing re-arms the action (the gate is no longer terminal), so a
+        // subsequent `torc submit` re-schedules exactly them. on_workflow_start is kept (suppressed)
+        // on reinit and submit cannot re-fire it, which strands the job. We use job_names (exact
+        // names) rather than job_name_patterns (regexes) because after parameter expansion each job
+        // has an exact name.
         Some(PlannedAction {
-            trigger_type: trigger_type.to_string(),
+            trigger_type: "on_jobs_ready".to_string(),
             scheduler_name: scheduler_name.clone(),
-            job_names,
-            job_name_patterns,
+            job_names: Some(group.job_names.clone()),
+            job_name_patterns: None,
             num_allocations,
             is_recovery,
         })
@@ -769,7 +767,7 @@ fn generate_plan_grouped_by_partition<RR: ResourceRequirements>(
         // Merge if total allocations are small enough that a single scheduler makes sense.
         // Note: When both groups exist, each needs at least 1 allocation, so total >= 2.
         if total_allocs <= MERGE_THRESHOLD {
-            // Merge deferred into non-deferred (so we use on_workflow_start)
+            // Merge deferred into non-deferred (a single on_jobs_ready action gated on all of them)
             let deferred = partition_groups.remove(&deferred_key).unwrap();
             let non_deferred = partition_groups.get_mut(&non_deferred_key).unwrap();
 
@@ -930,19 +928,15 @@ fn generate_plan_grouped_by_partition<RR: ResourceRequirements>(
 
         plan.schedulers.push(scheduler);
 
-        // Create action if requested
+        // Create action if requested. Tie every scheduler to its jobs via on_jobs_ready, including
+        // no-dependency (root) jobs (Ready at init), so generated workflows are re-run-safe -- see
+        // the matching note in plan_scheduler_action().
         if add_actions {
-            let (trigger_type, job_names, job_name_patterns) = if pg.has_dependencies {
-                ("on_jobs_ready", Some(pg.job_names.clone()), None)
-            } else {
-                ("on_workflow_start", None, None)
-            };
-
             plan.actions.push(PlannedAction {
-                trigger_type: trigger_type.to_string(),
+                trigger_type: "on_jobs_ready".to_string(),
                 scheduler_name,
-                job_names,
-                job_name_patterns,
+                job_names: Some(pg.job_names.clone()),
+                job_name_patterns: None,
                 num_allocations,
                 is_recovery,
             });

--- a/src/client/scheduler_plan.rs
+++ b/src/client/scheduler_plan.rs
@@ -553,6 +553,13 @@ struct PartitionGroup {
     job_count: usize,
     job_names: Vec<String>,
     job_name_patterns: Vec<String>,
+    /// Jobs to gate the generated `on_jobs_ready` action on, when that differs from `job_names`.
+    /// Set only when a deferred group is merged into a non-deferred one: the scheduler then serves
+    /// both root and dependent jobs (`job_names`), but the action must be gated on the *root* jobs
+    /// only so it fires at workflow start. Gating on the whole merged set would never become pending
+    /// (dependent jobs aren't Ready until the root jobs run, which need this allocation) — a deadlock.
+    /// `None` means gate on `job_names` (the group is uniform: all root, or all the same level).
+    gate_job_names: Option<Vec<String>>,
     /// All RR names in this group (for naming the scheduler)
     rr_names: Vec<String>,
     /// Maximum memory in MB across all RRs
@@ -677,6 +684,7 @@ fn generate_plan_grouped_by_partition<RR: ResourceRequirements>(
                 job_count: 0,
                 job_names: Vec::new(),
                 job_name_patterns: Vec::new(),
+                gate_job_names: None,
                 rr_names: Vec::new(),
                 max_memory_mb: 0,
                 max_runtime_secs: 0,
@@ -767,10 +775,14 @@ fn generate_plan_grouped_by_partition<RR: ResourceRequirements>(
         // Merge if total allocations are small enough that a single scheduler makes sense.
         // Note: When both groups exist, each needs at least 1 allocation, so total >= 2.
         if total_allocs <= MERGE_THRESHOLD {
-            // Merge deferred into non-deferred (a single on_jobs_ready action gated on all of them)
+            // Merge deferred into non-deferred. The scheduler then serves both groups' jobs, but its
+            // on_jobs_ready action must stay gated on the *root* (non-deferred) jobs only, so it
+            // fires at workflow start. Capture those root job names before extending job_names with
+            // the dependent jobs; gating on the full merged set would deadlock (see gate_job_names).
             let deferred = partition_groups.remove(&deferred_key).unwrap();
             let non_deferred = partition_groups.get_mut(&non_deferred_key).unwrap();
 
+            non_deferred.gate_job_names = Some(non_deferred.job_names.clone());
             non_deferred.job_count += deferred.job_count;
             non_deferred.job_names.extend(deferred.job_names);
             non_deferred
@@ -930,12 +942,18 @@ fn generate_plan_grouped_by_partition<RR: ResourceRequirements>(
 
         // Create action if requested. Tie every scheduler to its jobs via on_jobs_ready, including
         // no-dependency (root) jobs (Ready at init), so generated workflows are re-run-safe -- see
-        // the matching note in plan_scheduler_action().
+        // the matching note in plan_scheduler_action(). For a merged group, gate on the root jobs
+        // only (gate_job_names) so the action can fire at start; gating on the dependent jobs too
+        // would never become pending.
         if add_actions {
+            let gate = pg
+                .gate_job_names
+                .clone()
+                .unwrap_or_else(|| pg.job_names.clone());
             plan.actions.push(PlannedAction {
                 trigger_type: "on_jobs_ready".to_string(),
                 scheduler_name,
-                job_names: Some(pg.job_names.clone()),
+                job_names: Some(gate),
                 job_name_patterns: None,
                 num_allocations,
                 is_recovery,

--- a/src/client/workflow_manager.rs
+++ b/src/client/workflow_manager.rs
@@ -17,6 +17,24 @@ pub struct InitializationCheck {
     pub existing_output_files: Vec<String>,
 }
 
+/// Summary of what `WorkflowManager::start` actually did, so the caller can distinguish a real
+/// submission from a no-op. A zero-allocation outcome is not a benign "deferred" state: deferred
+/// `on_jobs_ready`/`on_jobs_complete` actions are only ever fired by running workers, and a worker
+/// only exists because an allocation launched it. So if a submit invocation launches no
+/// allocations, nothing downstream will ever fire it either — the caller should report that as an
+/// error rather than printing success.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct StartOutcome {
+    /// Total Slurm allocations actually submitted across every fired schedule_nodes action.
+    pub allocations_submitted: i32,
+    /// Number of slurm schedule_nodes actions that were pending and due at submit time (counted
+    /// before claim/dedup). Used to explain a zero-allocation outcome: zero here means nothing was
+    /// due (already running/complete, or misconfigured with no bootstrap action); non-zero means
+    /// actions were due but produced no allocations (claimed by a concurrent submitter, or their
+    /// counts were overridden to 0).
+    pub slurm_actions_seen: usize,
+}
+
 pub struct WorkflowManager {
     config: Configuration,
     torc_config: TorcConfig,
@@ -224,7 +242,7 @@ impl WorkflowManager {
         poll_interval_override: Option<i32>,
         claim_backoff_max_secs_override: Option<f64>,
         allocation_overrides: &std::collections::HashMap<i64, i32>,
-    ) -> Result<(), TorcError> {
+    ) -> Result<StartOutcome, TorcError> {
         // Check if workflow is uninitialized
         match apis::workflows_api::is_workflow_uninitialized(&self.config, self.workflow_id) {
             Ok(response) => {
@@ -280,6 +298,7 @@ impl WorkflowManager {
         };
 
         // Filter for schedule_nodes actions
+        let mut outcome = StartOutcome::default();
         for action in actions {
             let action_type = &action.action_type;
             let action_id = action.id.unwrap_or(0);
@@ -295,6 +314,7 @@ impl WorkflowManager {
 
                 // Only claim the action if we can execute it (scheduler_type == "slurm")
                 if scheduler_type == "slurm" {
+                    outcome.slurm_actions_seen += 1;
                     // Claim the action atomically (no compute_node_id since we're on login node)
                     let claimed = match crate::client::utils::claim_action(
                         &self.config,
@@ -361,6 +381,7 @@ impl WorkflowManager {
                         claim_backoff_max_secs_override,
                     ) {
                         Ok(()) => {
+                            outcome.allocations_submitted += num_allocations.max(0);
                             info!(
                                 "Successfully scheduled {} Slurm allocation(s) for {} action {}",
                                 num_allocations, action.trigger_type, action_id
@@ -386,7 +407,7 @@ impl WorkflowManager {
             }
         }
 
-        Ok(())
+        Ok(outcome)
     }
 
     /// Reinitialize the workflow. Resets workflow status (which also bumps

--- a/src/client/workflow_manager.rs
+++ b/src/client/workflow_manager.rs
@@ -239,13 +239,29 @@ impl WorkflowManager {
             }
         }
 
-        // Get pending on_workflow_start actions
-        // Note: We don't create a compute node for the submission host (login node)
-        // since it's not actually running jobs - it just submits to the scheduler
+        // Get every pending schedule_nodes-capable action, regardless of trigger type. "Pending"
+        // already means "armed and due now" (trigger_count >= required_triggers, executed = 0), and
+        // reinitialize's keep/re-arm logic guarantees that set is exactly what should be scheduled:
+        //
+        // - Initial run: only on_workflow_start (and any on_jobs_ready gated on root jobs that are
+        //   ready at init) are pending, so this bootstraps the first allocations.
+        // - Re-run (reset a subset of jobs + reinit): the reset jobs' job-gated actions re-arm and
+        //   become pending while untouched stages stay suppressed, so submit re-schedules exactly
+        //   the affected classes. This is what lets `reset-status <ids> --reinit` + `submit`
+        //   re-submit only the jobs being re-run.
+        //
+        // Note: We don't create a compute node for the submission host (login node) since it's not
+        // actually running jobs - it just submits to the scheduler. Downstream job-gated actions
+        // whose gates are not yet ready stay pending-less here and are fired later by running
+        // workers (see job_runner::check_and_execute_actions).
         let actions = match apis::workflow_actions_api::get_pending_actions(
             &self.config,
             self.workflow_id,
-            Some(vec!["on_workflow_start".to_string()]),
+            Some(vec![
+                "on_workflow_start".to_string(),
+                "on_jobs_ready".to_string(),
+                "on_jobs_complete".to_string(),
+            ]),
         ) {
             Ok(actions) => actions,
             Err(err) => {
@@ -292,8 +308,8 @@ impl WorkflowManager {
 
                     // Successfully claimed, now execute
                     info!(
-                        "Scheduling Slurm nodes for on_workflow_start action {}",
-                        action_id
+                        "Scheduling Slurm nodes for {} action {}",
+                        action.trigger_type, action_id
                     );
 
                     let scheduler_id = action_config

--- a/src/client/workflow_manager.rs
+++ b/src/client/workflow_manager.rs
@@ -208,6 +208,14 @@ impl WorkflowManager {
     }
 
     /// Start the workflow: initialize if needed and schedule nodes for on_workflow_start actions
+    ///
+    /// `allocation_overrides` maps an action id to the number of Slurm allocations to submit for
+    /// that action **on this invocation only** (it is not persisted to the action's config). It is
+    /// populated by the interactive submit review (see `slurm::review_submit_pending_actions`) so a
+    /// user re-submitting a workflow can right-size what `sbatch` requests without editing the
+    /// action. Actions the user chose to disable are already suppressed (claimed) before `start` is
+    /// called, so they do not appear in the pending set here; an empty map means "fire every pending
+    /// action with its configured count".
     pub fn start(
         &self,
         force: bool,
@@ -215,6 +223,7 @@ impl WorkflowManager {
         output_dir: &str,
         poll_interval_override: Option<i32>,
         claim_backoff_max_secs_override: Option<f64>,
+        allocation_overrides: &std::collections::HashMap<i64, i32>,
     ) -> Result<(), TorcError> {
         // Check if workflow is uninitialized
         match apis::workflows_api::is_workflow_uninitialized(&self.config, self.workflow_id) {
@@ -320,10 +329,15 @@ impl WorkflowManager {
                         .get("start_one_worker_per_node")
                         .and_then(|v| v.as_bool())
                         .unwrap_or(false);
-                    let num_allocations = action_config
-                        .get("num_allocations")
-                        .and_then(|v| v.as_i64())
-                        .unwrap_or(1) as i32;
+                    // Use the per-submission override from the interactive review if the user set
+                    // one for this action; otherwise fall back to the action's configured count
+                    // (missing defaults to 1, matching job_runner / list-actions display).
+                    let num_allocations = allocation_overrides.get(&action_id).copied().unwrap_or(
+                        action_config
+                            .get("num_allocations")
+                            .and_then(|v| v.as_i64())
+                            .unwrap_or(1) as i32,
+                    );
                     let max_parallel_jobs = max_parallel_jobs_override.or_else(|| {
                         action_config
                             .get("max_parallel_jobs")
@@ -348,8 +362,8 @@ impl WorkflowManager {
                     ) {
                         Ok(()) => {
                             info!(
-                                "Successfully scheduled {} Slurm allocation(s) for on_workflow_start",
-                                num_allocations
+                                "Successfully scheduled {} Slurm allocation(s) for {} action {}",
+                                num_allocations, action.trigger_type, action_id
                             );
                         }
                         Err(err) => {

--- a/src/client/workflow_spec.rs
+++ b/src/client/workflow_spec.rs
@@ -177,7 +177,8 @@ pub struct ValidationSummary {
     pub slurm_scheduler_count: usize,
     /// Number of workflow actions that would be created
     pub action_count: usize,
-    /// Whether the workflow has on_workflow_start schedule_nodes action
+    /// Whether the workflow has a schedule_nodes action that `torc submit` can fire
+    /// (on_workflow_start, on_jobs_ready, or on_jobs_complete)
     pub has_schedule_nodes_action: bool,
     /// List of job names that would be created
     pub job_names: Vec<String>,
@@ -2510,12 +2511,19 @@ impl WorkflowSpec {
         }
     }
 
-    /// Check if the workflow spec has an on_workflow_start action with schedule_nodes
-    /// Returns true if such an action exists, false otherwise
+    /// Check if the workflow spec has a `schedule_nodes` action that `torc submit` can act on.
+    ///
+    /// `submit` fires every pending Slurm `schedule_nodes` action regardless of trigger type
+    /// (on_workflow_start to bootstrap, on_jobs_ready/on_jobs_complete for job-gated scheduling and
+    /// re-runs), so any of those qualifies a spec as submittable. Returns false otherwise.
     pub fn has_schedule_nodes_action(&self) -> bool {
         if let Some(ref actions) = self.actions {
             actions.iter().any(|action| {
-                action.trigger_type == "on_workflow_start" && action.action_type == "schedule_nodes"
+                action.action_type == "schedule_nodes"
+                    && matches!(
+                        action.trigger_type.as_str(),
+                        "on_workflow_start" | "on_jobs_ready" | "on_jobs_complete"
+                    )
             })
         } else {
             false

--- a/src/client/workflow_spec.rs
+++ b/src/client/workflow_spec.rs
@@ -1987,10 +1987,57 @@ impl WorkflowSpec {
         clone.validate_file_identifiers()
     }
 
+    /// Recognized workflow action trigger types.
+    ///
+    /// Kept in sync with the server's `check_and_trigger_actions` dispatch
+    /// (`src/server/api/workflow_actions.rs`). An unknown trigger type silently never
+    /// fires, so we reject it at creation rather than producing a confusing
+    /// "0 allocations" failure at submit time.
+    const VALID_TRIGGER_TYPES: &'static [&'static str] = &[
+        "on_workflow_start",
+        "on_workflow_complete",
+        "on_worker_start",
+        "on_worker_complete",
+        "on_jobs_ready",
+        "on_jobs_complete",
+    ];
+
     /// Validate workflow actions
     pub fn validate_actions(&self) -> Result<(), Box<dyn std::error::Error>> {
         if let Some(ref actions) = self.actions {
             for action in actions {
+                // Reject unknown trigger types (e.g. a typo'd `on_ready_jobs`), which would
+                // otherwise be stored silently and never fire.
+                if !Self::VALID_TRIGGER_TYPES.contains(&action.trigger_type.as_str()) {
+                    return Err(format!(
+                        "action has unknown trigger_type '{}'; valid trigger types are: {}",
+                        action.trigger_type,
+                        Self::VALID_TRIGGER_TYPES.join(", ")
+                    )
+                    .into());
+                }
+
+                // Job-gated triggers must name at least one job (exact names or regexes);
+                // without any, the action can never become due.
+                if matches!(
+                    action.trigger_type.as_str(),
+                    "on_jobs_ready" | "on_jobs_complete"
+                ) {
+                    let has_jobs = action.jobs.as_ref().is_some_and(|j| !j.is_empty());
+                    let has_regexes = action
+                        .job_name_regexes
+                        .as_ref()
+                        .is_some_and(|r| !r.is_empty());
+                    if !has_jobs && !has_regexes {
+                        return Err(format!(
+                            "action with trigger_type '{}' must specify at least one job via \
+                             'jobs' or 'job_name_regexes'",
+                            action.trigger_type
+                        )
+                        .into());
+                    }
+                }
+
                 // Validate schedule_nodes actions
                 if action.action_type == "schedule_nodes" {
                     // Ensure scheduler_type is provided
@@ -9157,5 +9204,88 @@ jobs:
             .expect("KDL variables_demo should expand");
         assert_eq!(spec.jobs.len(), 6);
         assert_variables_demo_substituted(&spec);
+    }
+
+    /// Build a minimal spec carrying a single action, for `validate_actions` tests.
+    fn spec_with_action(action: WorkflowActionSpec) -> WorkflowSpec {
+        let mut spec = WorkflowSpec::new(
+            "wf".to_string(),
+            "user".to_string(),
+            None,
+            vec![JobSpec::new("job1".to_string(), "exit 0".to_string())],
+        );
+        spec.actions = Some(vec![action]);
+        spec
+    }
+
+    /// Build a `run_commands` action with the given trigger and optional gating jobs.
+    fn run_commands_action(trigger_type: &str, jobs: Option<Vec<String>>) -> WorkflowActionSpec {
+        WorkflowActionSpec {
+            trigger_type: trigger_type.to_string(),
+            action_type: "run_commands".to_string(),
+            jobs,
+            job_name_regexes: None,
+            commands: Some(vec!["echo hi".to_string()]),
+            scheduler: None,
+            scheduler_type: None,
+            num_allocations: None,
+            start_one_worker_per_node: None,
+            max_parallel_jobs: None,
+            persistent: None,
+        }
+    }
+
+    #[test]
+    fn test_validate_actions_rejects_unknown_trigger_type() {
+        // `on_ready_jobs` is a transposed typo of `on_jobs_ready`.
+        let spec = spec_with_action(run_commands_action("on_ready_jobs", None));
+        let err = spec
+            .validate_actions()
+            .expect_err("unknown trigger should fail");
+        let msg = err.to_string();
+        assert!(msg.contains("unknown trigger_type"), "got: {msg}");
+        assert!(msg.contains("on_ready_jobs"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_validate_actions_accepts_known_trigger_types() {
+        for trigger in WorkflowSpec::VALID_TRIGGER_TYPES {
+            // Job-gated triggers need a job; supply one unconditionally.
+            let spec =
+                spec_with_action(run_commands_action(trigger, Some(vec!["job1".to_string()])));
+            spec.validate_actions()
+                .unwrap_or_else(|e| panic!("trigger '{trigger}' should be valid: {e}"));
+        }
+    }
+
+    #[test]
+    fn test_validate_actions_rejects_job_gated_trigger_without_jobs() {
+        for trigger in ["on_jobs_ready", "on_jobs_complete"] {
+            let spec = spec_with_action(run_commands_action(trigger, None));
+            let err = spec
+                .validate_actions()
+                .expect_err("job-gated trigger without jobs should fail");
+            let msg = err.to_string();
+            assert!(msg.contains("must specify at least one job"), "got: {msg}");
+        }
+    }
+
+    #[test]
+    fn test_validate_actions_accepts_job_gated_trigger_with_regexes() {
+        let mut action = run_commands_action("on_jobs_ready", None);
+        action.job_name_regexes = Some(vec!["^job.*$".to_string()]);
+        let spec = spec_with_action(action);
+        spec.validate_actions()
+            .expect("regex-gated on_jobs_ready should be valid");
+    }
+
+    #[test]
+    fn test_validate_actions_rejects_job_gated_trigger_with_empty_jobs() {
+        // An explicitly-empty `jobs` list is as useless as omitting it.
+        let spec = spec_with_action(run_commands_action("on_jobs_complete", Some(vec![])));
+        let err = spec
+            .validate_actions()
+            .expect_err("empty jobs list should fail");
+        assert!(err.to_string().contains("must specify at least one job"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -968,12 +968,44 @@ fn main() {
                         *claim_backoff_max_secs,
                         &allocation_overrides,
                     ) {
-                        Ok(()) => {
+                        Ok(outcome) if outcome.allocations_submitted > 0 => {
                             print_workflow_message(
                                 &format,
                                 workflow_id,
-                                &format!("Successfully submitted workflow {}", workflow_id),
+                                &format!(
+                                    "Successfully submitted workflow {} ({} allocation(s))",
+                                    workflow_id, outcome.allocations_submitted
+                                ),
                             );
+                        }
+                        Ok(outcome) => {
+                            // Zero allocations submitted is not a benign "deferred" state: deferred
+                            // job-gated actions are only fired by running workers, and a worker
+                            // only exists because an allocation launched it. So nothing downstream
+                            // will fire what this submit declined to launch — report it as an error.
+                            eprintln!(
+                                "Error: submit launched 0 allocations for workflow {}",
+                                workflow_id
+                            );
+                            eprintln!();
+                            if outcome.slurm_actions_seen > 0 {
+                                eprintln!(
+                                    "{} pending slurm schedule_nodes action(s) were due but produced \
+                                     no allocations. They may have been claimed by a concurrent \
+                                     submitter, or their allocation counts were set to 0.",
+                                    outcome.slurm_actions_seen
+                                );
+                            } else {
+                                eprintln!(
+                                    "No slurm schedule_nodes actions were due. The workflow may \
+                                     already be running or complete, or it has no on_workflow_start \
+                                     / on_jobs_ready action to bootstrap the first allocation."
+                                );
+                                eprintln!();
+                                eprintln!("Check status with:");
+                                eprintln!("  torc workflows status {}", workflow_id);
+                            }
+                            std::process::exit(1);
                         }
                         Err(e) => {
                             eprintln!("Error submitting workflow {}: {}", workflow_id, e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -800,6 +800,7 @@ fn main() {
             output_dir,
             poll_interval,
             claim_backoff_max_secs,
+            no_prompts,
         } => {
             let workflow_id = if is_spec_file(workflow_spec_or_id) {
                 // Resolve the spec source once (handles `-` reading from stdin) so the
@@ -935,6 +936,27 @@ fn main() {
             // Submit the workflow
             match apis::workflows_api::get_workflow(&config, workflow_id) {
                 Ok(workflow) => {
+                    // On a re-submission (run_id > 1) the reinitialize re-arm logic can leave
+                    // schedule_nodes actions pending that submit would fire, possibly with a
+                    // different allocation count than the user now wants. Show what submit will
+                    // submit now (and what is deferred to later stages) and let the user disable
+                    // actions or change their per-submission allocation count. Disabled actions are
+                    // suppressed in here; the returned map carries per-action allocation overrides
+                    // for this submission only.
+                    let run_id = workflow.run_id.unwrap_or(1);
+                    let allocation_overrides =
+                        match torc::client::commands::slurm::review_submit_pending_actions(
+                            &config,
+                            workflow_id,
+                            run_id,
+                            *no_prompts,
+                        ) {
+                            Ok(overrides) => overrides,
+                            Err(e) => {
+                                eprintln!("Error reviewing pending schedule_nodes actions: {}", e);
+                                std::process::exit(1);
+                            }
+                        };
                     let torc_config = TorcConfig::load().unwrap_or_default();
                     let workflow_manager =
                         WorkflowManager::new(config.clone(), torc_config, workflow);
@@ -944,6 +966,7 @@ fn main() {
                         output_dir,
                         *poll_interval,
                         *claim_backoff_max_secs,
+                        &allocation_overrides,
                     ) {
                         Ok(()) => {
                             print_workflow_message(

--- a/src/main.rs
+++ b/src/main.rs
@@ -828,7 +828,8 @@ fn main() {
                     eprintln!("Error: Cannot submit workflow");
                     eprintln!();
                     eprintln!(
-                        "The spec does not define an on_workflow_start action with schedule_nodes."
+                        "The spec does not define a schedule_nodes action (on_workflow_start, \
+                         on_jobs_ready, or on_jobs_complete)."
                     );
                     eprintln!("To submit to Slurm, either:");
                     eprintln!();
@@ -894,20 +895,26 @@ fn main() {
                 }
             };
 
-            // Check if workflow has schedule_nodes actions (for existing workflows)
+            // Check if workflow has schedule_nodes actions (for existing workflows). submit fires
+            // every pending Slurm schedule_nodes action regardless of trigger type, so any of
+            // on_workflow_start / on_jobs_ready / on_jobs_complete makes the workflow submittable.
             if !is_spec_file(workflow_spec_or_id) {
                 match apis::workflow_actions_api::get_workflow_actions(&config, workflow_id) {
                     Ok(actions) => {
                         let has_schedule_nodes = actions.iter().any(|action| {
-                            action.trigger_type == "on_workflow_start"
-                                && action.action_type == "schedule_nodes"
+                            action.action_type == "schedule_nodes"
+                                && matches!(
+                                    action.trigger_type.as_str(),
+                                    "on_workflow_start" | "on_jobs_ready" | "on_jobs_complete"
+                                )
                         });
 
                         if !has_schedule_nodes {
                             eprintln!("Error: Cannot submit workflow {}", workflow_id);
                             eprintln!();
                             eprintln!(
-                                "The workflow does not define an on_workflow_start action with schedule_nodes."
+                                "The workflow has no schedule_nodes action (on_workflow_start, \
+                                 on_jobs_ready, or on_jobs_complete)."
                             );
                             eprintln!(
                                 "To submit to a scheduler, the workflow must have an action configured."

--- a/src/server/api/workflow_actions.rs
+++ b/src/server/api/workflow_actions.rs
@@ -803,14 +803,21 @@ impl WorkflowActionsApiImpl {
     /// - `on_workflow_complete`, `on_worker_start`, `on_worker_complete` → **re-arm**. These recur
     ///   every run (the workflow will complete again; new workers start), so they should fire again.
     ///
-    /// This keep-on-`on_workflow_start` behavior makes the server the single point that prevents
-    /// reinit from resurrecting already-satisfied actions, so every entry point (`reinit`,
-    /// `reset-status --reinit`, `recover`, `regenerate`, `watch`) is covered; the client-side
-    /// recover/regenerate guards remain as defense in depth.
-    pub async fn reset_actions_for_reinitialize(&self, workflow_id: i64) -> Result<(), ApiError> {
+    /// The keep logic above applies only to a **partial** reinitialize (`only_uninitialized = true`:
+    /// `reinit`, `reset-status --reinit`, `recover`, `regenerate`, `watch`), which is the case that
+    /// must not resurrect already-satisfied actions. A **full** initialize (`only_uninitialized =
+    /// false`, i.e. `torc workflows init`, which first resets every job to uninitialized) is a clean
+    /// slate: every action is re-armed, including `on_workflow_start`. Otherwise re-running
+    /// `workflows init` on a workflow that already ran would leave its `on_workflow_start` actions
+    /// suppressed forever.
+    pub async fn reset_actions_for_reinitialize(
+        &self,
+        workflow_id: i64,
+        only_uninitialized: bool,
+    ) -> Result<(), ApiError> {
         debug!(
-            "reset_actions_for_reinitialize(workflow_id={})",
-            workflow_id
+            "reset_actions_for_reinitialize(workflow_id={}, only_uninitialized={})",
+            workflow_id, only_uninitialized
         );
 
         // First, delete all recovery actions (ephemeral actions created during recovery)
@@ -892,40 +899,46 @@ impl WorkflowActionsApiImpl {
             // iff its triggering condition will genuinely re-occur in the new run. "Keep" only
             // preserves the flag -- a never-fired action keeps `executed = 0` and stays fireable. See
             // the function doc comment for the full rationale and the per-trigger reasoning.
-            let keep_executed = match trigger_type.as_str() {
-                // The workflow starts exactly once in its lifetime; a reinitialize is NOT a new
-                // start. Keep on_workflow_start actions suppressed so reinit never re-runs start-time
-                // setup (run_commands) or re-submits start-time allocations (schedule_nodes).
-                "on_workflow_start" => true,
+            //
+            // A full initialize (only_uninitialized = false, e.g. `torc workflows init`) is a clean
+            // slate: it reset every job, so re-arm every action (never keep). The per-trigger keep
+            // logic below applies only to a partial reinitialize.
+            let keep_executed = only_uninitialized
+                && match trigger_type.as_str() {
+                    // The workflow starts exactly once per run-from-the-top; a *partial* reinitialize
+                    // is NOT a new start. Keep on_workflow_start actions suppressed so reinit never
+                    // re-runs start-time setup (run_commands) or re-submits start-time allocations
+                    // (schedule_nodes).
+                    "on_workflow_start" => true,
 
-                // Job-gated: the condition re-occurs iff the gating jobs will run again, i.e. they
-                // are no longer all in a terminal state. Measured with the terminal-state
-                // (on_jobs_complete) notion for BOTH triggers, NOT trigger_count: a reset
-                // on_jobs_ready gate returns to Ready, and Ready would spuriously satisfy
-                // on_jobs_ready and wrongly keep the action suppressed on a full re-run. This is
-                // action-type-agnostic on purpose -- the hazard is a duplicate side effect (a
-                // re-submitted allocation, a re-run command), not anything specific to
-                // schedule_nodes.
-                "on_jobs_ready" | "on_jobs_complete" => {
-                    if job_ids.is_empty() {
-                        false
-                    } else {
-                        let already_ran = self
-                            .count_jobs_in_satisfied_state(
-                                workflow_id,
-                                &job_ids,
-                                "on_jobs_complete",
-                            )
-                            .await?;
-                        already_ran >= required_triggers
+                    // Job-gated: the condition re-occurs iff the gating jobs will run again, i.e. they
+                    // are no longer all in a terminal state. Measured with the terminal-state
+                    // (on_jobs_complete) notion for BOTH triggers, NOT trigger_count: a reset
+                    // on_jobs_ready gate returns to Ready, and Ready would spuriously satisfy
+                    // on_jobs_ready and wrongly keep the action suppressed on a full re-run. This is
+                    // action-type-agnostic on purpose -- the hazard is a duplicate side effect (a
+                    // re-submitted allocation, a re-run command), not anything specific to
+                    // schedule_nodes.
+                    "on_jobs_ready" | "on_jobs_complete" => {
+                        if job_ids.is_empty() {
+                            false
+                        } else {
+                            let already_ran = self
+                                .count_jobs_in_satisfied_state(
+                                    workflow_id,
+                                    &job_ids,
+                                    "on_jobs_complete",
+                                )
+                                .await?;
+                            already_ran >= required_triggers
+                        }
                     }
-                }
 
-                // on_workflow_complete (the workflow will complete again once the re-run finishes)
-                // and on_worker_start / on_worker_complete (new workers run in the new run) genuinely
-                // recur each run, so they are always re-armed.
-                _ => false,
-            };
+                    // on_workflow_complete (the workflow will complete again once the re-run finishes)
+                    // and on_worker_start / on_worker_complete (new workers run in the new run)
+                    // genuinely recur each run, so they are always re-armed.
+                    _ => false,
+                };
 
             let result = if keep_executed {
                 // Leave executed/executed_by intact; only refresh trigger_count.

--- a/src/server/http_server.rs
+++ b/src/server/http_server.rs
@@ -956,7 +956,7 @@ impl<C> Server<C> {
         // idempotent, so a failed (re)initialize can be safely retried.
         if let Err(e) = self
             .workflow_actions_api
-            .reset_actions_for_reinitialize(id)
+            .reset_actions_for_reinitialize(id, only_uninit)
             .await
         {
             error!(

--- a/tests/test_hpc.rs
+++ b/tests/test_hpc.rs
@@ -385,12 +385,13 @@ fn test_generate_schedulers_basic() {
     let actions = spec.actions.as_ref().unwrap();
     assert_eq!(actions.len(), 2);
 
-    // Jobs without dependencies use on_workflow_start
+    // Every scheduler is tied to its jobs via on_jobs_ready (root jobs are Ready at init), so
+    // generated workflows are re-run-safe.
     let small_action = actions
         .iter()
         .find(|a| a.scheduler.as_deref() == Some("small_scheduler"))
         .unwrap();
-    assert_eq!(small_action.trigger_type, "on_workflow_start");
+    assert_eq!(small_action.trigger_type, "on_jobs_ready");
     assert_eq!(small_action.action_type, "schedule_nodes");
 
     // Jobs with dependencies use on_jobs_ready
@@ -1199,12 +1200,12 @@ fn test_generate_schedulers_per_resource_requirement() {
         Some("small_deferred_scheduler")
     ); // finalize (has deps)
 
-    // Jobs without dependencies use on_workflow_start
+    // Every scheduler is tied to its jobs via on_jobs_ready (root jobs are Ready at init).
     let small_action = actions
         .iter()
         .find(|a| a.scheduler.as_deref() == Some("small_scheduler"))
         .unwrap();
-    assert_eq!(small_action.trigger_type, "on_workflow_start");
+    assert_eq!(small_action.trigger_type, "on_jobs_ready");
 
     // Jobs with dependencies use on_jobs_ready
     let medium_action = actions
@@ -1424,7 +1425,7 @@ fn test_generate_schedulers_stage_aware_for_dependent_jobs() {
         .iter()
         .find(|a| a.scheduler.as_deref() == Some("small_scheduler"))
         .unwrap();
-    assert_eq!(job1_action.trigger_type, "on_workflow_start");
+    assert_eq!(job1_action.trigger_type, "on_jobs_ready");
 
     let job2_action = actions
         .iter()

--- a/tests/test_slurm_commands.rs
+++ b/tests/test_slurm_commands.rs
@@ -2391,7 +2391,8 @@ fn test_slurm_generate_auto_merge_small_allocations() {
         serde_json::to_string_pretty(&actions).unwrap()
     );
 
-    // Verify the action uses on_workflow_start (not on_jobs_ready)
+    // The merged scheduler covers root jobs, which are Ready at init; it is tied to those jobs via
+    // on_jobs_ready (re-run-safe) rather than on_workflow_start.
     let action = &actions[0];
     let trigger_type = action
         .get("trigger_type")
@@ -2399,8 +2400,8 @@ fn test_slurm_generate_auto_merge_small_allocations() {
         .expect("Expected trigger_type");
 
     assert_eq!(
-        trigger_type, "on_workflow_start",
-        "Merged scheduler should use on_workflow_start trigger (not on_jobs_ready)"
+        trigger_type, "on_jobs_ready",
+        "Merged root-job scheduler should use on_jobs_ready trigger"
     );
 
     // Verify all jobs are assigned to the same scheduler
@@ -2550,19 +2551,17 @@ fn test_slurm_generate_no_merge_large_allocations() {
         serde_json::to_string_pretty(&actions).unwrap()
     );
 
-    // Verify we have both on_workflow_start and on_jobs_ready triggers
+    // Both schedulers are tied to their jobs via on_jobs_ready (root jobs are Ready at init, deferred
+    // jobs when their dependencies complete), so generated workflows are re-run-safe.
     let trigger_types: Vec<&str> = actions
         .iter()
         .filter_map(|a| a.get("trigger_type").and_then(|t| t.as_str()))
         .collect();
 
     assert!(
-        trigger_types.contains(&"on_workflow_start"),
-        "Should have on_workflow_start action"
-    );
-    assert!(
-        trigger_types.contains(&"on_jobs_ready"),
-        "Should have on_jobs_ready action for deferred jobs"
+        trigger_types.iter().all(|t| *t == "on_jobs_ready"),
+        "All generated actions should use on_jobs_ready, got {:?}",
+        trigger_types
     );
 
     // Temp file is automatically cleaned up when workflow_file goes out of scope

--- a/tests/test_slurm_commands.rs
+++ b/tests/test_slurm_commands.rs
@@ -2404,6 +2404,34 @@ fn test_slurm_generate_auto_merge_small_allocations() {
         "Merged root-job scheduler should use on_jobs_ready trigger"
     );
 
+    // Deadlock guard: the merged action must be gated on the ROOT job(s) only ("build"), not the
+    // dependent jobs that were merged into the same scheduler ("join"/"job_*"). An on_jobs_ready
+    // action only becomes pending once ALL its gating jobs are Ready, so gating on a dependent job
+    // would never fire at workflow start (the dependent jobs need this allocation to run) -> the
+    // root jobs would never be scheduled.
+    let action_jobs: Vec<&str> = action
+        .get("jobs")
+        .and_then(|j| j.as_array())
+        .expect("merged action should specify gating jobs")
+        .iter()
+        .filter_map(|v| v.as_str())
+        .collect();
+    assert!(
+        action_jobs.contains(&"build"),
+        "merged action must be gated on the root job 'build', got {:?}",
+        action_jobs
+    );
+    assert!(
+        !action_jobs.contains(&"join"),
+        "merged action must NOT be gated on the dependent job 'join' (would deadlock at start), got {:?}",
+        action_jobs
+    );
+    assert!(
+        !action_jobs.iter().any(|j| j.starts_with("job_")),
+        "merged action must NOT be gated on dependent 'job_*' jobs (would deadlock at start), got {:?}",
+        action_jobs
+    );
+
     // Verify all jobs are assigned to the same scheduler
     // Note: slurm generate returns the spec before parameter expansion,
     // so we have 3 job specs (build, job_{i}, join), not 12 expanded jobs

--- a/tests/test_slurm_regenerate.rs
+++ b/tests/test_slurm_regenerate.rs
@@ -782,3 +782,66 @@ fn test_regenerate_json_output_structure(start_server: &ServerProcess) {
     assert!(json.get("warnings").unwrap().is_array());
     assert!(json.get("submitted").unwrap().is_boolean());
 }
+
+/// Regenerate must create the recovery `on_jobs_ready` action for ready-now jobs in the **Pending**
+/// state (trigger_count >= required_triggers), not Waiting.
+///
+/// This is the linchpin of routing recovery scheduling through actions: `torc submit` (and
+/// `regenerate --submit`) only fire actions that are already pending, so a ready-now recovery action
+/// born Waiting (trigger_count 0) would never fire — the bug where `recover` had to schedule the
+/// allocation directly *and* leave behind a perpetually-Waiting action. Here the gate jobs are all
+/// Ready at creation time, so the action must be armed.
+#[rstest]
+fn test_regenerate_ready_jobs_create_pending_recovery_action(start_server: &ServerProcess) {
+    let config = &start_server.config;
+
+    let job_configs: Vec<(String, models::JobStatus)> = (0..5)
+        .map(|i| (format!("job_{}", i), models::JobStatus::Ready))
+        .collect();
+
+    let (workflow_id, _job_ids) =
+        create_workflow_with_job_states(config, "test_regenerate_pending_action", &job_configs);
+
+    let args = [
+        "slurm",
+        "regenerate",
+        &workflow_id.to_string(),
+        "--account",
+        "test_account",
+        "--profile",
+        "kestrel",
+    ];
+    let result = run_cli_with_json(&args, start_server, None);
+    assert!(result.is_ok(), "Regenerate command failed: {:?}", result);
+
+    let actions = apis::workflow_actions_api::get_workflow_actions(config, workflow_id)
+        .expect("Failed to fetch workflow actions");
+
+    let recovery_actions: Vec<&models::WorkflowActionModel> = actions
+        .iter()
+        .filter(|a| {
+            a.action_type == "schedule_nodes" && a.is_recovery && a.trigger_type == "on_jobs_ready"
+        })
+        .collect();
+
+    assert!(
+        !recovery_actions.is_empty(),
+        "regenerate should create at least one on_jobs_ready recovery action"
+    );
+
+    // Every ready-now recovery action must be armed (Pending), and required_triggers must reflect
+    // the gated job count (the server sets it to job_ids.len()).
+    for action in &recovery_actions {
+        assert!(
+            action.required_triggers > 0,
+            "required_triggers should equal the gated job count, got {}",
+            action.required_triggers
+        );
+        assert!(
+            action.trigger_count >= action.required_triggers,
+            "ready-now recovery action must be Pending: trigger_count ({}) >= required_triggers ({})",
+            action.trigger_count,
+            action.required_triggers
+        );
+    }
+}

--- a/tests/test_workflow_actions.rs
+++ b/tests/test_workflow_actions.rs
@@ -3362,3 +3362,109 @@ fn test_schedule_nodes_suppress_ignores_run_commands(start_server: &ServerProces
         "run_commands action must not be suppressed (only schedule_nodes is the hazard)"
     );
 }
+
+/// On the first run (`run_id <= 1`) the submit review is a no-op: there is nothing to reconcile, so
+/// it returns no overrides without inspecting or mutating any action.
+#[rstest]
+fn test_review_submit_pending_actions_first_run_is_noop(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let workflow = create_test_workflow(config, "review_submit_first_run");
+    let workflow_id = workflow.id.unwrap();
+
+    let action = apis::workflow_actions_api::create_workflow_action(
+        config,
+        workflow_id,
+        workflow_action(
+            workflow_id,
+            "on_workflow_start",
+            "schedule_nodes",
+            json!({"scheduler_type": "slurm", "scheduler_id": 1, "num_allocations": 2}),
+            None,
+        ),
+    )
+    .expect("create action");
+    let action_id = action.id.unwrap();
+
+    let overrides = torc::client::commands::slurm::review_submit_pending_actions(
+        config,
+        workflow_id,
+        1, // first run
+        false,
+    )
+    .expect("review");
+
+    assert!(
+        overrides.is_empty(),
+        "first-run review must not produce allocation overrides"
+    );
+    assert!(
+        !fetch_action(config, workflow_id, action_id).executed,
+        "first-run review must not suppress any action"
+    );
+}
+
+/// On a re-submission (`run_id > 1`) the review must NEVER suppress or change anything when run
+/// non-interactively (the test harness has a non-TTY stdin, which the helper treats like
+/// `--no-prompts`): it prints what will happen and proceeds with the configured counts. This guards
+/// the safe default — the interactive disable/override path is opt-in only.
+#[rstest]
+fn test_review_submit_pending_actions_noninteractive_does_not_suppress(
+    start_server: &ServerProcess,
+) {
+    let config = &start_server.config;
+    let workflow = create_test_workflow(config, "review_submit_noninteractive");
+    let workflow_id = workflow.id.unwrap();
+    let manager = WorkflowManager::new(
+        config.clone(),
+        TorcConfig::load().unwrap_or_default(),
+        workflow,
+    );
+
+    // Root job gated by an on_jobs_ready schedule_nodes action; after initialize the root job is
+    // Ready, so the action becomes pending (the "submit now" group).
+    let job_id = create_test_job(config, workflow_id, "root")
+        .expect("create root")
+        .id
+        .unwrap();
+    let action = apis::workflow_actions_api::create_workflow_action(
+        config,
+        workflow_id,
+        workflow_action(
+            workflow_id,
+            "on_jobs_ready",
+            "schedule_nodes",
+            json!({"scheduler_type": "slurm", "scheduler_id": 1, "num_allocations": 3}),
+            Some(vec![job_id]),
+        ),
+    )
+    .expect("create action");
+    let action_id = action.id.unwrap();
+
+    manager.initialize(true).expect("initialize");
+    wait_for_pending_action(config, workflow_id);
+    assert!(
+        action_is_pending(config, workflow_id, action_id),
+        "action should be pending after initialize"
+    );
+
+    let overrides = torc::client::commands::slurm::review_submit_pending_actions(
+        config,
+        workflow_id,
+        2, // re-submission
+        false,
+    )
+    .expect("review");
+
+    assert!(
+        overrides.is_empty(),
+        "non-interactive review must not override allocation counts"
+    );
+    assert!(
+        action_is_pending(config, workflow_id, action_id),
+        "non-interactive review must leave the pending action pending (not suppressed)"
+    );
+    assert!(
+        !fetch_action(config, workflow_id, action_id).executed,
+        "non-interactive review must not mark the action executed"
+    );
+}

--- a/tests/test_workflow_actions.rs
+++ b/tests/test_workflow_actions.rs
@@ -3218,3 +3218,147 @@ fn test_full_init_rearms_workflow_start_action(start_server: &ServerProcess) {
         "re-armed on_workflow_start should be pending again after a full init"
     );
 }
+
+// ===========================================================================
+// `torc slurm schedule-nodes` pending-action handling
+// (handle_pending_schedule_actions): a worker started by schedule-nodes would claim the workflow's
+// own pending schedule_nodes actions and submit their allocations on top of the manual request.
+// --suppress-actions marks them executed; --no-prompts (non-interactive) proceeds and lets them
+// fire. These call the helper directly (no Slurm submission / sbatch needed).
+// ===========================================================================
+
+/// Create a workflow with one job and a pending `on_workflow_start` `schedule_nodes` action
+/// (pending right after initialize). Returns (workflow_id, action_id).
+fn workflow_with_pending_schedule_action(
+    config: &torc::client::Configuration,
+    name: &str,
+) -> (i64, i64) {
+    let workflow = create_test_workflow(config, name);
+    let workflow_id = workflow.id.unwrap();
+    let manager = WorkflowManager::new(
+        config.clone(),
+        TorcConfig::load().unwrap_or_default(),
+        workflow,
+    );
+    create_test_job(config, workflow_id, "j1").expect("create job");
+    let action_id = apis::workflow_actions_api::create_workflow_action(
+        config,
+        workflow_id,
+        workflow_action(
+            workflow_id,
+            "on_workflow_start",
+            "schedule_nodes",
+            schedule_nodes_config(),
+            None,
+        ),
+    )
+    .expect("create action")
+    .id
+    .unwrap();
+    manager.initialize(true).expect("initialize");
+    wait_for_pending_action(config, workflow_id);
+    (workflow_id, action_id)
+}
+
+/// `--suppress-actions`: a pending `schedule_nodes` action is marked executed so the worker started
+/// by `schedule-nodes` will not re-fire it.
+#[rstest]
+fn test_schedule_nodes_suppress_actions_marks_pending_executed(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let (workflow_id, action_id) =
+        workflow_with_pending_schedule_action(config, "schedule_nodes_suppress");
+    assert!(
+        !fetch_action(config, workflow_id, action_id).executed,
+        "precondition: action is pending (not executed)"
+    );
+
+    torc::client::commands::slurm::handle_pending_schedule_actions(
+        config,
+        workflow_id,
+        1,
+        /* suppress_actions */ true,
+        /* no_prompts */ false,
+    )
+    .expect("handle_pending_schedule_actions");
+
+    assert!(
+        fetch_action(config, workflow_id, action_id).executed,
+        "--suppress-actions must mark the pending schedule_nodes action executed"
+    );
+    assert!(
+        !action_is_pending(config, workflow_id, action_id),
+        "suppressed action must no longer be pending"
+    );
+}
+
+/// `--no-prompts` (non-interactive, no `--suppress-actions`): proceed and leave the action armed so
+/// it still fires (historical behavior).
+#[rstest]
+fn test_schedule_nodes_no_prompts_proceeds_without_suppressing(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let (workflow_id, action_id) =
+        workflow_with_pending_schedule_action(config, "schedule_nodes_no_prompts");
+
+    torc::client::commands::slurm::handle_pending_schedule_actions(
+        config,
+        workflow_id,
+        1,
+        /* suppress_actions */ false,
+        /* no_prompts */ true,
+    )
+    .expect("handle_pending_schedule_actions");
+
+    assert!(
+        !fetch_action(config, workflow_id, action_id).executed,
+        "--no-prompts without --suppress-actions must leave the action armed (proceed)"
+    );
+    assert!(
+        action_is_pending(config, workflow_id, action_id),
+        "un-suppressed action must remain pending so the worker still fires it"
+    );
+}
+
+/// The helper only targets `schedule_nodes` actions: a pending `run_commands` action is left armed
+/// even with `--suppress-actions` (it does not submit Slurm allocations, so it is not the hazard).
+#[rstest]
+fn test_schedule_nodes_suppress_ignores_run_commands(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let workflow = create_test_workflow(config, "schedule_nodes_ignores_run_commands");
+    let workflow_id = workflow.id.unwrap();
+    let manager = WorkflowManager::new(
+        config.clone(),
+        TorcConfig::load().unwrap_or_default(),
+        workflow,
+    );
+    create_test_job(config, workflow_id, "j1").expect("create job");
+    let action_id = apis::workflow_actions_api::create_workflow_action(
+        config,
+        workflow_id,
+        workflow_action(
+            workflow_id,
+            "on_workflow_start",
+            "run_commands",
+            json!({ "commands": ["echo hi"] }),
+            None,
+        ),
+    )
+    .expect("create action")
+    .id
+    .unwrap();
+    manager.initialize(true).expect("initialize");
+    wait_for_pending_action(config, workflow_id);
+
+    torc::client::commands::slurm::handle_pending_schedule_actions(
+        config,
+        workflow_id,
+        1,
+        /* suppress_actions */ true,
+        /* no_prompts */ false,
+    )
+    .expect("handle_pending_schedule_actions");
+
+    assert!(
+        !fetch_action(config, workflow_id, action_id).executed,
+        "run_commands action must not be suppressed (only schedule_nodes is the hazard)"
+    );
+}

--- a/tests/test_workflow_actions.rs
+++ b/tests/test_workflow_actions.rs
@@ -3153,3 +3153,68 @@ fn test_submit_pending_set_after_subset_reinit_is_only_reset_classes(start_serve
         "regular action should remain executed (kept) after the subset reinit"
     );
 }
+
+// ===========================================================================
+// Full init (`torc workflows init`, only_uninitialized = false) is a clean slate: it resets every
+// job and re-arms EVERY action, including on_workflow_start. This contrasts with a partial
+// reinitialize (only_uninitialized = true), which keeps a satisfied on_workflow_start action
+// (test_workflow_start_schedule_action_kept_on_reinitialize).
+// ===========================================================================
+
+/// A full initialize re-arms an already-fired on_workflow_start action (clean slate), so re-running
+/// `torc workflows init` on a workflow that already ran does not leave its start actions stranded.
+#[rstest]
+fn test_full_init_rearms_workflow_start_action(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let workflow = create_test_workflow(config, "full_init_rearms_workflow_start");
+    let workflow_id = workflow.id.unwrap();
+    let manager = WorkflowManager::new(
+        config.clone(),
+        TorcConfig::load().unwrap_or_default(),
+        workflow,
+    );
+
+    create_test_job(config, workflow_id, "j1").expect("create job");
+    let action = apis::workflow_actions_api::create_workflow_action(
+        config,
+        workflow_id,
+        workflow_action(
+            workflow_id,
+            "on_workflow_start",
+            "schedule_nodes",
+            schedule_nodes_config(),
+            None,
+        ),
+    )
+    .expect("create action");
+    let action_id = action.id.unwrap();
+
+    // First init: on_workflow_start is pending; claim it (fired).
+    manager.initialize(true).expect("initialize");
+    let compute_node_id = create_test_compute_node(config, workflow_id).expect("compute node");
+    wait_for_pending_action(config, workflow_id);
+    apis::workflow_actions_api::claim_action(
+        config,
+        workflow_id,
+        action_id,
+        ClaimActionRequest {
+            compute_node_id: Some(compute_node_id),
+        },
+    )
+    .expect("claim action");
+    assert!(fetch_action(config, workflow_id, action_id).executed);
+
+    // Full init again (what `torc workflows init` does: reset all jobs + initialize). This is a
+    // clean slate, so the on_workflow_start action is re-armed (unlike a partial reinitialize, which
+    // keeps it).
+    manager.initialize(true).expect("re-initialize (full)");
+
+    assert!(
+        !fetch_action(config, workflow_id, action_id).executed,
+        "full init must re-arm on_workflow_start (clean slate)"
+    );
+    assert!(
+        action_is_pending(config, workflow_id, action_id),
+        "re-armed on_workflow_start should be pending again after a full init"
+    );
+}

--- a/tests/test_workflow_actions.rs
+++ b/tests/test_workflow_actions.rs
@@ -2978,3 +2978,178 @@ fn test_reinit_workflow_complete_rearmed_matrix(
     );
     wait_for_specific_action_pending(config, workflow_id, action_id);
 }
+
+// ===========================================================================
+// `torc submit` supports on_jobs_ready scheduling: after a subset re-run, the set of pending
+// schedule_nodes actions that submit fires (across on_workflow_start / on_jobs_ready /
+// on_jobs_complete) must be exactly the reset classes. This is the selection that lets
+// `reset-status <ids> --reinit` + `submit` re-schedule only the jobs being re-run.
+// ===========================================================================
+
+/// True if `action_id` is in the set of pending schedule_nodes actions that `WorkflowManager::start`
+/// (i.e. `torc submit`) would fire: pending actions across the three schedule-capable trigger types.
+fn action_in_submit_pending_set(
+    config: &torc::client::Configuration,
+    workflow_id: i64,
+    action_id: i64,
+) -> bool {
+    apis::workflow_actions_api::get_pending_actions(
+        config,
+        workflow_id,
+        Some(vec![
+            "on_workflow_start".to_string(),
+            "on_jobs_ready".to_string(),
+            "on_jobs_complete".to_string(),
+        ]),
+    )
+    .expect("get_pending_actions")
+    .iter()
+    .any(|a| a.id == Some(action_id))
+}
+
+/// The reported scenario: per-class `on_jobs_ready` schedule_nodes actions (regular / bigmem / gpu),
+/// plus a postprocess job depending on all three with its own action. Run once, then reset only the
+/// gpu + bigmem jobs and reinitialize. The submit pending-set must then be EXACTLY {gpu, bigmem}:
+/// regular stays suppressed (its jobs are still terminal), and postprocess is not pending (its job is
+/// Blocked). So `torc submit` re-schedules only the gpu + bigmem allocations.
+#[rstest]
+fn test_submit_pending_set_after_subset_reinit_is_only_reset_classes(start_server: &ServerProcess) {
+    let config = &start_server.config;
+    let workflow = create_test_workflow(config, "submit_on_jobs_ready_subset");
+    let workflow_id = workflow.id.unwrap();
+    let manager = WorkflowManager::new(
+        config.clone(),
+        TorcConfig::load().unwrap_or_default(),
+        workflow,
+    );
+
+    // Three root job classes + a postprocess job gated on all of them.
+    let regular = create_test_job(config, workflow_id, "regular1")
+        .expect("create regular")
+        .id
+        .unwrap();
+    let bigmem = create_test_job(config, workflow_id, "bigmem1")
+        .expect("create bigmem")
+        .id
+        .unwrap();
+    let gpu = create_test_job(config, workflow_id, "gpu1")
+        .expect("create gpu")
+        .id
+        .unwrap();
+    let mut post = JobModel::new(
+        workflow_id,
+        "postprocess".to_string(),
+        "echo post".to_string(),
+    );
+    post.depends_on_job_ids = Some(vec![regular, bigmem, gpu]);
+    post.cancel_on_blocking_job_failure = Some(false);
+    let post_id = apis::jobs_api::create_job(config, post)
+        .expect("create postprocess")
+        .id
+        .unwrap();
+
+    // One on_jobs_ready schedule_nodes action per class + one for postprocess.
+    let mk_action = |trigger_jobs: Vec<i64>| {
+        apis::workflow_actions_api::create_workflow_action(
+            config,
+            workflow_id,
+            workflow_action(
+                workflow_id,
+                "on_jobs_ready",
+                "schedule_nodes",
+                schedule_nodes_config(),
+                Some(trigger_jobs),
+            ),
+        )
+        .expect("create action")
+        .id
+        .unwrap()
+    };
+    let reg_action = mk_action(vec![regular]);
+    let big_action = mk_action(vec![bigmem]);
+    let gpu_action = mk_action(vec![gpu]);
+    let post_action = mk_action(vec![post_id]);
+
+    manager.initialize(true).expect("initialize");
+    let run_id = manager.get_run_id().expect("run_id");
+    let compute_node_id = create_test_compute_node(config, workflow_id).expect("compute node");
+
+    // Run 1: the three roots are Ready at init, so their actions are pending. Claim each (fired),
+    // then complete the jobs so postprocess becomes ready; claim its action and run postprocess.
+    for (job, action) in [
+        (regular, reg_action),
+        (bigmem, big_action),
+        (gpu, gpu_action),
+    ] {
+        wait_for_specific_action_pending(config, workflow_id, action);
+        apis::workflow_actions_api::claim_action(
+            config,
+            workflow_id,
+            action,
+            ClaimActionRequest {
+                compute_node_id: Some(compute_node_id),
+            },
+        )
+        .expect("claim class action");
+        run_job_to_status(
+            config,
+            workflow_id,
+            job,
+            run_id,
+            compute_node_id,
+            0,
+            JobStatus::Completed,
+        );
+    }
+    wait_for_job_status(config, post_id, JobStatus::Ready);
+    wait_for_specific_action_pending(config, workflow_id, post_action);
+    apis::workflow_actions_api::claim_action(
+        config,
+        workflow_id,
+        post_action,
+        ClaimActionRequest {
+            compute_node_id: Some(compute_node_id),
+        },
+    )
+    .expect("claim postprocess action");
+    run_job_to_status(
+        config,
+        workflow_id,
+        post_id,
+        run_id,
+        compute_node_id,
+        1,
+        JobStatus::Failed,
+    );
+
+    // Subset re-run: reset only gpu + bigmem (postprocess cascade-resets since it depends on them),
+    // then reinitialize. regular is left untouched.
+    apis::jobs_api::manage_status_change(config, gpu, JobStatus::Uninitialized, run_id)
+        .expect("reset gpu");
+    apis::jobs_api::manage_status_change(config, bigmem, JobStatus::Uninitialized, run_id)
+        .expect("reset bigmem");
+    manager.reinitialize(true, false).expect("reinitialize");
+
+    // The submit pending-set must be exactly {gpu, bigmem}.
+    assert!(
+        action_in_submit_pending_set(config, workflow_id, gpu_action),
+        "gpu action must be pending (gpu was reset and is Ready) so submit re-schedules it"
+    );
+    assert!(
+        action_in_submit_pending_set(config, workflow_id, big_action),
+        "bigmem action must be pending (bigmem was reset and is Ready) so submit re-schedules it"
+    );
+    assert!(
+        !action_in_submit_pending_set(config, workflow_id, reg_action),
+        "regular action must NOT be pending (its jobs stayed terminal) so submit does not re-schedule it"
+    );
+    assert!(
+        !action_in_submit_pending_set(config, workflow_id, post_action),
+        "postprocess action must NOT be pending yet (postprocess is Blocked); a running worker fires it later"
+    );
+    // regular's action stays executed (kept), confirming it was suppressed rather than just unready.
+    assert!(
+        fetch_action(config, workflow_id, reg_action).executed,
+        "regular action should remain executed (kept) after the subset reinit"
+    );
+}

--- a/tests/test_workflow_spec.rs
+++ b/tests/test_workflow_spec.rs
@@ -3049,6 +3049,51 @@ fn test_validate_spec_complete_workflow() {
     );
 }
 
+/// A spec whose only schedule_nodes action is `on_jobs_ready` (no on_workflow_start) is still
+/// submittable: `torc submit` fires every pending Slurm schedule_nodes action regardless of trigger,
+/// so `has_schedule_nodes_action` must report true.
+#[test]
+fn test_validate_spec_on_jobs_ready_schedule_action_is_submittable() {
+    let workflow_data = serde_json::json!({
+        "name": "on_jobs_ready_only",
+        "jobs": [
+            {"name": "root1", "command": "echo root", "resource_requirements": "small"}
+        ],
+        "resource_requirements": [
+            {"name": "small", "num_cpus": 1, "num_nodes": 1, "memory": "1g"}
+        ],
+        "slurm_schedulers": [
+            {"name": "sched", "account": "test", "nodes": 1, "walltime": "01:00:00"}
+        ],
+        "actions": [
+            {
+                "trigger_type": "on_jobs_ready",
+                "action_type": "schedule_nodes",
+                "jobs": ["root1"],
+                "scheduler": "sched",
+                "scheduler_type": "slurm"
+            }
+        ]
+    });
+
+    let temp_file = tempfile::Builder::new()
+        .suffix(".json")
+        .tempfile()
+        .expect("Failed to create temp file");
+    fs::write(
+        temp_file.path(),
+        serde_json::to_string_pretty(&workflow_data).unwrap(),
+    )
+    .expect("Failed to write temp file");
+
+    let result = WorkflowSpec::validate_spec(temp_file.path());
+    assert!(result.valid, "Expected validation to pass");
+    assert!(
+        result.summary.has_schedule_nodes_action,
+        "on_jobs_ready schedule_nodes action must count as submittable"
+    );
+}
+
 /// Test that validate_spec detects duplicate job names
 #[test]
 fn test_validate_spec_duplicate_job_names() {
@@ -4021,11 +4066,9 @@ fn test_subgraph_workflow_generated_actions_have_correct_triggers() {
         .filter_map(|a| a.scheduler.clone().map(|s| (s, a.trigger_type.clone())))
         .collect();
 
-    // Verify each job has the correct trigger type based on dependencies
-    // prep_a, prep_b: no dependencies -> on_workflow_start
-    // work_*: depend on prep_* outputs -> on_jobs_ready
-    // post_*: depend on work_* outputs -> on_jobs_ready
-    // final: depends on post_* outputs -> on_jobs_ready
+    // Every generated scheduler is tied to its jobs via on_jobs_ready, including no-dependency root
+    // jobs (prep_a, prep_b) -- they are Ready at init, so on_jobs_ready fires at start, and the
+    // action is re-run-safe (resetting the jobs re-arms it).
     for job in &spec.jobs {
         let sched = job
             .scheduler
@@ -4035,16 +4078,10 @@ fn test_subgraph_workflow_generated_actions_have_correct_triggers() {
             .get(sched)
             .unwrap_or_else(|| panic!("Scheduler {} should have action", sched));
 
-        let expected_trigger = if job.name == "prep_a" || job.name == "prep_b" {
-            "on_workflow_start"
-        } else {
-            "on_jobs_ready"
-        };
-
         assert_eq!(
-            trigger, expected_trigger,
-            "job name='{}' scheduler='{}' should have trigger='{}', got trigger='{}'",
-            job.name, sched, expected_trigger, trigger
+            trigger, "on_jobs_ready",
+            "job name='{}' scheduler='{}' should have trigger='on_jobs_ready', got trigger='{}'",
+            job.name, sched, trigger
         );
     }
 


### PR DESCRIPTION
Rebased onto `main` after #403 (the reinit keep/re-arm work this builds on) was squash-merged. Supersedes the now-closed #404. Two commits: the feature + the docs/example.

## Summary

Makes `torc submit` re-schedule **exactly** the jobs being re-run, so a selective Slurm re-run works without `torc recover`:

```bash
torc jobs reset-status <id1> <id2> ... --reinit
torc submit <workflow_id>
```

## (a) `submit` fires all pending `schedule_nodes` actions

- `WorkflowManager::start` now fires pending Slurm `schedule_nodes` actions across `on_workflow_start` + `on_jobs_ready` + `on_jobs_complete` (previously only `on_workflow_start`). "Pending" already means *armed and due*, and the reinit keep/re-arm logic guarantees that set is exactly the reset jobs' actions — untouched stages stay suppressed.
- Relaxes the submit preconditions (existing-workflow check in `main.rs` and `WorkflowSpec::has_schedule_nodes_action`) to accept `on_jobs_ready`/`on_jobs_complete`, so `on_jobs_ready`-only workflows are submittable.

Worked example: regular / big-memory / GPU job classes, each with its own `on_jobs_ready` `schedule_nodes` action, plus a postprocess job gated on all. Reset only the GPU + big-memory jobs, reinit, `submit` → only the GPU + big-memory allocations are re-submitted; regular is left alone; postprocess fires later from a running worker.

## (b) Generated schedulers re-run-safe by default

- `scheduler_plan` emits `on_jobs_ready[root_jobs]` for no-dependency jobs instead of `on_workflow_start` (root jobs are Ready at init, so it fires at the same moment but is re-run-safe).
- `execution_plan` shows `on_jobs_ready[root]` allocations at the start event, so the plan visualization is unchanged.
- Per-stage example specs (`workflow_actions_simple_slurm.*`, `subgraphs_workflow.*`) converted to `on_jobs_ready`. New canonical example `examples/yaml/workflow_actions_multi_class_slurm.yaml` (the multi-class re-run scenario). `multi_node_slurm`/`data_pipeline` keep `on_workflow_start` (single whole-workflow allocation).

## Tests

Headline selective-re-run test (submit pending-set after a subset reinit is exactly the reset classes); `on_jobs_ready`-only submittability; updated generator assertions (`test_hpc`, `test_slurm_commands`, `test_workflow_spec`).

## Docs

`on_jobs_ready` recommendation propagated to the HPC + reference docs, a new "Re-running part of a workflow" section, and the walltime/stranding caveat (follow `submit` with `torc watch`).

## Caveat

`submit` is one-shot. For an unattended multi-stage re-run, follow it with `torc watch` so a stage whose action becomes pending after all workers exit (e.g. Slurm walltime) isn't stranded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)