### PR TITLE
fix(deps): bump bcrypt to 0.19.2 for RUSTSEC-2026-0199

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,9 +322,9 @@ dependencies = [
 
 [[package]]
 name = "bcrypt"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ae5479c93d3720e4c1dbd6b945b97457c50cb672781104768190371df1a905"
+checksum = "7f3c067aa24dd4ed5c79cf222a38f260c8f23d3b82a062fba3f28c6fe563b753"
 dependencies = [
  "base64 0.22.1",
  "blowfish",


### PR DESCRIPTION
## Summary

Bumps `bcrypt` from 0.19.1 to 0.19.2 (lockfile-only) to resolve **RUSTSEC-2026-0199**, which is failing the `cargo-deny` **Security** check on `main` and every open PR.

## The vulnerability

`bcrypt::verify(password, hash)` and `HashParts::from_str(hash)` panic in `str::slice_error_fail` when given a 60-byte `&str` containing a multi-byte UTF-8 character at certain byte positions. The crate is `#![forbid(unsafe_code)]`, so impact is limited to denial-of-service (no memory corruption) whenever an attacker-controlled hash string reaches those functions.

- Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0199
- Fix: https://github.com/Keats/rust-bcrypt/pull/103 (released as bcrypt 0.19.2 on 2026-06-20), which rejects non-ASCII hash bytes up front.

## Change

The manifest already declares `bcrypt = "0.19"`, so this is a `Cargo.lock`-only update:

```
cargo update -p bcrypt --precise 0.19.2
```

This is repo-wide (not tied to any feature branch), so it is raised directly against `main`. Once merged, other open PRs go green on the Security check after a rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)