### PR TITLE
Fix flaky test_satisfied_schedule_action_not_rearmed_on_reinitialize

### DIFF
--- a/tests/test_workflow_actions.rs
+++ b/tests/test_workflow_actions.rs
@@ -1592,6 +1592,9 @@ fn test_satisfied_schedule_action_not_rearmed_on_reinitialize(start_server: &Ser
     );
 
     // work1 fails, then we re-run only the failed job: reset failed jobs + reinitialize.
+    // Wait for the background unblocking task to move work1 blocked->ready before running it;
+    // otherwise the running transition races with the unblock and 422s ("concurrently modified").
+    wait_for_job_status(config, work1_id, JobStatus::Ready);
     run_job_to_status(
         config,
         workflow_id,


### PR DESCRIPTION
## Problem

`test_satisfied_schedule_action_not_rearmed_on_reinitialize` fails intermittently in CI (e.g. [run on #381](https://github.com/NatLabRockies/torc/actions/runs/28124966543/job/83286308160)) with:

```
job_id=2 status was concurrently modified (expected status='blocked'), please retry
```

## Root cause

A race in the test, not a server bug. When the gate job completes, the **background unblocking task** moves `work1` (which depends on the gate) from `blocked → ready` asynchronously. The test then immediately called `run_job_to_status(work1, …)` without waiting.

`manage_status_change` issues a conditional `UPDATE job SET status=? WHERE id=? AND status=<status read moments earlier>`. The server read `work1` as `blocked`, the background task flipped it to `ready` in the read→update window, the UPDATE matched 0 rows, and the endpoint returned 422 → the test's `.expect()` panicked. Timing-dependent, hence the intermittent failure.

## Fix

Add the `wait_for_job_status(config, work1_id, JobStatus::Ready)` guard — the same one already used at every other dependent-job run site in this file (e.g. lines 1887-1888, 1987-1988, 3206-3207) — before running `work1`. This test was the only dependent-job run missing it.

## Verification

- `cargo nextest run -E 'test(test_satisfied_schedule_action_not_rearmed_on_reinitialize)'` passes.
- `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)