### PR TITLE
feat(remote): support Windows worker hosts in torc remote

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,12 +137,17 @@ jobs:
           CARGO_INCREMENTAL: 0
           CARGO_TERM_COLOR: always
 
+      # Includes the SSH loopback test in the same nextest invocation as the
+      # other Windows test. Running it as a separate `cargo nextest run` step
+      # triggers a rebuild, and Windows cannot relink torc-server.exe while it
+      # is locked ("Access is denied"); a single invocation builds only once.
       - name: Run tests (Windows - limited test set)
         if: matrix.os == 'windows-latest'
-        run: cargo nextest run --all-features -E 'test(test_many_jobs_parameterized)'
+        run: cargo nextest run --all-features -E 'test(test_many_jobs_parameterized) + test(loopback_remote_shell_lifecycle)'
         env:
           RUST_BACKTRACE: 1
           CARGO_INCREMENTAL: 0
+          TORC_TEST_SSH_LOOPBACK: '1'
           OPENSSL_DIR: C:/vcpkg/installed/x64-windows-static-md
           OPENSSL_ROOT_DIR: C:/vcpkg/installed/x64-windows-static-md
           OPENSSL_INCLUDE_DIR: C:/vcpkg/installed/x64-windows-static-md/include
@@ -156,21 +161,10 @@ jobs:
           RUST_BACKTRACE: 1
           CARGO_INCREMENTAL: 0
 
-      # Opt-in loopback test: drives the remote-worker shell commands against
-      # localhost over SSH, validating the real per-OS command strings.
-      - name: Run remote loopback test (Windows)
-        if: matrix.os == 'windows-latest'
-        run: cargo nextest run --all-features -E 'test(loopback_remote_shell_lifecycle)'
-        env:
-          RUST_BACKTRACE: 1
-          CARGO_INCREMENTAL: 0
-          TORC_TEST_SSH_LOOPBACK: '1'
-          OPENSSL_DIR: C:/vcpkg/installed/x64-windows-static-md
-          OPENSSL_ROOT_DIR: C:/vcpkg/installed/x64-windows-static-md
-          OPENSSL_INCLUDE_DIR: C:/vcpkg/installed/x64-windows-static-md/include
-          OPENSSL_LIB_DIR: C:/vcpkg/installed/x64-windows-static-md/lib
-          VCPKG_ROOT: C:/vcpkg
-
+      # Opt-in loopback test on Ubuntu: drives the remote-worker shell commands
+      # against localhost over SSH, validating the real POSIX command strings.
+      # (The Windows equivalent runs in the limited-test step above to avoid a
+      # second build that would fail to relink torc-server.exe.)
       - name: Run remote loopback test (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
         run: cargo nextest run --all-features -E 'test(loopback_remote_shell_lifecycle)'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,14 +113,18 @@ jobs:
 
           $sshDir = "$env:USERPROFILE\.ssh"
           New-Item -ItemType Directory -Force -Path $sshDir | Out-Null
-          ssh-keygen -t ed25519 -f "$sshDir\id_ed25519" -N '""' -q
+          # -N '' is an empty passphrase (PowerShell passes it as "" to the exe);
+          # the BatchMode sanity check below fails loudly if the key is encrypted.
+          ssh-keygen -t ed25519 -f "$sshDir\id_ed25519" -N '' -q
 
           # The runner user is an administrator, so OpenSSH reads authorized
-          # keys from administrators_authorized_keys with strict ACLs.
+          # keys from administrators_authorized_keys with strict ACLs. Use
+          # /inheritance:r + /grant:r so only Administrators and SYSTEM remain;
+          # OpenSSH rejects the file if any other identity can access it.
           $adminKeys = "$env:ProgramData\ssh\administrators_authorized_keys"
           Get-Content "$sshDir\id_ed25519.pub" | Out-File -FilePath $adminKeys -Encoding ascii
           icacls $adminKeys /inheritance:r
-          icacls $adminKeys /grant "Administrators:F" /grant "SYSTEM:F"
+          icacls $adminKeys /grant:r "Administrators:F" "SYSTEM:F"
 
           ssh-keyscan -H localhost 2>$null | Out-File -Append -Encoding ascii "$sshDir\known_hosts"
           # Sanity check that non-interactive (key-based) login works

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,6 +87,45 @@ jobs:
         env:
           DATABASE_URL: sqlite:db/sqlite/dev.db
 
+      # Configure key-based SSH to localhost so the remote-worker loopback test
+      # can exercise the real shell commands against this host.
+      - name: Setup SSH loopback (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo systemctl start ssh || sudo service ssh start
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519 -N "" -q
+          cat ~/.ssh/id_ed25519.pub >> ~/.ssh/authorized_keys
+          chmod 600 ~/.ssh/authorized_keys
+          ssh-keyscan -H localhost >> ~/.ssh/known_hosts 2>/dev/null || true
+          # Sanity check that non-interactive (key-based) login works
+          ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new localhost "uname -a"
+
+      - name: Setup SSH loopback (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          # Install and start the OpenSSH server. Its default shell is cmd.exe,
+          # which is exactly the path the loopback test should cover.
+          Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+          Start-Service sshd
+          Set-Service -Name sshd -StartupType Automatic
+
+          $sshDir = "$env:USERPROFILE\.ssh"
+          New-Item -ItemType Directory -Force -Path $sshDir | Out-Null
+          ssh-keygen -t ed25519 -f "$sshDir\id_ed25519" -N '""' -q
+
+          # The runner user is an administrator, so OpenSSH reads authorized
+          # keys from administrators_authorized_keys with strict ACLs.
+          $adminKeys = "$env:ProgramData\ssh\administrators_authorized_keys"
+          Get-Content "$sshDir\id_ed25519.pub" | Out-File -FilePath $adminKeys -Encoding ascii
+          icacls $adminKeys /inheritance:r
+          icacls $adminKeys /grant "Administrators:F" /grant "SYSTEM:F"
+
+          ssh-keyscan -H localhost 2>$null | Out-File -Append -Encoding ascii "$sshDir\known_hosts"
+          # Sanity check that non-interactive (key-based) login works
+          ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new localhost "powershell -NoProfile -Command Write-Output ok"
+
       - name: Build test binaries (only necessary packages)
         run: cargo build --all-features -p torc
         env:
@@ -112,6 +151,29 @@ jobs:
         env:
           RUST_BACKTRACE: 1
           CARGO_INCREMENTAL: 0
+
+      # Opt-in loopback test: drives the remote-worker shell commands against
+      # localhost over SSH, validating the real per-OS command strings.
+      - name: Run remote loopback test (Windows)
+        if: matrix.os == 'windows-latest'
+        run: cargo nextest run --all-features -E 'test(loopback_remote_shell_lifecycle)'
+        env:
+          RUST_BACKTRACE: 1
+          CARGO_INCREMENTAL: 0
+          TORC_TEST_SSH_LOOPBACK: '1'
+          OPENSSL_DIR: C:/vcpkg/installed/x64-windows-static-md
+          OPENSSL_ROOT_DIR: C:/vcpkg/installed/x64-windows-static-md
+          OPENSSL_INCLUDE_DIR: C:/vcpkg/installed/x64-windows-static-md/include
+          OPENSSL_LIB_DIR: C:/vcpkg/installed/x64-windows-static-md/lib
+          VCPKG_ROOT: C:/vcpkg
+
+      - name: Run remote loopback test (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: cargo nextest run --all-features -E 'test(loopback_remote_shell_lifecycle)'
+        env:
+          RUST_BACKTRACE: 1
+          CARGO_INCREMENTAL: 0
+          TORC_TEST_SSH_LOOPBACK: '1'
 
       # Clean up intermediate build artifacts to free disk space for Julia
       # Keep only the binaries needed to run the server

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -804,9 +804,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -232,6 +232,7 @@ client = [
     "dep:percent-encoding",
     "dep:sha2",
     "dep:hex",
+    "dep:base64",
     "dep:shlex",
     "dep:flate2",
     "dep:tar",

--- a/docs/src/specialized/remote/remote-workers.md
+++ b/docs/src/specialized/remote/remote-workers.md
@@ -16,6 +16,29 @@ Remote workers are ideal for:
 - Environments without a scheduler
 - Testing distributed workflows before HPC deployment
 
+## Supported Platforms
+
+Worker hosts may run either a POSIX operating system (Linux, macOS, \*BSD) or Windows. Torc detects
+the remote shell automatically the first time it contacts each host and issues platform-appropriate
+commands:
+
+- **POSIX hosts** are driven through a POSIX shell (`mkdir -p`, `nohup`, `pgrep`, `kill`, `tar`,
+  ...).
+- **Windows hosts** are driven through PowerShell (`Start-Process`, `Get-Process`, `Stop-Process`,
+  `tar`, ...). Commands are sent as PowerShell `-EncodedCommand` payloads, so they work whether the
+  host's OpenSSH default shell is `cmd.exe` or PowerShell.
+
+Requirements:
+
+- The host must run an SSH server (OpenSSH Server is available on Windows 10/11 and Windows Server).
+- `torc` must be on the host's `PATH`.
+- Windows hosts need PowerShell (built in) and `tar.exe` (built into Windows 10 1803+ and later) for
+  `collect-logs`.
+
+> **Note:** `torc remote stop` performs a graceful shutdown (SIGTERM) on POSIX hosts but always
+> performs a forced stop on Windows, which has no SIGTERM equivalent for a detached process. Use
+> checkpoint/restart patterns rather than relying on a graceful stop signal for Windows workers.
+
 ## Worker File Format
 
 Create a text file listing remote machines:
@@ -254,10 +277,13 @@ torc remote run 42 --workers workers.txt
 
 ## How It Works
 
-1. **Version Check**: Verifies all remote machines have the same torc version
-2. **Worker Start**: Uses `nohup` to start detached workers that survive SSH disconnection
-3. **Job Execution**: Each worker polls the server for available jobs and executes them locally
-4. **Completion**: Workers exit when the workflow is complete or canceled
+1. **Shell Detection**: Probes each host to determine whether it is POSIX or Windows, then issues
+   platform-appropriate commands for the rest of the operation
+2. **Version Check**: Verifies all remote machines have the same torc version
+3. **Worker Start**: Starts detached workers (via `nohup` on POSIX, `Start-Process` on Windows) that
+   survive SSH disconnection
+4. **Job Execution**: Each worker polls the server for available jobs and executes them locally
+5. **Completion**: Workers exit when the workflow is complete or canceled
 
 The server coordinates job distribution. Multiple workers can safely poll the same workflow without
 double-allocating jobs.
@@ -356,6 +382,18 @@ If workers start but don't claim jobs:
 1. Check the workflow is initialized: `torc status <id>`
 2. Check jobs are ready: `torc jobs list <id>`
 3. Check resource requirements match available resources
+
+### Could Not Determine the Remote Shell
+
+```
+Could not determine the remote shell on worker1: the host responded to neither 'uname' (POSIX)
+nor PowerShell. 'torc remote' supports POSIX shells and Windows PowerShell.
+```
+
+The host is reachable over SSH but is neither a POSIX shell nor a PowerShell-capable Windows host.
+On Windows, make sure PowerShell is on the SSH session's `PATH` (it is by default) and that the
+OpenSSH Server is configured normally. Torc works with either the default `cmd.exe` shell or a
+PowerShell default shell.
 
 ## Comparison with Slurm
 

--- a/docs/src/specialized/remote/remote-workers.md
+++ b/docs/src/specialized/remote/remote-workers.md
@@ -22,11 +22,11 @@ Worker hosts may run either a POSIX operating system (Linux, macOS, \*BSD) or Wi
 the remote shell automatically the first time it contacts each host and issues platform-appropriate
 commands:
 
-- **POSIX hosts** are driven through a POSIX shell (`mkdir -p`, `nohup`, `pgrep`, `kill`, `tar`,
-  ...).
-- **Windows hosts** are driven through PowerShell (`Start-Process`, `Get-Process`, `Stop-Process`,
-  `tar`, ...). Commands are sent as PowerShell `-EncodedCommand` payloads, so they work whether the
-  host's OpenSSH default shell is `cmd.exe` or PowerShell.
+- **POSIX hosts** are driven through `bash` (`mkdir -p`, `nohup ... & disown`, `pgrep`, `kill`,
+  `tar`, ...), so worker hosts must have `bash` on `PATH`.
+- **Windows hosts** are driven through PowerShell (`Win32_Process.Create`, `Get-Process`,
+  `taskkill`, `tar`, ...). Commands are sent as PowerShell `-EncodedCommand` payloads, so they work
+  whether the host's OpenSSH default shell is `cmd.exe` or PowerShell.
 
 Requirements:
 
@@ -280,8 +280,8 @@ torc remote run 42 --workers workers.txt
 1. **Shell Detection**: Probes each host to determine whether it is POSIX or Windows, then issues
    platform-appropriate commands for the rest of the operation
 2. **Version Check**: Verifies all remote machines have the same torc version
-3. **Worker Start**: Starts detached workers (via `nohup` on POSIX, `Start-Process` on Windows) that
-   survive SSH disconnection
+3. **Worker Start**: Starts detached workers (via `nohup ... & disown` on POSIX,
+   `Win32_Process.Create` on Windows) that survive SSH disconnection
 4. **Job Execution**: Each worker polls the server for available jobs and executes them locally
 5. **Completion**: Workers exit when the workflow is complete or canceled
 

--- a/src/client/commands/remote.rs
+++ b/src/client/commands/remote.rs
@@ -11,7 +11,8 @@ use crate::client::commands::{get_env_user_name, select_workflow_interactively};
 use crate::client::remote::{
     RemoteOperationResult, RemoteShell, RemoteWorkerState, WorkerEntry, check_all_connectivity,
     check_ssh_connectivity, detect_remote_shell, parallel_execute, parse_worker_content,
-    parse_worker_file, scp_download, ssh_execute, ssh_execute_capture, verify_all_versions,
+    parse_worker_file, scp_download, ssh_execute, ssh_execute_capture, ssh_execute_checked,
+    verify_all_versions,
 };
 use crate::client::workflow_manager::WorkflowManager;
 use crate::config::TorcConfig;
@@ -524,6 +525,41 @@ fn handle_run(
     }
 }
 
+/// Poll the remote PID file until it contains a parseable PID, up to a bounded
+/// timeout.
+///
+/// `read_file` exits non-zero (an `Err`) while the file is still absent, and can
+/// briefly return empty content after the file is created but before the PID is
+/// written; both are treated as "not ready yet" and retried. Returns the PID, or
+/// an error describing the last thing read if it never appears in time.
+fn poll_for_remote_pid(
+    worker: &WorkerEntry,
+    shell: RemoteShell,
+    pid_file: &str,
+) -> Result<u32, String> {
+    const MAX_ATTEMPTS: u32 = 20;
+    const POLL_DELAY_MS: u64 = 500;
+
+    let read_cmd = shell.read_file(pid_file);
+    let mut last = String::from("<never read>");
+    for _ in 0..MAX_ATTEMPTS {
+        if let Ok(raw) = ssh_execute_capture(worker, &read_cmd) {
+            if let Ok(pid) = raw.trim().parse::<u32>() {
+                return Ok(pid);
+            }
+            last = raw;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(POLL_DELAY_MS));
+    }
+
+    Err(format!(
+        "PID file '{}' did not contain a valid PID within {} seconds (last read: '{}')",
+        pid_file,
+        (MAX_ATTEMPTS as u64 * POLL_DELAY_MS) / 1000,
+        last.trim()
+    ))
+}
+
 /// Start a single worker on a remote machine.
 #[allow(clippy::too_many_arguments)]
 fn start_remote_worker(
@@ -598,36 +634,23 @@ fn start_remote_worker(
         start_cmd
     );
 
-    if let Err(e) = ssh_execute(worker, &start_cmd, Some(60)) {
+    // Use the checked variant: a launch that fails on the remote side (a
+    // PowerShell `throw`, a missing `torc`, a permissions error) must surface
+    // here with the real stderr, rather than silently succeeding and reappearing
+    // later as a confusing "failed to read PID file" error.
+    if let Err(e) = ssh_execute_checked(worker, &start_cmd, Some(60)) {
         return RemoteOperationResult::failure(
             worker.clone(),
             format!("Failed to start worker: {}", e),
         );
     }
 
-    // Give it a moment to start
-    std::thread::sleep(std::time::Duration::from_secs(2));
-
-    // Read PID file
-    let pid_cmd = shell.read_file(&pid_file);
-    let pid_output = match ssh_execute_capture(worker, &pid_cmd) {
-        Ok(output) => output,
-        Err(e) => {
-            return RemoteOperationResult::failure(
-                worker.clone(),
-                format!("Failed to read PID file: {}", e),
-            );
-        }
-    };
-
-    let pid: u32 = match pid_output.trim().parse() {
-        Ok(p) => p,
-        Err(_) => {
-            return RemoteOperationResult::failure(
-                worker.clone(),
-                format!("Invalid PID in file: '{}'", pid_output.trim()),
-            );
-        }
+    // Poll for the PID file rather than sleeping a fixed interval: the detached
+    // spawn (especially Win32_Process.Create on a busy Windows host) can take a
+    // variable amount of time to create the file and write the PID.
+    let pid = match poll_for_remote_pid(worker, shell, &pid_file) {
+        Ok(pid) => pid,
+        Err(e) => return RemoteOperationResult::failure(worker.clone(), e),
     };
 
     // Verify process is running with retries
@@ -1006,7 +1029,7 @@ fn collect_worker_logs(
 
     // Create tarball
     let tar_cmd = shell.create_tarball(&remote_tarball, remote_output_dir);
-    if let Err(e) = ssh_execute(worker, &tar_cmd, Some(300)) {
+    if let Err(e) = ssh_execute_checked(worker, &tar_cmd, Some(300)) {
         return RemoteOperationResult::failure(
             worker.clone(),
             format!("Failed to create archive: {}", e),
@@ -1039,7 +1062,7 @@ fn collect_worker_logs(
     // Delete remote output directory if requested
     if delete_after {
         let delete_cmd = shell.remove_dir(remote_output_dir);
-        if let Err(e) = ssh_execute(worker, &delete_cmd, Some(60)) {
+        if let Err(e) = ssh_execute_checked(worker, &delete_cmd, Some(60)) {
             return RemoteOperationResult::failure(
                 worker.clone(),
                 format!("Collected but failed to delete: {}", e),
@@ -1130,7 +1153,7 @@ fn delete_worker_logs(worker: &WorkerEntry, remote_output_dir: &str) -> RemoteOp
 
     // Delete the directory
     let delete_cmd = shell.remove_dir(remote_output_dir);
-    match ssh_execute(worker, &delete_cmd, Some(60)) {
+    match ssh_execute_checked(worker, &delete_cmd, Some(60)) {
         Ok(_) => {
             RemoteOperationResult::success(worker.clone(), format!("Deleted {}", remote_output_dir))
         }

--- a/src/client/commands/remote.rs
+++ b/src/client/commands/remote.rs
@@ -9,9 +9,9 @@ use crate::client::apis;
 use crate::client::apis::configuration::Configuration;
 use crate::client::commands::{get_env_user_name, select_workflow_interactively};
 use crate::client::remote::{
-    RemoteOperationResult, RemoteWorkerState, WorkerEntry, check_all_connectivity,
-    check_ssh_connectivity, parallel_execute, parse_worker_content, parse_worker_file,
-    scp_download, ssh_execute, ssh_execute_capture, verify_all_versions,
+    RemoteOperationResult, RemoteShell, RemoteWorkerState, WorkerEntry, check_all_connectivity,
+    check_ssh_connectivity, detect_remote_shell, parallel_execute, parse_worker_content,
+    parse_worker_file, scp_download, ssh_execute, ssh_execute_capture, verify_all_versions,
 };
 use crate::client::workflow_manager::WorkflowManager;
 use crate::config::TorcConfig;
@@ -537,8 +537,15 @@ fn start_remote_worker(
     memory_gb: Option<f64>,
     num_gpus: Option<i64>,
 ) -> RemoteOperationResult {
+    // Detect the remote shell family so we issue commands the host understands
+    // (POSIX shells vs Windows PowerShell).
+    let shell = match detect_remote_shell(worker) {
+        Ok(shell) => shell,
+        Err(e) => return RemoteOperationResult::failure(worker.clone(), e),
+    };
+
     // Create output directory on remote
-    let mkdir_cmd = format!("mkdir -p {}", output_dir);
+    let mkdir_cmd = shell.mkdir_p(output_dir);
     if let Err(e) = ssh_execute_capture(worker, &mkdir_cmd) {
         return RemoteOperationResult::failure(
             worker.clone(),
@@ -546,36 +553,44 @@ fn start_remote_worker(
         );
     }
 
-    // Build the torc run command
-    // --url is a global option that must come before the subcommand
-    let mut torc_cmd = format!(
-        "torc --url {} run {} --output-dir {} --poll-interval {}",
-        api_url, workflow_id, output_dir, poll_interval
-    );
+    // Build the torc run command arguments.
+    // --url is a global option that must come before the subcommand.
+    let mut torc_args: Vec<String> = vec![
+        "--url".to_string(),
+        api_url.to_string(),
+        "run".to_string(),
+        workflow_id.to_string(),
+        "--output-dir".to_string(),
+        output_dir.to_string(),
+        "--poll-interval".to_string(),
+        poll_interval.to_string(),
+    ];
 
     if let Some(cpus) = num_cpus {
-        torc_cmd.push_str(&format!(" --num-cpus {}", cpus));
+        torc_args.push("--num-cpus".to_string());
+        torc_args.push(cpus.to_string());
     }
     if let Some(mem) = memory_gb {
-        torc_cmd.push_str(&format!(" --memory-gb {}", mem));
+        torc_args.push("--memory-gb".to_string());
+        torc_args.push(mem.to_string());
     }
     if let Some(gpus) = num_gpus {
-        torc_cmd.push_str(&format!(" --num-gpus {}", gpus));
+        torc_args.push("--num-gpus".to_string());
+        torc_args.push(gpus.to_string());
     }
     if let Some(max) = max_parallel_jobs {
-        torc_cmd.push_str(&format!(" --max-parallel-jobs {}", max));
+        torc_args.push("--max-parallel-jobs".to_string());
+        torc_args.push(max.to_string());
     }
 
-    // PID file and log file paths
+    // PID file and log file paths. Forward slashes are accepted by both POSIX
+    // and Windows file APIs (including PowerShell).
     let pid_file = format!("{}/torc_worker_{}.pid", output_dir, workflow_id);
     let log_file = format!("{}/torc_worker_{}.log", output_dir, workflow_id);
 
-    // Start with nohup, redirect output, save PID
-    // Use bash -c to ensure proper shell handling
-    let start_cmd = format!(
-        "bash -c 'nohup {} > {} 2>&1 & echo $! > {}; disown'",
-        torc_cmd, log_file, pid_file
-    );
+    // Launch the worker detached so it outlives the SSH session, redirecting
+    // output to the log file and recording the PID.
+    let start_cmd = shell.start_detached("torc", &torc_args, &log_file, &pid_file);
 
     debug!(
         "Starting worker on {}: {}",
@@ -594,7 +609,7 @@ fn start_remote_worker(
     std::thread::sleep(std::time::Duration::from_secs(2));
 
     // Read PID file
-    let pid_cmd = format!("cat {}", pid_file);
+    let pid_cmd = shell.read_file(&pid_file);
     let pid_output = match ssh_execute_capture(worker, &pid_cmd) {
         Ok(output) => output,
         Err(e) => {
@@ -621,11 +636,8 @@ fn start_remote_worker(
     const RETRY_DELAY_MS: u64 = 1000;
 
     for attempt in 0..MAX_RETRIES {
-        // First try kill -0
-        let check_cmd = format!(
-            "kill -0 {} 2>/dev/null && echo running || echo stopped",
-            pid
-        );
+        // First check whether the PID is alive
+        let check_cmd = shell.is_process_alive(pid);
         let check_output = ssh_execute_capture(worker, &check_cmd).unwrap_or_default();
 
         if check_output.trim() == "running" {
@@ -636,19 +648,13 @@ fn start_remote_worker(
         }
 
         // Also check if log file shows successful startup (job_runner logs this on start)
-        let log_check_cmd = format!(
-            "grep -q 'Starting torc job runner' {} 2>/dev/null && echo started || echo waiting",
-            log_file
-        );
+        let log_check_cmd = shell.log_shows_startup(&log_file);
         let log_check_output = ssh_execute_capture(worker, &log_check_cmd).unwrap_or_default();
 
         if log_check_output.trim() == "started" {
-            // Log shows startup, verify process is still running with pgrep
-            // Use word boundary pattern to avoid matching workflow 123 when looking for 12
-            let pgrep_cmd = format!(
-                "pgrep -f 'torc .* run {}( |$)' >/dev/null 2>&1 && echo running || echo stopped",
-                workflow_id
-            );
+            // Log shows startup, verify the worker process is still running.
+            // Use word boundary pattern to avoid matching workflow 123 when looking for 12.
+            let pgrep_cmd = shell.torc_process_running(workflow_id);
             let pgrep_output = ssh_execute_capture(worker, &pgrep_cmd).unwrap_or_default();
 
             if pgrep_output.trim() == "running" {
@@ -666,10 +672,7 @@ fn start_remote_worker(
     }
 
     // All retries exhausted - process appears to have died
-    let tail_cmd = format!(
-        "tail -5 {} 2>/dev/null || echo 'No log available'",
-        log_file
-    );
+    let tail_cmd = shell.tail(&log_file, 5);
     let log_output = ssh_execute_capture(worker, &tail_cmd).unwrap_or_default();
     RemoteOperationResult::failure(
         worker.clone(),
@@ -725,31 +728,34 @@ fn check_remote_worker_status(
     workflow_id: i64,
     output_dir: &str,
 ) -> RemoteWorkerState {
+    // Detect the remote shell so liveness checks use the right commands.
+    let shell = match detect_remote_shell(worker) {
+        Ok(shell) => shell,
+        Err(error) => return RemoteWorkerState::Unknown { error },
+    };
+
     let pid_file = format!("{}/torc_worker_{}.pid", output_dir, workflow_id);
 
     // Read PID file
-    let pid_cmd = format!("cat {} 2>/dev/null", pid_file);
+    let pid_cmd = shell.read_file(&pid_file);
     let pid_output = match ssh_execute_capture(worker, &pid_cmd) {
         Ok(output) => output,
         Err(_) => {
-            // No PID file, but check if process is running anyway via pgrep
-            return check_worker_via_pgrep(worker, workflow_id);
+            // No PID file, but check if process is running anyway
+            return check_worker_via_pgrep(worker, shell, workflow_id);
         }
     };
 
     let pid: u32 = match pid_output.trim().parse() {
         Ok(p) => p,
         Err(_) => {
-            // Invalid PID file, fall back to pgrep
-            return check_worker_via_pgrep(worker, workflow_id);
+            // Invalid PID file, fall back to process search
+            return check_worker_via_pgrep(worker, shell, workflow_id);
         }
     };
 
-    // Check if process is running via kill -0
-    let check_cmd = format!(
-        "kill -0 {} 2>/dev/null && echo running || echo stopped",
-        pid
-    );
+    // Check if the process is alive
+    let check_cmd = shell.is_process_alive(pid);
     match ssh_execute_capture(worker, &check_cmd) {
         Ok(output) => {
             if output.trim() == "running" {
@@ -759,17 +765,19 @@ fn check_remote_worker_status(
                 RemoteWorkerState::NotRunning
             }
         }
-        Err(_) => check_worker_via_pgrep(worker, workflow_id),
+        Err(_) => check_worker_via_pgrep(worker, shell, workflow_id),
     }
 }
 
-/// Check if a torc worker is running via pgrep (fallback when PID check fails).
-fn check_worker_via_pgrep(worker: &WorkerEntry, workflow_id: i64) -> RemoteWorkerState {
+/// Check if a torc worker is running by searching processes (fallback when the
+/// PID check fails).
+fn check_worker_via_pgrep(
+    worker: &WorkerEntry,
+    shell: RemoteShell,
+    workflow_id: i64,
+) -> RemoteWorkerState {
     // Use word boundary pattern to avoid matching workflow 123 when looking for 12
-    let pgrep_cmd = format!(
-        "pgrep -f 'torc .* run {}( |$)' 2>/dev/null | head -1",
-        workflow_id
-    );
+    let pgrep_cmd = shell.torc_process_pid(workflow_id);
     match ssh_execute_capture(worker, &pgrep_cmd) {
         Ok(output) => {
             let trimmed = output.trim();
@@ -801,7 +809,6 @@ fn handle_stop(
     }
 
     let output_dir_owned = output_dir.to_string();
-    let signal = if force { "KILL" } else { "TERM" };
 
     println!(
         "Stopping workers (signal: {})...",
@@ -810,7 +817,7 @@ fn handle_stop(
 
     let results: Vec<RemoteOperationResult> = parallel_execute(
         &workers,
-        move |worker| stop_remote_worker(worker, workflow_id, &output_dir_owned, signal),
+        move |worker| stop_remote_worker(worker, workflow_id, &output_dir_owned, force),
         max_parallel_ssh,
     );
 
@@ -827,16 +834,26 @@ fn handle_stop(
 }
 
 /// Stop a single remote worker.
+///
+/// `force` requests an immediate kill (SIGKILL on POSIX). When false, POSIX
+/// workers receive SIGTERM for a graceful shutdown. Windows has no SIGTERM
+/// equivalent for a detached process, so Windows workers are always stopped
+/// forcibly regardless of `force`.
 fn stop_remote_worker(
     worker: &WorkerEntry,
     workflow_id: i64,
     output_dir: &str,
-    signal: &str,
+    force: bool,
 ) -> RemoteOperationResult {
+    let shell = match detect_remote_shell(worker) {
+        Ok(shell) => shell,
+        Err(e) => return RemoteOperationResult::failure(worker.clone(), e),
+    };
+
     let pid_file = format!("{}/torc_worker_{}.pid", output_dir, workflow_id);
 
     // Read PID
-    let pid_cmd = format!("cat {} 2>/dev/null", pid_file);
+    let pid_cmd = shell.read_file(&pid_file);
     let pid_output = match ssh_execute_capture(worker, &pid_cmd) {
         Ok(output) => output,
         Err(_) => {
@@ -851,17 +868,21 @@ fn stop_remote_worker(
         }
     };
 
-    // Send signal
-    let kill_cmd = format!(
-        "kill -{} {} 2>/dev/null && echo killed || echo not_found",
-        signal, pid
-    );
+    // Stop the worker. POSIX honors the graceful/forced distinction; Windows is
+    // always a forced stop.
+    let graceful = !force;
+    let stop_label = match shell {
+        RemoteShell::Posix if graceful => "SIGTERM",
+        RemoteShell::Posix => "SIGKILL",
+        RemoteShell::Windows => "forced stop",
+    };
+    let kill_cmd = shell.kill_process(pid, graceful);
     match ssh_execute_capture(worker, &kill_cmd) {
         Ok(output) => {
             if output.trim() == "killed" {
                 RemoteOperationResult::success(
                     worker.clone(),
-                    format!("Sent SIG{} to PID {}", signal, pid),
+                    format!("Sent {} to PID {}", stop_label, pid),
                 )
             } else {
                 RemoteOperationResult::success(worker.clone(), "Process not running")
@@ -954,19 +975,21 @@ fn collect_worker_logs(
     remote_output_dir: &str,
     delete_after: bool,
 ) -> RemoteOperationResult {
+    let shell = match detect_remote_shell(worker) {
+        Ok(shell) => shell,
+        Err(e) => return RemoteOperationResult::failure(worker.clone(), e),
+    };
+
     // Create tarball on remote
     let tarball_name = format!(
         "torc_logs_{}_{}.tar.gz",
         workflow_id,
         worker.host.replace('.', "_")
     );
-    let remote_tarball = format!("/tmp/{}", tarball_name);
+    let remote_tarball = shell.temp_tarball_path(&tarball_name);
 
     // Check if remote directory exists
-    let check_cmd = format!(
-        "test -d {} && echo exists || echo missing",
-        remote_output_dir
-    );
+    let check_cmd = shell.dir_exists(remote_output_dir);
     match ssh_execute_capture(worker, &check_cmd) {
         Ok(output) => {
             if output.trim() == "missing" {
@@ -982,10 +1005,7 @@ fn collect_worker_logs(
     }
 
     // Create tarball
-    let tar_cmd = format!(
-        "tar -czf {} -C {} . 2>/dev/null",
-        remote_tarball, remote_output_dir
-    );
+    let tar_cmd = shell.create_tarball(&remote_tarball, remote_output_dir);
     if let Err(e) = ssh_execute(worker, &tar_cmd, Some(300)) {
         return RemoteOperationResult::failure(
             worker.clone(),
@@ -1013,12 +1033,12 @@ fn collect_worker_logs(
     }
 
     // Clean up remote tarball
-    let rm_cmd = format!("rm -f {}", remote_tarball);
+    let rm_cmd = shell.remove_file(&remote_tarball);
     let _ = ssh_execute(worker, &rm_cmd, None);
 
     // Delete remote output directory if requested
     if delete_after {
-        let delete_cmd = format!("rm -rf {}", remote_output_dir);
+        let delete_cmd = shell.remove_dir(remote_output_dir);
         if let Err(e) = ssh_execute(worker, &delete_cmd, Some(60)) {
             return RemoteOperationResult::failure(
                 worker.clone(),
@@ -1084,11 +1104,13 @@ fn handle_delete_logs(
 
 /// Delete logs from a single remote worker.
 fn delete_worker_logs(worker: &WorkerEntry, remote_output_dir: &str) -> RemoteOperationResult {
+    let shell = match detect_remote_shell(worker) {
+        Ok(shell) => shell,
+        Err(e) => return RemoteOperationResult::failure(worker.clone(), e),
+    };
+
     // Check if remote directory exists
-    let check_cmd = format!(
-        "test -d {} && echo exists || echo missing",
-        remote_output_dir
-    );
+    let check_cmd = shell.dir_exists(remote_output_dir);
     match ssh_execute_capture(worker, &check_cmd) {
         Ok(output) => {
             if output.trim() == "missing" {
@@ -1107,7 +1129,7 @@ fn delete_worker_logs(worker: &WorkerEntry, remote_output_dir: &str) -> RemoteOp
     }
 
     // Delete the directory
-    let delete_cmd = format!("rm -rf {}", remote_output_dir);
+    let delete_cmd = shell.remove_dir(remote_output_dir);
     match ssh_execute(worker, &delete_cmd, Some(60)) {
         Ok(_) => {
             RemoteOperationResult::success(worker.clone(), format!("Deleted {}", remote_output_dir))

--- a/src/client/commands/remote.rs
+++ b/src/client/commands/remote.rs
@@ -624,6 +624,27 @@ fn start_remote_worker(
     let pid_file = format!("{}/torc_worker_{}.pid", output_dir, workflow_id);
     let log_file = format!("{}/torc_worker_{}.log", output_dir, workflow_id);
 
+    // The Windows detached-launch path builds a `cmd.exe /s /c "..."` command
+    // line, and cmd.exe has no reliable way to escape an embedded double quote.
+    // Reject any value containing one up front with a clear error, rather than
+    // emitting a mangled (and potentially injectable) command line. POSIX quoting
+    // handles quotes safely, so this guard only applies to Windows hosts.
+    if shell == RemoteShell::Windows
+        && let Some(bad) = torc_args
+            .iter()
+            .chain([&log_file, &pid_file])
+            .find(|v| v.contains('"'))
+    {
+        return RemoteOperationResult::failure(
+            worker.clone(),
+            format!(
+                "Refusing to launch worker: value contains a double quote, which cannot be \
+                 safely escaped for the Windows cmd.exe launcher: {:?}",
+                bad
+            ),
+        );
+    }
+
     // Launch the worker detached so it outlives the SSH session, redirecting
     // output to the log file and recording the PID.
     let start_cmd = shell.start_detached("torc", &torc_args, &log_file, &pid_file);

--- a/src/client/remote.rs
+++ b/src/client/remote.rs
@@ -23,10 +23,12 @@
 //! torc remote collect-logs workers.txt <workflow-id>
 //! ```
 
+pub mod shell;
 pub mod ssh;
 pub mod types;
 pub mod worker_file;
 
+pub use shell::{RemoteShell, detect_remote_shell};
 pub use ssh::{
     check_all_connectivity, check_ssh_connectivity, get_remote_torc_version, parallel_execute,
     scp_download, ssh_execute, ssh_execute_capture, verify_all_versions, verify_version,

--- a/src/client/remote.rs
+++ b/src/client/remote.rs
@@ -31,7 +31,8 @@ pub mod worker_file;
 pub use shell::{RemoteShell, detect_remote_shell};
 pub use ssh::{
     check_all_connectivity, check_ssh_connectivity, get_remote_torc_version, parallel_execute,
-    scp_download, ssh_execute, ssh_execute_capture, verify_all_versions, verify_version,
+    scp_download, ssh_execute, ssh_execute_capture, ssh_execute_checked, verify_all_versions,
+    verify_version,
 };
 pub use types::{RemoteOperationResult, RemoteWorkerState, WorkerEntry};
 pub use worker_file::{parse_worker_content, parse_worker_file};

--- a/src/client/remote/shell.rs
+++ b/src/client/remote/shell.rs
@@ -324,11 +324,12 @@ impl RemoteShell {
                 )
             }
             // `taskkill /T` kills the recorded cmd.exe and its child worker
-            // process. Exit 0 = killed, 128 = process not found; any other code
-            // throws so a real failure (e.g. access denied) surfaces as an error
-            // rather than a false "killed".
+            // process. Its "SUCCESS:" chatter is discarded (`*> $null`) so only
+            // the status token is emitted. Exit 0 = killed, 128 = process not
+            // found; any other code throws so a real failure (e.g. access
+            // denied) surfaces as an error rather than a false "killed".
             RemoteShell::Windows => powershell_encoded(&format!(
-                "taskkill /PID {pid} /T /F 2>$null; \
+                "taskkill /PID {pid} /T /F *> $null; \
                  switch ($LASTEXITCODE) {{ 0 {{ 'killed' }} 128 {{ 'not_found' }} \
                  default {{ throw \"taskkill failed: $LASTEXITCODE\" }} }}",
                 pid = pid

--- a/src/client/remote/shell.rs
+++ b/src/client/remote/shell.rs
@@ -65,6 +65,15 @@ fn powershell_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "''"))
 }
 
+/// Quote a value for use as a `cmd.exe` token by wrapping it in double quotes.
+///
+/// cmd has no general escape for an embedded double quote, but worker paths and
+/// arguments do not contain them in practice; double-quoting handles the common
+/// case of spaces.
+fn cmd_quote(value: &str) -> String {
+    format!("\"{}\"", value)
+}
+
 /// Detect the remote shell family for a worker by probing over SSH.
 ///
 /// POSIX hosts respond to `uname`. If `uname` is unavailable but the host is
@@ -144,10 +153,18 @@ impl RemoteShell {
     /// Command to launch a detached `torc` worker, redirecting output to
     /// `log_file` and writing the worker PID to `pid_file`.
     ///
-    /// `program` is the worker executable (`torc`) and `args` its arguments.
-    /// The worker's `env_logger` output (including the "Starting torc job
-    /// runner" startup line) goes to stderr, so both shells route stderr to
+    /// `program` is the worker executable (`torc`) and `args` its arguments. The
+    /// worker's `env_logger` output (including the "Starting torc job runner"
+    /// startup line) goes to stderr, so both shells merge stderr+stdout into
     /// `log_file`, which the liveness/tail checks inspect.
+    ///
+    /// The launched process must outlive the SSH session. POSIX uses
+    /// `nohup ... & disown`. Windows uses `Win32_Process.Create` (via CIM): the
+    /// new process is owned by the WMI service rather than the SSH session, so
+    /// it is not killed when the session disconnects -- unlike `Start-Process`,
+    /// whose children inherit the session's job object. The recorded PID is the
+    /// wrapping `cmd.exe`, which lives for the worker's lifetime and whose tree
+    /// `kill_process` tears down with `taskkill /T`.
     pub fn start_detached(
         &self,
         program: &str,
@@ -173,29 +190,25 @@ impl RemoteShell {
                 format!("bash -c '{}'", inner.replace('\'', r"'\''"))
             }
             RemoteShell::Windows => {
-                // Start-Process cannot redirect stdout and stderr to the same
-                // file, so stderr (where the torc log lives) goes to `log_file`
-                // and stdout to a sibling `.out` file.
-                let arg_clause = if args.is_empty() {
-                    String::new()
-                } else {
-                    let arg_list = args
-                        .iter()
-                        .map(|a| powershell_quote(a))
-                        .collect::<Vec<_>>()
-                        .join(",");
-                    format!(" -ArgumentList {}", arg_list)
-                };
-                let out_file = format!("{}.out", log_file);
+                // Build the command line cmd.exe will run: the program and args,
+                // merging stderr into the log file. cmd handles the redirection;
+                // double quotes guard paths/args containing spaces.
+                let mut inner = cmd_quote(program);
+                for arg in args {
+                    inner.push(' ');
+                    inner.push_str(&cmd_quote(arg));
+                }
+                inner.push_str(&format!(" > {} 2>&1", cmd_quote(log_file)));
+                // `cmd.exe /s /c "..."` strips exactly the outermost quote pair
+                // and runs the remainder verbatim.
+                let command_line = format!("cmd.exe /s /c \"{}\"", inner);
                 powershell_encoded(&format!(
-                    "$p = Start-Process -FilePath {program}{arg_clause} \
-                     -RedirectStandardError {log} -RedirectStandardOutput {out} \
-                     -WindowStyle Hidden -PassThru; \
-                     $p.Id | Out-File -Encoding ascii -FilePath {pid}",
-                    program = powershell_quote(program),
-                    arg_clause = arg_clause,
-                    log = powershell_quote(log_file),
-                    out = powershell_quote(&out_file),
+                    "$r = Invoke-CimMethod -ClassName Win32_Process -MethodName Create \
+                     -Arguments @{{ CommandLine = {cmd} }}; \
+                     if ($r.ReturnValue -ne 0) {{ throw \"Win32_Process Create failed: \
+                     $($r.ReturnValue)\" }}; \
+                     $r.ProcessId | Out-File -Encoding ascii -FilePath {pid}",
+                    cmd = powershell_quote(&command_line),
                     pid = powershell_quote(pid_file),
                 ))
             }
@@ -304,13 +317,14 @@ impl RemoteShell {
                     signal, pid
                 )
             }
-            // `-ErrorAction Stop` makes a failed Stop-Process (e.g. access
-            // denied) throw, so the command exits non-zero instead of falsely
-            // reporting "killed".
+            // `taskkill /T` kills the recorded cmd.exe and its child worker
+            // process. Exit 0 = killed, 128 = process not found; any other code
+            // throws so a real failure (e.g. access denied) surfaces as an error
+            // rather than a false "killed".
             RemoteShell::Windows => powershell_encoded(&format!(
-                "if (Get-Process -Id {pid} -ErrorAction SilentlyContinue) \
-                 {{ Stop-Process -Id {pid} -Force -ErrorAction Stop; 'killed' }} \
-                 else {{ 'not_found' }}",
+                "taskkill /PID {pid} /T /F 2>$null; \
+                 switch ($LASTEXITCODE) {{ 0 {{ 'killed' }} 128 {{ 'not_found' }} \
+                 default {{ throw \"taskkill failed: $LASTEXITCODE\" }} }}",
                 pid = pid
             )),
         }
@@ -467,17 +481,14 @@ mod tests {
             "pid",
         );
         let start_script = decode_powershell(&start);
-        assert!(start_script.contains("Start-Process -FilePath 'torc'"));
-        assert!(start_script.contains("'--url','u','run'"));
-        // stderr (where the torc log line goes) must land in the greppable log file.
-        assert!(start_script.contains("-RedirectStandardError 'log'"));
-        assert!(start_script.contains("-RedirectStandardOutput 'log.out'"));
+        // Launched via Win32_Process.Create so it survives SSH disconnect.
+        assert!(start_script.contains("Win32_Process -MethodName Create"));
+        // cmd.exe runs the program with merged stderr+stdout into the log file.
+        assert!(start_script.contains(r#"cmd.exe /s /c ""torc" "--url" "u" "run" > "log" 2>&1""#));
+        assert!(start_script.contains("$r.ProcessId | Out-File -Encoding ascii -FilePath 'pid'"));
 
         assert!(decode_powershell(&sh.is_process_alive(7)).contains("Get-Process -Id 7"));
-        assert!(
-            decode_powershell(&sh.kill_process(7, true))
-                .contains("Stop-Process -Id 7 -Force -ErrorAction Stop")
-        );
+        assert!(decode_powershell(&sh.kill_process(7, true)).contains("taskkill /PID 7 /T /F"));
         assert!(decode_powershell(&sh.torc_process_pid(9)).contains("' run 9( |$)'"));
         assert_eq!(sh.temp_tarball_path("a.tgz"), "a.tgz");
     }
@@ -486,8 +497,10 @@ mod tests {
     fn windows_quoting_doubles_single_quotes() {
         // PowerShell escapes a literal single quote by doubling it.
         assert_eq!(powershell_quote("a'b"), "'a''b'");
+        // The arg flows into the cmd line (double-quoted), and the whole line is
+        // PowerShell single-quoted, so the embedded quote is doubled.
         let start = RemoteShell::Windows.start_detached("torc", &["a'b".into()], "log", "pid");
-        assert!(decode_powershell(&start).contains("'a''b'"));
+        assert!(decode_powershell(&start).contains(r#""a''b""#));
     }
 
     #[test]

--- a/src/client/remote/shell.rs
+++ b/src/client/remote/shell.rs
@@ -301,9 +301,12 @@ impl RemoteShell {
     /// Build the shared PowerShell prologue that locates torc worker processes
     /// for `workflow_id`, binding the matches to `$m`, then appends `tail`.
     fn win_find_torc_script(workflow_id: i64, tail: &str) -> String {
+        // Filter by process name at the CIM query level so we do not enumerate
+        // and marshal every process on a busy host; the CommandLine regex match
+        // still runs client-side because WQL cannot express it.
         format!(
-            "$m = Get-CimInstance Win32_Process | Where-Object {{ \
-             $_.Name -eq 'torc.exe' -and $_.CommandLine -match ' run {}( |$)' }}; {}",
+            "$m = Get-CimInstance Win32_Process -Filter \"Name = 'torc.exe'\" | \
+             Where-Object {{ $_.CommandLine -match ' run {}( |$)' }}; {}",
             workflow_id, tail
         )
     }
@@ -396,9 +399,12 @@ impl RemoteShell {
                 posix_quote(tarball),
                 posix_quote(dir)
             ),
-            // Runs via the remote default shell (cmd.exe), so use double quotes,
-            // which cmd.exe understands, rather than POSIX single quotes.
-            RemoteShell::Windows => format!("tar -czf \"{}\" -C \"{}\" .", tarball, dir),
+            // Runs via the remote default shell (cmd.exe), so use the same
+            // double-quoting helper as `start_detached` rather than POSIX single
+            // quotes.
+            RemoteShell::Windows => {
+                format!("tar -czf {} -C {} .", cmd_quote(tarball), cmd_quote(dir))
+            }
         }
     }
 
@@ -498,7 +504,10 @@ mod tests {
 
         assert!(decode_powershell(&sh.is_process_alive(7)).contains("Get-Process -Id 7"));
         assert!(decode_powershell(&sh.kill_process(7, true)).contains("taskkill /PID 7 /T /F"));
-        assert!(decode_powershell(&sh.torc_process_pid(9)).contains("' run 9( |$)'"));
+        let pid_lookup = decode_powershell(&sh.torc_process_pid(9));
+        assert!(pid_lookup.contains("' run 9( |$)'"));
+        // Filter by process name at the CIM query level to avoid enumerating all processes.
+        assert!(pid_lookup.contains("Get-CimInstance Win32_Process -Filter \"Name = 'torc.exe'\""));
         assert_eq!(sh.temp_tarball_path("a.tgz"), "a.tgz");
     }
 

--- a/src/client/remote/shell.rs
+++ b/src/client/remote/shell.rs
@@ -202,9 +202,15 @@ impl RemoteShell {
                 // `cmd.exe /s /c "..."` strips exactly the outermost quote pair
                 // and runs the remainder verbatim.
                 let command_line = format!("cmd.exe /s /c \"{}\"", inner);
+                // Win32_Process.Create does not inherit the SSH session's working
+                // directory (it launches from the WMI host's directory), so pass
+                // the session's CWD explicitly. Otherwise relative paths -- the
+                // log file and the worker's --output-dir -- resolve against the
+                // wrong directory and the process exits immediately.
                 powershell_encoded(&format!(
-                    "$r = Invoke-CimMethod -ClassName Win32_Process -MethodName Create \
-                     -Arguments @{{ CommandLine = {cmd} }}; \
+                    "$cwd = (Get-Location).Path; \
+                     $r = Invoke-CimMethod -ClassName Win32_Process -MethodName Create \
+                     -Arguments @{{ CommandLine = {cmd}; CurrentDirectory = $cwd }}; \
                      if ($r.ReturnValue -ne 0) {{ throw \"Win32_Process Create failed: \
                      $($r.ReturnValue)\" }}; \
                      $r.ProcessId | Out-File -Encoding ascii -FilePath {pid}",
@@ -483,6 +489,8 @@ mod tests {
         let start_script = decode_powershell(&start);
         // Launched via Win32_Process.Create so it survives SSH disconnect.
         assert!(start_script.contains("Win32_Process -MethodName Create"));
+        // Must run in the SSH session's CWD, not the WMI host's directory.
+        assert!(start_script.contains("CurrentDirectory = $cwd"));
         // cmd.exe runs the program with merged stderr+stdout into the log file.
         assert!(start_script.contains(r#"cmd.exe /s /c ""torc" "--url" "u" "run" > "log" 2>&1""#));
         assert!(start_script.contains("$r.ProcessId | Out-File -Encoding ascii -FilePath 'pid'"));

--- a/src/client/remote/shell.rs
+++ b/src/client/remote/shell.rs
@@ -399,12 +399,15 @@ impl RemoteShell {
                 posix_quote(tarball),
                 posix_quote(dir)
             ),
-            // Runs via the remote default shell (cmd.exe), so use the same
-            // double-quoting helper as `start_detached` rather than POSIX single
-            // quotes.
-            RemoteShell::Windows => {
-                format!("tar -czf {} -C {} .", cmd_quote(tarball), cmd_quote(dir))
-            }
+            // Run `tar` from PowerShell (encoded) like every other Windows
+            // command, rather than emitting a bare `tar` string that depends on
+            // the host's default SSH shell being cmd.exe. Encoding also keeps
+            // the paths quote-safe.
+            RemoteShell::Windows => powershell_encoded(&format!(
+                "tar -czf {} -C {} .",
+                powershell_quote(tarball),
+                powershell_quote(dir)
+            )),
         }
     }
 
@@ -524,9 +527,10 @@ mod tests {
     #[test]
     fn windows_tarball_uses_tar() {
         let sh = RemoteShell::Windows;
-        assert_eq!(
-            sh.create_tarball("a.tgz", "out"),
-            "tar -czf \"a.tgz\" -C \"out\" ."
-        );
+        let tarball = sh.create_tarball("a.tgz", "out");
+        // Emitted as encoded PowerShell (not a bare cmd.exe string) so it does
+        // not depend on the host's default SSH shell.
+        assert!(tarball.starts_with("powershell -NoProfile -NonInteractive -EncodedCommand "));
+        assert_eq!(decode_powershell(&tarball), "tar -czf 'a.tgz' -C 'out' .");
     }
 }

--- a/src/client/remote/shell.rs
+++ b/src/client/remote/shell.rs
@@ -1,0 +1,419 @@
+//! Cross-platform remote shell abstraction for remote worker execution.
+//!
+//! `torc remote` issues commands to worker hosts over SSH. The remote login
+//! shell may be a POSIX shell with coreutils (Linux, macOS, *BSD) or a Windows
+//! host where the default shell is `cmd.exe` or PowerShell. The original
+//! implementation assumed bash unconditionally (`bash -c 'nohup ... & disown'`,
+//! `pgrep`, `kill -0`, `tail`, `tar`, ...), so none of the remote commands
+//! worked against Windows workers.
+//!
+//! This module detects which shell family a host belongs to and builds the
+//! appropriate command string for each remote operation. Windows commands are
+//! delivered as PowerShell `-EncodedCommand` payloads (base64 of a UTF-16LE
+//! script). Encoding sidesteps the nested-quoting problem entirely: the SSH
+//! argument that reaches the remote default shell (`cmd.exe` or PowerShell) is
+//! plain ASCII with no quotes or shell metacharacters, so it survives whichever
+//! shell interprets it before launching PowerShell.
+
+use base64::Engine;
+use log::debug;
+
+use super::ssh::ssh_execute;
+use super::types::WorkerEntry;
+
+/// The remote shell family used to interpret commands on a worker host.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RemoteShell {
+    /// POSIX shell with coreutils (Linux, macOS, *BSD).
+    Posix,
+    /// Windows host; commands are run via `powershell -EncodedCommand`.
+    Windows,
+}
+
+/// Wrap a PowerShell script as a `powershell -EncodedCommand <base64>` invocation.
+///
+/// `-EncodedCommand` expects standard base64 of the UTF-16LE script bytes. Using
+/// it means the command string sent over SSH contains no quotes or shell
+/// metacharacters, so it is interpreted identically whether the remote default
+/// shell is `cmd.exe` or PowerShell.
+fn powershell_encoded(script: &str) -> String {
+    let utf16_le: Vec<u8> = script
+        .encode_utf16()
+        .flat_map(|unit| unit.to_le_bytes())
+        .collect();
+    let encoded = base64::engine::general_purpose::STANDARD.encode(utf16_le);
+    format!(
+        "powershell -NoProfile -NonInteractive -EncodedCommand {}",
+        encoded
+    )
+}
+
+/// Detect the remote shell family for a worker by probing over SSH.
+///
+/// POSIX hosts respond to `uname`. If `uname` is unavailable but the host is
+/// reachable, we confirm a usable PowerShell before classifying it as Windows.
+/// This doubles as the connectivity check: a transport failure (SSH exit 255)
+/// is reported as an unreachable host rather than an unknown shell.
+pub fn detect_remote_shell(worker: &WorkerEntry) -> Result<RemoteShell, String> {
+    let uname = ssh_execute(worker, "uname", Some(15))?;
+
+    if uname.status.success() {
+        let kernel = String::from_utf8_lossy(&uname.stdout);
+        if !kernel.trim().is_empty() {
+            debug!(
+                "Detected POSIX shell on {} (uname={})",
+                worker.display_name(),
+                kernel.trim()
+            );
+            return Ok(RemoteShell::Posix);
+        }
+    }
+
+    // SSH transport failures use exit code 255 -- distinguish "unreachable"
+    // from "reachable but no uname" (i.e. a likely Windows host).
+    if uname.status.code() == Some(255) {
+        let stderr = String::from_utf8_lossy(&uname.stderr);
+        return Err(format!(
+            "SSH connection failed to {}: {}",
+            worker.display_name(),
+            stderr.trim()
+        ));
+    }
+
+    // Reachable, but `uname` is not available. Confirm PowerShell works before
+    // assuming a Windows host so we fail clearly on truly unsupported shells.
+    let probe = powershell_encoded("Write-Output 'torc_powershell_ok'");
+    let ps = ssh_execute(worker, &probe, Some(20))?;
+    if ps.status.success() && String::from_utf8_lossy(&ps.stdout).contains("torc_powershell_ok") {
+        debug!(
+            "Detected Windows/PowerShell shell on {}",
+            worker.display_name()
+        );
+        return Ok(RemoteShell::Windows);
+    }
+
+    Err(format!(
+        "Could not determine the remote shell on {}: the host responded to neither \
+         'uname' (POSIX) nor PowerShell. 'torc remote' supports POSIX shells and \
+         Windows PowerShell.",
+        worker.display_name()
+    ))
+}
+
+impl RemoteShell {
+    /// Command to create `dir` (including parents), succeeding if it exists.
+    pub fn mkdir_p(&self, dir: &str) -> String {
+        match self {
+            RemoteShell::Posix => format!("mkdir -p {}", dir),
+            RemoteShell::Windows => powershell_encoded(&format!(
+                "New-Item -ItemType Directory -Force -Path '{}' | Out-Null",
+                dir
+            )),
+        }
+    }
+
+    /// Command to launch a detached `torc` worker, redirecting output to
+    /// `log_file` and writing the worker PID to `pid_file`.
+    ///
+    /// `program` is the worker executable (`torc`) and `args` its arguments.
+    /// The worker's `env_logger` output (including the "Starting torc job
+    /// runner" startup line) goes to stderr, so both shells route stderr to
+    /// `log_file`, which the liveness/tail checks inspect.
+    pub fn start_detached(
+        &self,
+        program: &str,
+        args: &[String],
+        log_file: &str,
+        pid_file: &str,
+    ) -> String {
+        match self {
+            RemoteShell::Posix => {
+                let cmd = std::iter::once(program.to_string())
+                    .chain(args.iter().cloned())
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                // nohup + background + disown so the worker outlives the SSH session.
+                format!(
+                    "bash -c 'nohup {} > {} 2>&1 & echo $! > {}; disown'",
+                    cmd, log_file, pid_file
+                )
+            }
+            RemoteShell::Windows => {
+                // Start-Process cannot redirect stdout and stderr to the same
+                // file, so stderr (where the torc log lives) goes to `log_file`
+                // and stdout to a sibling `.out` file.
+                let arg_list = args
+                    .iter()
+                    .map(|a| format!("'{}'", a))
+                    .collect::<Vec<_>>()
+                    .join(",");
+                let out_file = format!("{}.out", log_file);
+                powershell_encoded(&format!(
+                    "$p = Start-Process -FilePath '{program}' -ArgumentList {arg_list} \
+                     -RedirectStandardError '{log}' -RedirectStandardOutput '{out}' \
+                     -WindowStyle Hidden -PassThru; \
+                     $p.Id | Out-File -Encoding ascii -FilePath '{pid}'",
+                    program = program,
+                    arg_list = arg_list,
+                    log = log_file,
+                    out = out_file,
+                    pid = pid_file,
+                ))
+            }
+        }
+    }
+
+    /// Command to print the contents of `path`. Fails (non-zero exit) if the
+    /// file does not exist, so callers can treat that as "no PID file".
+    pub fn read_file(&self, path: &str) -> String {
+        match self {
+            RemoteShell::Posix => format!("cat {}", path),
+            RemoteShell::Windows => powershell_encoded(&format!("Get-Content '{}'", path)),
+        }
+    }
+
+    /// Command that prints `running` if the given PID is alive, else `stopped`.
+    pub fn is_process_alive(&self, pid: u32) -> String {
+        match self {
+            RemoteShell::Posix => {
+                format!(
+                    "kill -0 {} 2>/dev/null && echo running || echo stopped",
+                    pid
+                )
+            }
+            RemoteShell::Windows => powershell_encoded(&format!(
+                "if (Get-Process -Id {} -ErrorAction SilentlyContinue) {{ 'running' }} \
+                 else {{ 'stopped' }}",
+                pid
+            )),
+        }
+    }
+
+    /// Command that prints `started` if `log_file` contains the worker startup
+    /// line, else `waiting`. A missing log file prints `waiting`.
+    pub fn log_shows_startup(&self, log_file: &str) -> String {
+        match self {
+            RemoteShell::Posix => format!(
+                "grep -q 'Starting torc job runner' {} 2>/dev/null && echo started || echo waiting",
+                log_file
+            ),
+            RemoteShell::Windows => powershell_encoded(&format!(
+                "if ((Test-Path '{log}') -and \
+                 (Select-String -Quiet -Pattern 'Starting torc job runner' -Path '{log}')) \
+                 {{ 'started' }} else {{ 'waiting' }}",
+                log = log_file
+            )),
+        }
+    }
+
+    /// Command that prints `running` if a `torc ... run <workflow_id>` process
+    /// exists, else `stopped`. Used to confirm startup after the log line.
+    pub fn torc_process_running(&self, workflow_id: i64) -> String {
+        match self {
+            RemoteShell::Posix => format!(
+                "pgrep -f 'torc .* run {}( |$)' >/dev/null 2>&1 && echo running || echo stopped",
+                workflow_id
+            ),
+            RemoteShell::Windows => powershell_encoded(&Self::win_find_torc_script(
+                workflow_id,
+                "if ($m) { 'running' } else { 'stopped' }",
+            )),
+        }
+    }
+
+    /// Command that prints the PID of a `torc ... run <workflow_id>` process if
+    /// one exists, else nothing. Used as a fallback when the PID file is absent.
+    pub fn torc_process_pid(&self, workflow_id: i64) -> String {
+        match self {
+            RemoteShell::Posix => {
+                format!(
+                    "pgrep -f 'torc .* run {}( |$)' 2>/dev/null | head -1",
+                    workflow_id
+                )
+            }
+            RemoteShell::Windows => powershell_encoded(&Self::win_find_torc_script(
+                workflow_id,
+                "if ($m) { @($m)[0].ProcessId }",
+            )),
+        }
+    }
+
+    /// Build the shared PowerShell prologue that locates torc worker processes
+    /// for `workflow_id`, binding the matches to `$m`, then appends `tail`.
+    fn win_find_torc_script(workflow_id: i64, tail: &str) -> String {
+        format!(
+            "$m = Get-CimInstance Win32_Process | Where-Object {{ \
+             $_.Name -eq 'torc.exe' -and $_.CommandLine -match ' run {}( |$)' }}; {}",
+            workflow_id, tail
+        )
+    }
+
+    /// Command to send a stop signal to `pid`, printing `killed` on success or
+    /// `not_found` if the process is already gone.
+    ///
+    /// `graceful` requests a SIGTERM-style stop on POSIX. Windows has no
+    /// SIGTERM equivalent for a detached process, so it is always a hard stop;
+    /// callers should surface that limitation to the user.
+    pub fn kill_process(&self, pid: u32, graceful: bool) -> String {
+        match self {
+            RemoteShell::Posix => {
+                let signal = if graceful { "TERM" } else { "KILL" };
+                format!(
+                    "kill -{} {} 2>/dev/null && echo killed || echo not_found",
+                    signal, pid
+                )
+            }
+            RemoteShell::Windows => powershell_encoded(&format!(
+                "if (Get-Process -Id {pid} -ErrorAction SilentlyContinue) \
+                 {{ Stop-Process -Id {pid} -Force; 'killed' }} else {{ 'not_found' }}",
+                pid = pid
+            )),
+        }
+    }
+
+    /// Command that prints `exists` if `dir` is a directory, else `missing`.
+    pub fn dir_exists(&self, dir: &str) -> String {
+        match self {
+            RemoteShell::Posix => format!("test -d {} && echo exists || echo missing", dir),
+            RemoteShell::Windows => powershell_encoded(&format!(
+                "if (Test-Path -PathType Container '{}') {{ 'exists' }} else {{ 'missing' }}",
+                dir
+            )),
+        }
+    }
+
+    /// Command to print the last `lines` lines of `file`, or a placeholder if
+    /// the file is missing.
+    pub fn tail(&self, file: &str, lines: usize) -> String {
+        match self {
+            RemoteShell::Posix => {
+                format!(
+                    "tail -{} {} 2>/dev/null || echo 'No log available'",
+                    lines, file
+                )
+            }
+            RemoteShell::Windows => powershell_encoded(&format!(
+                "if (Test-Path '{file}') {{ Get-Content -Tail {lines} '{file}' }} \
+                 else {{ 'No log available' }}",
+                file = file,
+                lines = lines
+            )),
+        }
+    }
+
+    /// Remote path for the temporary logs tarball named `name`.
+    ///
+    /// POSIX uses `/tmp`; Windows uses a home-relative path (resolved by the SSH
+    /// session's working directory) so the path is concrete for `scp` without
+    /// needing environment-variable expansion.
+    pub fn temp_tarball_path(&self, name: &str) -> String {
+        match self {
+            RemoteShell::Posix => format!("/tmp/{}", name),
+            RemoteShell::Windows => name.to_string(),
+        }
+    }
+
+    /// Command to create a gzip tarball `tarball` from the contents of `dir`.
+    ///
+    /// Both shells use `tar`, which ships with modern Windows (bsdtar, Win10
+    /// 1803+) and accepts the same `-czf -C` flags.
+    pub fn create_tarball(&self, tarball: &str, dir: &str) -> String {
+        match self {
+            RemoteShell::Posix => format!("tar -czf {} -C {} . 2>/dev/null", tarball, dir),
+            RemoteShell::Windows => format!("tar -czf {} -C {} .", tarball, dir),
+        }
+    }
+
+    /// Command to remove the file at `path` (no error if absent).
+    pub fn remove_file(&self, path: &str) -> String {
+        match self {
+            RemoteShell::Posix => format!("rm -f {}", path),
+            RemoteShell::Windows => powershell_encoded(&format!(
+                "Remove-Item -Force -ErrorAction SilentlyContinue '{}'",
+                path
+            )),
+        }
+    }
+
+    /// Command to recursively remove the directory at `path` (no error if absent).
+    pub fn remove_dir(&self, path: &str) -> String {
+        match self {
+            RemoteShell::Posix => format!("rm -rf {}", path),
+            RemoteShell::Windows => powershell_encoded(&format!(
+                "Remove-Item -Recurse -Force -ErrorAction SilentlyContinue '{}'",
+                path
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Decode a `powershell -EncodedCommand` invocation back to its script.
+    fn decode_powershell(command: &str) -> String {
+        let b64 = command
+            .strip_prefix("powershell -NoProfile -NonInteractive -EncodedCommand ")
+            .expect("expected an encoded PowerShell command");
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(b64)
+            .expect("valid base64");
+        let units: Vec<u16> = bytes
+            .chunks_exact(2)
+            .map(|c| u16::from_le_bytes([c[0], c[1]]))
+            .collect();
+        String::from_utf16(&units).expect("valid UTF-16")
+    }
+
+    #[test]
+    fn posix_commands_are_bash() {
+        let sh = RemoteShell::Posix;
+        assert_eq!(sh.mkdir_p("out"), "mkdir -p out");
+        assert!(
+            sh.start_detached("torc", &["run".into()], "log", "pid")
+                .contains("nohup torc run")
+        );
+        assert_eq!(sh.read_file("p"), "cat p");
+        assert!(sh.is_process_alive(42).contains("kill -0 42"));
+        assert!(sh.kill_process(42, true).contains("kill -TERM 42"));
+        assert!(sh.kill_process(42, false).contains("kill -KILL 42"));
+        assert_eq!(sh.temp_tarball_path("a.tgz"), "/tmp/a.tgz");
+        assert_eq!(sh.remove_dir("d"), "rm -rf d");
+    }
+
+    #[test]
+    fn windows_commands_are_encoded_powershell() {
+        let sh = RemoteShell::Windows;
+
+        let mkdir = sh.mkdir_p("out");
+        assert!(mkdir.starts_with("powershell -NoProfile -NonInteractive -EncodedCommand "));
+        assert!(
+            decode_powershell(&mkdir).contains("New-Item -ItemType Directory -Force -Path 'out'")
+        );
+
+        let start = sh.start_detached(
+            "torc",
+            &["--url".into(), "u".into(), "run".into()],
+            "log",
+            "pid",
+        );
+        let start_script = decode_powershell(&start);
+        assert!(start_script.contains("Start-Process -FilePath 'torc'"));
+        assert!(start_script.contains("'--url','u','run'"));
+        // stderr (where the torc log line goes) must land in the greppable log file.
+        assert!(start_script.contains("-RedirectStandardError 'log'"));
+        assert!(start_script.contains("-RedirectStandardOutput 'log.out'"));
+
+        assert!(decode_powershell(&sh.is_process_alive(7)).contains("Get-Process -Id 7"));
+        assert!(decode_powershell(&sh.kill_process(7, true)).contains("Stop-Process -Id 7 -Force"));
+        assert!(decode_powershell(&sh.torc_process_pid(9)).contains("' run 9( |$)'"));
+        assert_eq!(sh.temp_tarball_path("a.tgz"), "a.tgz");
+    }
+
+    #[test]
+    fn windows_tarball_uses_tar() {
+        let sh = RemoteShell::Windows;
+        assert_eq!(sh.create_tarball("a.tgz", "out"), "tar -czf a.tgz -C out .");
+    }
+}

--- a/src/client/remote/shell.rs
+++ b/src/client/remote/shell.rs
@@ -67,9 +67,9 @@ fn powershell_quote(value: &str) -> String {
 
 /// Quote a value for use as a `cmd.exe` token by wrapping it in double quotes.
 ///
-/// cmd has no general escape for an embedded double quote, but worker paths and
-/// arguments do not contain them in practice; double-quoting handles the common
-/// case of spaces.
+/// cmd has no general escape for an embedded double quote; callers
+/// (`start_remote_worker`) reject values containing one before building the
+/// command line. Double-quoting here handles the common case of spaces.
 fn cmd_quote(value: &str) -> String {
     format!("\"{}\"", value)
 }

--- a/src/client/remote/shell.rs
+++ b/src/client/remote/shell.rs
@@ -226,9 +226,14 @@ impl RemoteShell {
     pub fn read_file(&self, path: &str) -> String {
         match self {
             RemoteShell::Posix => format!("cat {}", posix_quote(path)),
-            RemoteShell::Windows => {
-                powershell_encoded(&format!("Get-Content {}", powershell_quote(path)))
-            }
+            // `-ErrorAction Stop` makes a missing file a terminating error so
+            // PowerShell exits non-zero (its default is a non-terminating error
+            // that still exits 0, which would break the "no PID file" contract
+            // callers rely on). `-LiteralPath` avoids wildcard expansion.
+            RemoteShell::Windows => powershell_encoded(&format!(
+                "Get-Content -LiteralPath {} -ErrorAction Stop",
+                powershell_quote(path)
+            )),
         }
     }
 
@@ -394,8 +399,11 @@ impl RemoteShell {
     /// 1803+) and accepts the same `-czf -C` flags.
     pub fn create_tarball(&self, tarball: &str, dir: &str) -> String {
         match self {
+            // Let tar write diagnostics to stderr: callers run this via
+            // `ssh_execute_checked`, which surfaces the remote stderr on
+            // failure, so suppressing it would produce a blank error message.
             RemoteShell::Posix => format!(
-                "tar -czf {} -C {} . 2>/dev/null",
+                "tar -czf {} -C {} .",
                 posix_quote(tarball),
                 posix_quote(dir)
             ),

--- a/src/client/remote/shell.rs
+++ b/src/client/remote/shell.rs
@@ -48,6 +48,23 @@ fn powershell_encoded(script: &str) -> String {
     )
 }
 
+/// Quote a value for safe interpolation into a POSIX shell command.
+///
+/// Wraps the value in single quotes, escaping embedded single quotes as `'\''`,
+/// so paths/arguments containing whitespace or shell metacharacters are passed
+/// through literally rather than re-interpreted by the shell.
+fn posix_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', r"'\''"))
+}
+
+/// Quote a value for safe interpolation into a PowerShell single-quoted string.
+///
+/// In PowerShell, a literal single quote inside a single-quoted string is
+/// escaped by doubling it (`''`).
+fn powershell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
 /// Detect the remote shell family for a worker by probing over SSH.
 ///
 /// POSIX hosts respond to `uname`. If `uname` is unavailable but the host is
@@ -59,11 +76,23 @@ pub fn detect_remote_shell(worker: &WorkerEntry) -> Result<RemoteShell, String> 
 
     if uname.status.success() {
         let kernel = String::from_utf8_lossy(&uname.stdout);
-        if !kernel.trim().is_empty() {
+        let trimmed = kernel.trim();
+        // A Windows host with Git/MSYS/Cygwin may have `uname` on PATH even
+        // though its SSH shell is cmd.exe/PowerShell (where `mkdir -p`, `pgrep`,
+        // etc. would fail). Those report MINGW*/MSYS*/CYGWIN*, so treat them as
+        // non-POSIX and let them fall through to the PowerShell probe.
+        let looks_windows = {
+            let upper = trimmed.to_ascii_uppercase();
+            upper.contains("MINGW")
+                || upper.contains("MSYS")
+                || upper.contains("CYGWIN")
+                || upper.contains("WINDOWS")
+        };
+        if !trimmed.is_empty() && !looks_windows {
             debug!(
                 "Detected POSIX shell on {} (uname={})",
                 worker.display_name(),
-                kernel.trim()
+                trimmed
             );
             return Ok(RemoteShell::Posix);
         }
@@ -104,10 +133,10 @@ impl RemoteShell {
     /// Command to create `dir` (including parents), succeeding if it exists.
     pub fn mkdir_p(&self, dir: &str) -> String {
         match self {
-            RemoteShell::Posix => format!("mkdir -p {}", dir),
+            RemoteShell::Posix => format!("mkdir -p {}", posix_quote(dir)),
             RemoteShell::Windows => powershell_encoded(&format!(
-                "New-Item -ItemType Directory -Force -Path '{}' | Out-Null",
-                dir
+                "New-Item -ItemType Directory -Force -Path {} | Out-Null",
+                powershell_quote(dir)
             )),
         }
     }
@@ -128,36 +157,46 @@ impl RemoteShell {
     ) -> String {
         match self {
             RemoteShell::Posix => {
-                let cmd = std::iter::once(program.to_string())
-                    .chain(args.iter().cloned())
+                let cmd = std::iter::once(posix_quote(program))
+                    .chain(args.iter().map(|a| posix_quote(a)))
                     .collect::<Vec<_>>()
                     .join(" ");
                 // nohup + background + disown so the worker outlives the SSH session.
-                format!(
-                    "bash -c 'nohup {} > {} 2>&1 & echo $! > {}; disown'",
-                    cmd, log_file, pid_file
-                )
+                let inner = format!(
+                    "nohup {} > {} 2>&1 & echo $! > {}; disown",
+                    cmd,
+                    posix_quote(log_file),
+                    posix_quote(pid_file)
+                );
+                // Wrap the script as a single `bash -c '...'` argument, escaping
+                // any single quotes the inner quoting introduced.
+                format!("bash -c '{}'", inner.replace('\'', r"'\''"))
             }
             RemoteShell::Windows => {
                 // Start-Process cannot redirect stdout and stderr to the same
                 // file, so stderr (where the torc log lives) goes to `log_file`
                 // and stdout to a sibling `.out` file.
-                let arg_list = args
-                    .iter()
-                    .map(|a| format!("'{}'", a))
-                    .collect::<Vec<_>>()
-                    .join(",");
+                let arg_clause = if args.is_empty() {
+                    String::new()
+                } else {
+                    let arg_list = args
+                        .iter()
+                        .map(|a| powershell_quote(a))
+                        .collect::<Vec<_>>()
+                        .join(",");
+                    format!(" -ArgumentList {}", arg_list)
+                };
                 let out_file = format!("{}.out", log_file);
                 powershell_encoded(&format!(
-                    "$p = Start-Process -FilePath '{program}' -ArgumentList {arg_list} \
-                     -RedirectStandardError '{log}' -RedirectStandardOutput '{out}' \
+                    "$p = Start-Process -FilePath {program}{arg_clause} \
+                     -RedirectStandardError {log} -RedirectStandardOutput {out} \
                      -WindowStyle Hidden -PassThru; \
-                     $p.Id | Out-File -Encoding ascii -FilePath '{pid}'",
-                    program = program,
-                    arg_list = arg_list,
-                    log = log_file,
-                    out = out_file,
-                    pid = pid_file,
+                     $p.Id | Out-File -Encoding ascii -FilePath {pid}",
+                    program = powershell_quote(program),
+                    arg_clause = arg_clause,
+                    log = powershell_quote(log_file),
+                    out = powershell_quote(&out_file),
+                    pid = powershell_quote(pid_file),
                 ))
             }
         }
@@ -167,8 +206,10 @@ impl RemoteShell {
     /// file does not exist, so callers can treat that as "no PID file".
     pub fn read_file(&self, path: &str) -> String {
         match self {
-            RemoteShell::Posix => format!("cat {}", path),
-            RemoteShell::Windows => powershell_encoded(&format!("Get-Content '{}'", path)),
+            RemoteShell::Posix => format!("cat {}", posix_quote(path)),
+            RemoteShell::Windows => {
+                powershell_encoded(&format!("Get-Content {}", powershell_quote(path)))
+            }
         }
     }
 
@@ -195,13 +236,13 @@ impl RemoteShell {
         match self {
             RemoteShell::Posix => format!(
                 "grep -q 'Starting torc job runner' {} 2>/dev/null && echo started || echo waiting",
-                log_file
+                posix_quote(log_file)
             ),
             RemoteShell::Windows => powershell_encoded(&format!(
-                "if ((Test-Path '{log}') -and \
-                 (Select-String -Quiet -Pattern 'Starting torc job runner' -Path '{log}')) \
+                "if ((Test-Path {log}) -and \
+                 (Select-String -Quiet -Pattern 'Starting torc job runner' -Path {log})) \
                  {{ 'started' }} else {{ 'waiting' }}",
-                log = log_file
+                log = powershell_quote(log_file)
             )),
         }
     }
@@ -263,9 +304,13 @@ impl RemoteShell {
                     signal, pid
                 )
             }
+            // `-ErrorAction Stop` makes a failed Stop-Process (e.g. access
+            // denied) throw, so the command exits non-zero instead of falsely
+            // reporting "killed".
             RemoteShell::Windows => powershell_encoded(&format!(
                 "if (Get-Process -Id {pid} -ErrorAction SilentlyContinue) \
-                 {{ Stop-Process -Id {pid} -Force; 'killed' }} else {{ 'not_found' }}",
+                 {{ Stop-Process -Id {pid} -Force -ErrorAction Stop; 'killed' }} \
+                 else {{ 'not_found' }}",
                 pid = pid
             )),
         }
@@ -274,10 +319,15 @@ impl RemoteShell {
     /// Command that prints `exists` if `dir` is a directory, else `missing`.
     pub fn dir_exists(&self, dir: &str) -> String {
         match self {
-            RemoteShell::Posix => format!("test -d {} && echo exists || echo missing", dir),
+            RemoteShell::Posix => {
+                format!(
+                    "test -d {} && echo exists || echo missing",
+                    posix_quote(dir)
+                )
+            }
             RemoteShell::Windows => powershell_encoded(&format!(
-                "if (Test-Path -PathType Container '{}') {{ 'exists' }} else {{ 'missing' }}",
-                dir
+                "if (Test-Path -PathType Container {}) {{ 'exists' }} else {{ 'missing' }}",
+                powershell_quote(dir)
             )),
         }
     }
@@ -289,13 +339,14 @@ impl RemoteShell {
             RemoteShell::Posix => {
                 format!(
                     "tail -{} {} 2>/dev/null || echo 'No log available'",
-                    lines, file
+                    lines,
+                    posix_quote(file)
                 )
             }
             RemoteShell::Windows => powershell_encoded(&format!(
-                "if (Test-Path '{file}') {{ Get-Content -Tail {lines} '{file}' }} \
+                "if (Test-Path {file}) {{ Get-Content -Tail {lines} {file} }} \
                  else {{ 'No log available' }}",
-                file = file,
+                file = powershell_quote(file),
                 lines = lines
             )),
         }
@@ -319,18 +370,24 @@ impl RemoteShell {
     /// 1803+) and accepts the same `-czf -C` flags.
     pub fn create_tarball(&self, tarball: &str, dir: &str) -> String {
         match self {
-            RemoteShell::Posix => format!("tar -czf {} -C {} . 2>/dev/null", tarball, dir),
-            RemoteShell::Windows => format!("tar -czf {} -C {} .", tarball, dir),
+            RemoteShell::Posix => format!(
+                "tar -czf {} -C {} . 2>/dev/null",
+                posix_quote(tarball),
+                posix_quote(dir)
+            ),
+            // Runs via the remote default shell (cmd.exe), so use double quotes,
+            // which cmd.exe understands, rather than POSIX single quotes.
+            RemoteShell::Windows => format!("tar -czf \"{}\" -C \"{}\" .", tarball, dir),
         }
     }
 
     /// Command to remove the file at `path` (no error if absent).
     pub fn remove_file(&self, path: &str) -> String {
         match self {
-            RemoteShell::Posix => format!("rm -f {}", path),
+            RemoteShell::Posix => format!("rm -f {}", posix_quote(path)),
             RemoteShell::Windows => powershell_encoded(&format!(
-                "Remove-Item -Force -ErrorAction SilentlyContinue '{}'",
-                path
+                "Remove-Item -Force -ErrorAction SilentlyContinue {}",
+                powershell_quote(path)
             )),
         }
     }
@@ -338,10 +395,10 @@ impl RemoteShell {
     /// Command to recursively remove the directory at `path` (no error if absent).
     pub fn remove_dir(&self, path: &str) -> String {
         match self {
-            RemoteShell::Posix => format!("rm -rf {}", path),
+            RemoteShell::Posix => format!("rm -rf {}", posix_quote(path)),
             RemoteShell::Windows => powershell_encoded(&format!(
-                "Remove-Item -Recurse -Force -ErrorAction SilentlyContinue '{}'",
-                path
+                "Remove-Item -Recurse -Force -ErrorAction SilentlyContinue {}",
+                powershell_quote(path)
             )),
         }
     }
@@ -369,17 +426,28 @@ mod tests {
     #[test]
     fn posix_commands_are_bash() {
         let sh = RemoteShell::Posix;
-        assert_eq!(sh.mkdir_p("out"), "mkdir -p out");
-        assert!(
-            sh.start_detached("torc", &["run".into()], "log", "pid")
-                .contains("nohup torc run")
-        );
-        assert_eq!(sh.read_file("p"), "cat p");
+        assert_eq!(sh.mkdir_p("out"), "mkdir -p 'out'");
+        let start = sh.start_detached("torc", &["run".into()], "log", "pid");
+        assert!(start.starts_with("bash -c "));
+        assert!(start.contains("nohup"));
+        assert!(start.contains("disown"));
+        assert_eq!(sh.read_file("p"), "cat 'p'");
         assert!(sh.is_process_alive(42).contains("kill -0 42"));
         assert!(sh.kill_process(42, true).contains("kill -TERM 42"));
         assert!(sh.kill_process(42, false).contains("kill -KILL 42"));
         assert_eq!(sh.temp_tarball_path("a.tgz"), "/tmp/a.tgz");
-        assert_eq!(sh.remove_dir("d"), "rm -rf d");
+        assert_eq!(sh.remove_dir("d"), "rm -rf 'd'");
+    }
+
+    #[test]
+    fn posix_quoting_is_injection_safe() {
+        // A path with whitespace and a single quote must be quoted such that the
+        // shell sees it as one literal token and cannot break out of the quote.
+        assert_eq!(posix_quote("a b"), "'a b'");
+        assert_eq!(posix_quote("a'b"), r"'a'\''b'");
+        // An attempted injection stays inside the quotes.
+        let cmd = RemoteShell::Posix.remove_dir("d; rm -rf /");
+        assert_eq!(cmd, "rm -rf 'd; rm -rf /'");
     }
 
     #[test]
@@ -406,14 +474,28 @@ mod tests {
         assert!(start_script.contains("-RedirectStandardOutput 'log.out'"));
 
         assert!(decode_powershell(&sh.is_process_alive(7)).contains("Get-Process -Id 7"));
-        assert!(decode_powershell(&sh.kill_process(7, true)).contains("Stop-Process -Id 7 -Force"));
+        assert!(
+            decode_powershell(&sh.kill_process(7, true))
+                .contains("Stop-Process -Id 7 -Force -ErrorAction Stop")
+        );
         assert!(decode_powershell(&sh.torc_process_pid(9)).contains("' run 9( |$)'"));
         assert_eq!(sh.temp_tarball_path("a.tgz"), "a.tgz");
     }
 
     #[test]
+    fn windows_quoting_doubles_single_quotes() {
+        // PowerShell escapes a literal single quote by doubling it.
+        assert_eq!(powershell_quote("a'b"), "'a''b'");
+        let start = RemoteShell::Windows.start_detached("torc", &["a'b".into()], "log", "pid");
+        assert!(decode_powershell(&start).contains("'a''b'"));
+    }
+
+    #[test]
     fn windows_tarball_uses_tar() {
         let sh = RemoteShell::Windows;
-        assert_eq!(sh.create_tarball("a.tgz", "out"), "tar -czf a.tgz -C out .");
+        assert_eq!(
+            sh.create_tarball("a.tgz", "out"),
+            "tar -czf \"a.tgz\" -C \"out\" ."
+        );
     }
 }

--- a/src/client/remote/ssh.rs
+++ b/src/client/remote/ssh.rs
@@ -67,23 +67,21 @@ pub fn ssh_execute_capture(worker: &WorkerEntry, command: &str) -> Result<String
 }
 
 /// Check if SSH connection to a worker is possible.
+///
+/// This probes the remote shell family (POSIX vs Windows), which both verifies
+/// connectivity and confirms the host runs a shell that `torc remote` supports.
+/// A previous implementation ran the POSIX `true` builtin, which fails on
+/// Windows hosts and caused them to be rejected before any work was attempted.
 pub fn check_ssh_connectivity(worker: &WorkerEntry) -> Result<(), String> {
     debug!("Checking SSH connectivity to {}", worker.display_name());
 
-    // Run a simple command to test connectivity
-    let output = ssh_execute(worker, "true", Some(10))?;
-
-    if output.status.success() {
-        debug!("SSH connectivity OK for {}", worker.display_name());
-        Ok(())
-    } else {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        Err(format!(
-            "SSH connection failed to {}: {}",
+    super::shell::detect_remote_shell(worker).map(|shell| {
+        debug!(
+            "SSH connectivity OK for {} (shell={:?})",
             worker.display_name(),
-            stderr.trim()
-        ))
-    }
+            shell
+        );
+    })
 }
 
 /// Get the torc version on a remote host.

--- a/src/client/remote/ssh.rs
+++ b/src/client/remote/ssh.rs
@@ -48,22 +48,55 @@ pub fn ssh_execute(
         .map_err(|e| format!("SSH execution failed for {}: {}", worker.display_name(), e))
 }
 
+/// Execute a command on a remote host, failing if the remote command exits
+/// non-zero.
+///
+/// Plain [`ssh_execute`] returns `Ok` whenever SSH itself connects, even if the
+/// remote command failed (e.g. a PowerShell `throw`, a missing executable, or a
+/// permission error). Callers that treat that `Ok` as success silently swallow
+/// the real failure, which then resurfaces later as a confusing downstream error
+/// (an unreadable PID file, a missing archive) with the original stderr lost.
+/// This wrapper checks `status.success()` and surfaces the remote stderr at the
+/// call site instead.
+pub fn ssh_execute_checked(
+    worker: &WorkerEntry,
+    command: &str,
+    timeout_secs: Option<u64>,
+) -> Result<Output, String> {
+    let output = ssh_execute(worker, command, timeout_secs)?;
+
+    if output.status.success() {
+        Ok(output)
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        // Prefer stderr, but fall back to stdout since some shells (notably
+        // cmd.exe/PowerShell) write diagnostics there.
+        let detail = if stderr.trim().is_empty() {
+            stdout.trim()
+        } else {
+            stderr.trim()
+        };
+        let code = output
+            .status
+            .code()
+            .map(|c| c.to_string())
+            .unwrap_or_else(|| "signal".to_string());
+        Err(format!(
+            "Command failed on {} (exit {}): {}",
+            worker.display_name(),
+            code,
+            detail
+        ))
+    }
+}
+
 /// Execute a command on a remote host and return stdout as a string.
 ///
 /// Returns an error if the command fails (non-zero exit code).
 pub fn ssh_execute_capture(worker: &WorkerEntry, command: &str) -> Result<String, String> {
-    let output = ssh_execute(worker, command, None)?;
-
-    if output.status.success() {
-        Ok(String::from_utf8_lossy(&output.stdout).to_string())
-    } else {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        Err(format!(
-            "Command failed on {}: {}",
-            worker.display_name(),
-            stderr.trim()
-        ))
-    }
+    let output = ssh_execute_checked(worker, command, None)?;
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
 /// Check if SSH connection to a worker is possible.

--- a/tests/test_remote_shell_loopback.rs
+++ b/tests/test_remote_shell_loopback.rs
@@ -1,0 +1,176 @@
+//! Loopback integration test for the remote-worker shell abstraction.
+//!
+//! This drives the [`RemoteShell`] command builders against a *real* SSH shell
+//! by connecting to `localhost`, so it exercises the commands that are
+//! generated for the host's actual operating system. On a Windows host it
+//! validates the PowerShell `-EncodedCommand` path (including the case where the
+//! OpenSSH default shell is `cmd.exe`); on a POSIX host it validates the bash
+//! path.
+//!
+//! It is **opt-in**: it only runs when `TORC_TEST_SSH_LOOPBACK=1` is set, since
+//! it requires a working `ssh localhost` with key-based authentication
+//! (`BatchMode=yes`). CI configures that before setting the variable. Without
+//! the variable the test is a no-op so normal `cargo nextest run` is unaffected.
+
+use std::thread::sleep;
+use std::time::Duration;
+
+use torc::client::remote::{
+    RemoteShell, WorkerEntry, detect_remote_shell, ssh_execute, ssh_execute_capture,
+};
+
+/// Whether the loopback test is enabled for this run.
+fn loopback_enabled() -> bool {
+    std::env::var("TORC_TEST_SSH_LOOPBACK").as_deref() == Ok("1")
+}
+
+/// The shell family we expect for the host running the test.
+fn expected_shell() -> RemoteShell {
+    if cfg!(windows) {
+        RemoteShell::Windows
+    } else {
+        RemoteShell::Posix
+    }
+}
+
+/// A long-running stub process used as a stand-in worker, per shell family.
+///
+/// Returns `(program, args)` for [`RemoteShell::start_detached`]. Both run for
+/// ~30 seconds, long enough to observe a live PID and then kill it.
+fn stub_worker(shell: RemoteShell) -> (&'static str, Vec<String>) {
+    match shell {
+        // `ping -n N 127.0.0.1` runs for roughly N-1 seconds on Windows.
+        RemoteShell::Windows => ("ping", vec!["-n".into(), "30".into(), "127.0.0.1".into()]),
+        RemoteShell::Posix => ("sleep", vec!["30".into()]),
+    }
+}
+
+#[test]
+fn loopback_remote_shell_lifecycle() {
+    if !loopback_enabled() {
+        eprintln!(
+            "skipping loopback_remote_shell_lifecycle: set TORC_TEST_SSH_LOOPBACK=1 \
+             (and ensure `ssh localhost` works with key-based auth) to enable"
+        );
+        return;
+    }
+
+    let worker = WorkerEntry::new("localhost");
+
+    // 1. Shell detection should identify this host's family. This also confirms
+    //    SSH connectivity to localhost works.
+    let shell = detect_remote_shell(&worker)
+        .unwrap_or_else(|e| panic!("detect_remote_shell(localhost) failed: {e}"));
+    assert_eq!(
+        shell,
+        expected_shell(),
+        "detected shell family does not match the host OS"
+    );
+
+    // Use a per-process directory so concurrent/repeated runs do not collide.
+    // Forward slashes are accepted by both POSIX and Windows file APIs.
+    let output_dir = format!("torc_loopback_test_{}", std::process::id());
+    let pid_file = format!("{output_dir}/worker.pid");
+    let log_file = format!("{output_dir}/worker.log");
+
+    // Best-effort cleanup of any leftovers from a previous aborted run.
+    let _ = ssh_execute(&worker, &shell.remove_dir(&output_dir), Some(30));
+
+    // 2. Create the output directory and confirm it exists.
+    let out = ssh_execute_capture(&worker, &shell.mkdir_p(&output_dir))
+        .unwrap_or_else(|e| panic!("mkdir_p failed: {e}"));
+    eprintln!("mkdir_p output: {out:?}");
+    assert_eq!(
+        ssh_execute_capture(&worker, &shell.dir_exists(&output_dir))
+            .expect("dir_exists failed")
+            .trim(),
+        "exists",
+    );
+
+    // 3. Launch the detached stub "worker" and record its PID.
+    let (program, args) = stub_worker(shell);
+    let start = ssh_execute(
+        &worker,
+        &shell.start_detached(program, &args, &log_file, &pid_file),
+        Some(60),
+    )
+    .unwrap_or_else(|e| panic!("start_detached failed: {e}"));
+    assert!(
+        start.status.success(),
+        "start_detached exited non-zero: {}",
+        String::from_utf8_lossy(&start.stderr)
+    );
+
+    // Give the process a moment to spawn and write the PID file.
+    sleep(Duration::from_secs(2));
+
+    // 4. Read and parse the PID.
+    let pid_raw = ssh_execute_capture(&worker, &shell.read_file(&pid_file))
+        .unwrap_or_else(|e| panic!("reading PID file failed: {e}"));
+    let pid: u32 = pid_raw
+        .trim()
+        .parse()
+        .unwrap_or_else(|_| panic!("PID file did not contain a number: {pid_raw:?}"));
+    eprintln!("stub worker started with PID {pid}");
+
+    // 5. The PID should be alive.
+    assert_eq!(
+        ssh_execute_capture(&worker, &shell.is_process_alive(pid))
+            .expect("is_process_alive failed")
+            .trim(),
+        "running",
+        "stub worker PID {pid} was not reported as running",
+    );
+
+    // 6. `tail` should run without error (content is not asserted; the stub may
+    //    not have written to the stderr log).
+    ssh_execute_capture(&worker, &shell.tail(&log_file, 5)).expect("tail failed");
+
+    // 7. Stop the process and confirm it is reported as killed, then dead.
+    assert_eq!(
+        ssh_execute_capture(&worker, &shell.kill_process(pid, false))
+            .expect("kill_process failed")
+            .trim(),
+        "killed",
+        "kill_process did not report a successful kill for PID {pid}",
+    );
+    sleep(Duration::from_secs(1));
+    assert_eq!(
+        ssh_execute_capture(&worker, &shell.is_process_alive(pid))
+            .expect("is_process_alive (post-kill) failed")
+            .trim(),
+        "stopped",
+        "stub worker PID {pid} still running after kill",
+    );
+
+    // 8. Archive the output directory, then clean up the tarball.
+    let tarball = shell.temp_tarball_path(&format!("{output_dir}.tar.gz"));
+    let tar = ssh_execute(
+        &worker,
+        &shell.create_tarball(&tarball, &output_dir),
+        Some(120),
+    )
+    .unwrap_or_else(|e| panic!("create_tarball failed: {e}"));
+    assert!(
+        tar.status.success(),
+        "create_tarball exited non-zero: {}",
+        String::from_utf8_lossy(&tar.stderr)
+    );
+    let _ = ssh_execute(&worker, &shell.remove_file(&tarball), Some(30));
+
+    // 9. Remove the output directory and confirm it is gone.
+    let rm = ssh_execute(&worker, &shell.remove_dir(&output_dir), Some(60))
+        .unwrap_or_else(|e| panic!("remove_dir failed: {e}"));
+    assert!(
+        rm.status.success(),
+        "remove_dir exited non-zero: {}",
+        String::from_utf8_lossy(&rm.stderr)
+    );
+    assert_eq!(
+        ssh_execute_capture(&worker, &shell.dir_exists(&output_dir))
+            .expect("dir_exists (post-remove) failed")
+            .trim(),
+        "missing",
+        "output directory still present after remove_dir",
+    );
+}

--- a/tests/test_remote_shell_loopback.rs
+++ b/tests/test_remote_shell_loopback.rs
@@ -45,6 +45,29 @@ fn stub_worker(shell: RemoteShell) -> (&'static str, Vec<String>) {
     }
 }
 
+/// Poll the remote PID file until it contains a parseable PID, up to a bounded
+/// timeout. Returns the PID, or panics if it never appears.
+///
+/// `read_file` exits non-zero (Err) while the file is absent, and can briefly
+/// return empty content after the file is created but before the PID is written;
+/// both are treated as "not ready yet" and retried.
+fn poll_for_pid(worker: &WorkerEntry, shell: RemoteShell, pid_file: &str) -> u32 {
+    let deadline = 30;
+    let mut waited = 0;
+    let mut last = String::from("<never read>");
+    while waited < deadline {
+        if let Ok(raw) = ssh_execute_capture(worker, &shell.read_file(pid_file)) {
+            if let Ok(pid) = raw.trim().parse::<u32>() {
+                return pid;
+            }
+            last = raw;
+        }
+        sleep(Duration::from_millis(500));
+        waited += 1;
+    }
+    panic!("PID file {pid_file} did not contain a number within {deadline} polls (last: {last:?})");
+}
+
 #[test]
 fn loopback_remote_shell_lifecycle() {
     if !loopback_enabled() {
@@ -101,16 +124,10 @@ fn loopback_remote_shell_lifecycle() {
         String::from_utf8_lossy(&start.stderr)
     );
 
-    // Give the process a moment to spawn and write the PID file.
-    sleep(Duration::from_secs(2));
-
-    // 4. Read and parse the PID.
-    let pid_raw = ssh_execute_capture(&worker, &shell.read_file(&pid_file))
-        .unwrap_or_else(|e| panic!("reading PID file failed: {e}"));
-    let pid: u32 = pid_raw
-        .trim()
-        .parse()
-        .unwrap_or_else(|_| panic!("PID file did not contain a number: {pid_raw:?}"));
+    // 4. Poll for the PID file rather than sleeping a fixed interval: the
+    //    detached spawn (especially Win32_Process.Create on a busy Windows CI
+    //    runner) can take a variable amount of time to write the PID.
+    let pid = poll_for_pid(&worker, shell, &pid_file);
     eprintln!("stub worker started with PID {pid}");
 
     // 5. The PID should be alive.


### PR DESCRIPTION
## Summary

`torc remote` (`add-workers`, `run`, `status`, `stop`, `collect-logs`, `delete-logs`) assumed a POSIX/bash login shell on every worker. It shelled out commands like `bash -c 'nohup ... & disown'`, `mkdir -p`, `pgrep`, `kill -0`, `grep`, `tail`, `tar`, `rm -rf`, and `/tmp` paths — none of which work on a Windows OpenSSH host, where the default shell is `cmd.exe` or PowerShell. Even the connectivity check ran the POSIX `true` builtin, so **Windows hosts were rejected before any work was attempted**.

This PR adds native Windows worker support.

## What changed

**New `RemoteShell` abstraction** (`src/client/remote/shell.rs`) with `Posix` and `Windows` backends and runtime detection:

- `detect_remote_shell()` probes each host (`uname` → POSIX; otherwise confirm PowerShell → Windows; SSH exit 255 → unreachable). This also **becomes the connectivity check**, so Windows hosts now pass.
- Windows commands are emitted as PowerShell **`-EncodedCommand`** payloads (base64 of UTF-16LE). This sidesteps nested SSH quoting entirely and works whether the host's OpenSSH default shell is `cmd.exe` or PowerShell.
- Per-shell builders cover `mkdir`, detached launch, PID liveness, process lookup, kill, tail, dir checks, `tar`, and removal. Forward-slash paths work on both OSes; only the temp tarball path is OS-specific.

**All command sites** in `commands/remote.rs` now detect the shell once per worker operation and build commands through the abstraction. `stop` takes `force: bool` (graceful SIGTERM on POSIX).

**Build/docs:** added `dep:base64` to the `client` feature; documented Windows support, the detection flow, and the caveat below.

## Caveat

Windows has no SIGTERM equivalent for a detached process, so `torc remote stop` is **always a forced stop on Windows** (graceful checkpoint-on-stop only works on POSIX). Documented in `remote-workers.md`.

## Testing

- **Unit tests** for the `RemoteShell` builders that decode and assert the generated PowerShell.
- **Opt-in loopback integration test** (`tests/test_remote_shell_loopback.rs`, gated by `TORC_TEST_SSH_LOOPBACK=1`) that drives the real per-OS commands against `localhost` over SSH — `detect → mkdir → start → PID liveness → tail → kill → tarball → cleanup` — using a stub process (so no torc server or `torc` on PATH is needed).
- **CI** (`.github/workflows/test.yml`) now sets up key-based SSH to `localhost` on both `ubuntu-latest` and `windows-latest` and runs the loopback test on each. The Windows runner's default shell stays `cmd.exe`, so this covers the `cmd → -EncodedCommand → PowerShell` route.

Local checks pass: `cargo fmt --check`, `cargo clippy --all --all-targets --all-features -D warnings`, `dprint check`.

## Notes for reviewers

- The live loopback path could not be exercised locally (no key-based `ssh localhost` here); it runs in CI. torc already builds on `windows-latest`, so the prerequisite is met.
- The Windows CI setup step's `OpenSSH.Server~~~~0.0.1.0` capability name and the `administrators_authorized_keys` ACL handling are the parts most likely to need a tweak on the first real Windows CI run; the test logic itself is independent of that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)