### PR TITLE
fix(tui): surface the log output directory; one log line per job start/stop

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,5 +22,7 @@ jobs:
       - name: Run cargo deny
         uses: EmbarkStudios/cargo-deny-action@v2
         with:
+          # No --config: the action appends command-arguments after `check`, and
+          # cargo-deny only accepts --config as a global flag. ./deny.toml is the
+          # default config path, so passing it was redundant anyway.
           command: check
-          command-arguments: --config deny.toml

--- a/docs/src/core/monitoring/debugging.md
+++ b/docs/src/core/monitoring/debugging.md
@@ -385,8 +385,8 @@ grep -r "Job completed workflow_id=" torc_output/
 # Find failed jobs
 grep -r "status=failed" torc_output/
 
-# Find all job process completions with return codes
-grep -r "Job process completed" torc_output/ | grep "return_code="
+# Find all job completions with non-zero return codes
+grep -r "Job completed workflow_id=" torc_output/ | grep -v "return_code=0 "
 ```
 
 **Tip**: Redirect grep output to a file for easier analysis of large result sets:

--- a/src/client/async_cli_command.rs
+++ b/src/client/async_cli_command.rs
@@ -384,10 +384,6 @@ impl AsyncCliCommand {
         self.is_running = true;
         self.start_time = Utc::now();
         self.status = JobStatus::Running;
-        debug!(
-            "Job process started workflow_id={} job_id={} pid={}",
-            workflow_id, self.job_id, pid
-        );
 
         // Start resource monitoring if enabled.
         // When running inside a Slurm allocation with srun, the job executes inside
@@ -834,17 +830,6 @@ impl AsyncCliCommand {
             }
         }
 
-        let final_rc = self.return_code.unwrap_or(return_code);
-        let final_status = format!("{:?}", self.status).to_lowercase();
-        info!(
-            "Job process completed workflow_id={} job_id={} run_id={} return_code={} status={} exec_time_s={:.3}",
-            self.workflow_id.unwrap_or(0),
-            self.job_id,
-            self.run_id.unwrap_or(0),
-            final_rc,
-            final_status,
-            self.exec_time_s
-        );
         Ok(())
     }
 
@@ -854,18 +839,12 @@ impl AsyncCliCommand {
         self.job.id.expect("Job ID must be set")
     }
 
-    // Get the process ID of the running job. Can only be called if the job is running.
-    // pub fn get_pid(&self) -> Result<u32, Box<dyn std::error::Error>> {
-    //     if !self.is_running {
-    //         return Err("Job is not running".into());
-    //     }
-
-    //     if let Some(ref child) = self.handle {
-    //         Ok(child.id())
-    //     } else {
-    //         Err("No process handle available".into())
-    //     }
-    // }
+    /// Process ID of the job, once `start()` has spawned it. In Slurm mode this
+    /// is the PID of the `srun` process, not of the job itself, which runs
+    /// under slurmstepd.
+    pub fn pid(&self) -> Option<u32> {
+        self.pid
+    }
 
     // pub fn get_exec_time_minutes(&self) -> f64 {
     //     self.exec_time_s / 60.0

--- a/src/client/commands/recover.rs
+++ b/src/client/commands/recover.rs
@@ -1680,7 +1680,7 @@ fn recover_workflow_interactive(
                 v.job_id,
                 truncate(&v.job_name, 30),
                 v.return_code,
-                &v.configured_memory,
+                v.configured_memory,
                 v.peak_memory_formatted.as_deref().unwrap_or("-"),
                 v.oom_reason.as_deref().unwrap_or("-"),
             );
@@ -1714,7 +1714,7 @@ fn recover_workflow_interactive(
                 v.job_id,
                 truncate(&v.job_name, 30),
                 v.return_code,
-                &v.configured_runtime,
+                v.configured_runtime,
                 v.exec_time_minutes,
                 v.timeout_reason.as_deref().unwrap_or("-"),
             );
@@ -1781,7 +1781,7 @@ fn recover_workflow_interactive(
                 v.job_id,
                 truncate(&v.job_name, 30),
                 v.return_code,
-                &v.configured_memory,
+                v.configured_memory,
             );
         }
         if unknown_jobs.len() > MAX_DISPLAY_ROWS {
@@ -2304,7 +2304,7 @@ fn resolve_existing_scheduler_source(
             let new_name = created.name.unwrap_or_default();
             eprintln!(
                 "  Created scheduler '{}' (ID {}) with walltime {}",
-                &new_name, new_id, &created.walltime
+                new_name, new_id, created.walltime
             );
             Ok((new_id, new_name))
         }
@@ -2352,7 +2352,7 @@ fn prompt_scheduler_choice(
             truncate(s.name.as_deref().unwrap_or("-"), 25),
             truncate(&s.account, 14),
             s.partition.as_deref().unwrap_or("-"),
-            &s.walltime,
+            s.walltime,
             s.nodes,
         );
     }
@@ -2409,7 +2409,7 @@ fn prompt_scheduler_choice(
         // after the user confirms recovery (so declining leaves no orphaned scheduler).
         let walltime_input = prompt_line(&format!(
             "  Walltime [default: {}] (press Enter to keep): ",
-            &scheduler.walltime
+            scheduler.walltime
         ))?;
 
         let source = if walltime_input.is_empty() {

--- a/src/client/commands/slurm.rs
+++ b/src/client/commands/slurm.rs
@@ -198,9 +198,9 @@ fn select_slurm_scheduler_interactively(
                     "{:<5} {:<20} {:<15} {:<8} {:<12}",
                     scheduler.id.unwrap_or(-1),
                     scheduler.name.as_deref().unwrap_or(""),
-                    &scheduler.account,
+                    scheduler.account,
                     scheduler.nodes,
-                    &scheduler.walltime
+                    scheduler.walltime
                 );
             }
 

--- a/src/client/job_runner.rs
+++ b/src/client/job_runner.rs
@@ -1850,6 +1850,16 @@ impl JobRunner {
                             self.compute_node_id,
                             self.resource_monitor.as_ref(),
                         );
+                        info!(
+                            "Job completed workflow_id={} job_id={} run_id={} attempt_id={} return_code={} status={} exec_time_s={:.3}",
+                            self.workflow_id,
+                            job_id,
+                            self.run_id,
+                            attempt_id,
+                            result.return_code,
+                            format!("{:?}", result.status).to_lowercase(),
+                            result.exec_time_minutes * 60.0
+                        );
 
                         // Extract output_file_ids for validation
                         let output_file_ids = async_job.job.output_file_ids.clone();
@@ -2415,12 +2425,8 @@ impl JobRunner {
                 continue;
             }
 
-            let status_str = format!("{:?}", final_result.status).to_lowercase();
-            info!(
-                "Job completed workflow_id={} job_id={} run_id={} status={}",
-                self.workflow_id, job_id, final_result.run_id, status_str
-            );
-
+            // The completion itself is logged in check_job_status(), where the
+            // process exit is detected; this path only reports it to the server.
             if let Some(stats) = slurm_stats {
                 match apis::slurm_stats_api::create_slurm_stats(&self.config, stats) {
                     Ok(_) => {
@@ -2961,12 +2967,15 @@ impl JobRunner {
                     ) {
                         Ok(()) => {
                             info!(
-                                "Job started workflow_id={} job_id={} run_id={} compute_node_id={} attempt_id={}{}",
+                                "Job started workflow_id={} job_id={} run_id={} compute_node_id={} attempt_id={} pid={}{}",
                                 self.workflow_id,
                                 job_id,
                                 self.run_id,
                                 self.compute_node_id,
                                 attempt_id,
+                                async_job
+                                    .pid()
+                                    .map_or("unknown".to_string(), |p| p.to_string()),
                                 target_node.map_or(String::new(), |n| format!(" node={}", n))
                             );
                             if let Some(node) = target_node {
@@ -3125,12 +3134,15 @@ impl JobRunner {
                     ) {
                         Ok(()) => {
                             info!(
-                                "Job started workflow_id={} job_id={} run_id={} compute_node_id={} attempt_id={}",
+                                "Job started workflow_id={} job_id={} run_id={} compute_node_id={} attempt_id={} pid={}",
                                 self.workflow_id,
                                 job_id,
                                 self.run_id,
                                 self.compute_node_id,
-                                attempt_id
+                                attempt_id,
+                                async_job
+                                    .pid()
+                                    .map_or("unknown".to_string(), |p| p.to_string())
                             );
                             self.running_jobs.insert(job_id, async_job);
                         }

--- a/src/client/job_runner.rs
+++ b/src/client/job_runner.rs
@@ -1850,16 +1850,6 @@ impl JobRunner {
                             self.compute_node_id,
                             self.resource_monitor.as_ref(),
                         );
-                        info!(
-                            "Job completed workflow_id={} job_id={} run_id={} attempt_id={} return_code={} status={} exec_time_s={:.3}",
-                            self.workflow_id,
-                            job_id,
-                            self.run_id,
-                            attempt_id,
-                            result.return_code,
-                            format!("{:?}", result.status).to_lowercase(),
-                            result.exec_time_minutes * 60.0
-                        );
 
                         // Extract output_file_ids for validation
                         let output_file_ids = async_job.job.output_file_ids.clone();
@@ -1885,6 +1875,19 @@ impl JobRunner {
                 result.return_code = 1;
                 result.status = JobStatus::Failed;
             }
+            // Log after validation so the line carries the status Torc actually
+            // records, not the raw process exit, and before the batch report so
+            // it is emitted even if the server rejects the completion.
+            info!(
+                "Job completed workflow_id={} job_id={} run_id={} attempt_id={} return_code={} status={} exec_time_s={:.3}",
+                self.workflow_id,
+                job_id,
+                self.run_id,
+                result.attempt_id.unwrap_or(1),
+                result.return_code,
+                format!("{:?}", result.status).to_lowercase(),
+                result.exec_time_minutes * 60.0
+            );
             to_report.push((job_id, result));
         }
         self.handle_completions_batch(to_report)?;

--- a/src/client/workflow_manager.rs
+++ b/src/client/workflow_manager.rs
@@ -1085,7 +1085,7 @@ impl WorkflowManager {
                         // If dry run is true, just log the change
                         info!(
                             "Dry run: Would reset job_id={} name='{}' from status={:?} to Uninitialized due to file change in '{}' file_id={}",
-                            job_id, &job.name, job_status, file.name, file_id
+                            job_id, job.name, job_status, file.name, file_id
                         );
 
                         // TODO
@@ -1110,7 +1110,7 @@ impl WorkflowManager {
 
                             info!(
                                 "Dry run: Would reset downstream job_id={} name='{}' status={:?} to Uninitialized",
-                                downstream_job_id, &downstream_job.name, downstream_job.status
+                                downstream_job_id, downstream_job.name, downstream_job.status
                             );
                         }
                     } else {
@@ -1123,7 +1123,7 @@ impl WorkflowManager {
                             Ok(_) => {
                                 info!(
                                     "Reset job_id={} name='{}' from status={:?} to Uninitialized due to file change in '{}' file_id={}",
-                                    job_id, &job.name, job_status, file.name, file_id
+                                    job_id, job.name, job_status, file.name, file_id
                                 );
                             }
                             Err(err) => {
@@ -1139,7 +1139,7 @@ impl WorkflowManager {
                     // Job is not Completed, Failed, or Canceled, no action needed
                     debug!(
                         "job_id={} name='{}' has status={:?}, no reset needed for file change in '{}' file_id={}",
-                        job_id, &job.name, job_status, file.name, file_id
+                        job_id, job.name, job_status, file.name, file_id
                     );
                 }
             }
@@ -1185,7 +1185,7 @@ impl WorkflowManager {
                     any_missing_files = true;
                     debug!(
                         "Output file {} from job {} (name: '{}') is missing",
-                        file.path, job_id, &job.name
+                        file.path, job_id, job.name
                     );
                     break; // No need to check more files for this job
                 }
@@ -1196,7 +1196,7 @@ impl WorkflowManager {
                 if dry_run {
                     info!(
                         "Dry run: Would reset job {} (name: '{}') from Done to Uninitialized due to missing output files",
-                        job_id, &job.name
+                        job_id, job.name
                     );
 
                     // Find and log direct downstream jobs (jobs that depend on this job)
@@ -1220,7 +1220,7 @@ impl WorkflowManager {
 
                         info!(
                             "Dry run: Would reset downstream job {} (name: '{}' status: {:?}) to Uninitialized",
-                            downstream_job_id, &downstream_job.name, downstream_job.status
+                            downstream_job_id, downstream_job.name, downstream_job.status
                         );
                     }
                 } else {
@@ -1233,7 +1233,7 @@ impl WorkflowManager {
                         Ok(_) => {
                             info!(
                                 "Reset job {} (name: '{}') from Done to Uninitialized due to missing output files",
-                                job_id, &job.name
+                                job_id, job.name
                             );
                         }
                         Err(err) => {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -298,6 +298,11 @@ where
                                         )));
                                     }
                                 }
+                                KeyCode::Char('o') => {
+                                    // Point the TUI at a different output directory and
+                                    // re-open these logs from there.
+                                    app.start_output_dir_input_from_log_viewer();
+                                }
                                 _ => {}
                             }
                         }

--- a/src/tui/README.md
+++ b/src/tui/README.md
@@ -208,6 +208,7 @@ Press `l` to view logs:
 | `n`             | Next search match                |
 | `N`             | Previous search match            |
 | `y`             | Show file path in status bar     |
+| `o`             | Read logs from another directory |
 | `q` / `Esc`     | Close log viewer                 |
 
 ### 7. Job Actions
@@ -474,14 +475,19 @@ torc config show
 
 ### Log File Locations
 
-Job logs are stored in the `output` directory by default:
+Job logs are stored in the `torc_output` directory by default:
 
 ```
-output/
+torc_output/
 └── job_stdio/
     ├── job_{workflow_id}_{job_id}_{run_id}.o  # stdout
     └── job_{workflow_id}_{job_id}_{run_id}.e  # stderr
 ```
+
+Workflows run with `torc run --output-dir <dir>` write elsewhere. The directory the TUI reads logs
+from is shown on the right of the Detail View tab bar; press `o` (from any pane, or from inside the
+log viewer) to point it at another one. Relative paths resolve against the workflow's submission
+directory, so the TUI finds the logs no matter where it is launched from.
 
 ---
 
@@ -499,7 +505,8 @@ Logs may not be available if:
 
 - The job hasn't run yet
 - You're on a different machine than where jobs ran
-- The output directory is in a different location
+- The workflow ran with a different `--output-dir` (press `o` to change the directory the TUI reads
+  from)
 
 ### Job actions not working
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 use std::thread::JoinHandle;
 
@@ -270,6 +270,16 @@ pub enum Focus {
     OutputDirInput,
     RecoverPrompt,
     Popup,
+}
+
+/// Which detail tab opened the log viewer. Recorded so the viewer can be
+/// re-opened against the same job/result/node after the user changes the
+/// output directory from inside the popup.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum LogSource {
+    Job,
+    Result,
+    Slurm,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -790,6 +800,12 @@ pub struct App {
     // Output directory for log files
     pub output_dir: PathBuf,
     pub output_dir_input: String,
+    /// Focus to restore when the output-directory input is applied or canceled.
+    output_dir_return_focus: Focus,
+    /// Tab that opened the currently displayed log viewer.
+    log_view_source: Option<LogSource>,
+    /// Log viewer to re-open once the output-directory input closes.
+    pending_log_view: Option<LogSource>,
 }
 
 impl App {
@@ -917,6 +933,9 @@ impl App {
             basic_auth,
             output_dir,
             output_dir_input: String::new(),
+            output_dir_return_focus: Focus::Workflows,
+            log_view_source: None,
+            pending_log_view: None,
         };
 
         // Update client to use the correct URL
@@ -3077,13 +3096,40 @@ impl App {
     // === Output Directory Input ===
 
     pub fn start_output_dir_input(&mut self) {
+        if self.focus != Focus::OutputDirInput {
+            self.output_dir_return_focus = self.focus;
+        }
         self.focus = Focus::OutputDirInput;
         self.output_dir_input = self.output_dir.display().to_string();
     }
 
+    /// Change the output directory while a log viewer is open. The viewer is
+    /// closed so the input widget is visible, and re-opened against the same
+    /// job/result/node once the input is applied or canceled -- the log viewer
+    /// tells users to press `o` when a file is missing, so the key has to work
+    /// from there.
+    pub fn start_output_dir_input_from_log_viewer(&mut self) {
+        let source = self.log_view_source;
+        self.close_popup();
+        self.start_output_dir_input();
+        self.pending_log_view = source;
+    }
+
     pub fn cancel_output_dir_input(&mut self) {
-        self.focus = Focus::Workflows;
+        self.focus = self.output_dir_return_focus;
         self.output_dir_input.clear();
+        self.reopen_pending_log_view();
+    }
+
+    /// Re-open the log viewer that was closed to make room for the
+    /// output-directory input, now reading from the current `output_dir`.
+    fn reopen_pending_log_view(&mut self) {
+        match self.pending_log_view.take() {
+            Some(LogSource::Job) => self.show_job_logs(),
+            Some(LogSource::Result) => self.show_result_logs(),
+            Some(LogSource::Slurm) => self.show_slurm_logs(),
+            None => {}
+        }
     }
 
     pub fn add_output_dir_char(&mut self, c: char) {
@@ -3109,11 +3155,12 @@ impl App {
         };
 
         self.output_dir = path;
-        self.focus = Focus::Workflows;
+        self.focus = self.output_dir_return_focus;
         self.set_status(StatusMessage::success(&format!(
             "Output directory set to: {}",
             self.output_dir.display()
         )));
+        self.reopen_pending_log_view();
     }
 
     pub fn get_current_user_display(&self) -> String {
@@ -4323,6 +4370,7 @@ impl App {
                 )));
             }
 
+            self.log_view_source = Some(LogSource::Job);
             self.previous_focus = self.focus;
             self.focus = Focus::Popup;
             self.popup = Some(PopupType::LogViewer(viewer));
@@ -4390,6 +4438,7 @@ impl App {
             result.attempt_id.unwrap_or(1),
         );
 
+        self.log_view_source = Some(LogSource::Result);
         self.previous_focus = self.focus;
         self.focus = Focus::Popup;
         self.popup = Some(PopupType::LogViewer(viewer));
@@ -4424,11 +4473,11 @@ impl App {
             viewer.stdout_path = Some(combined_path.clone());
             viewer.stdout_content = content;
         } else {
-            viewer.stdout_path = Some(stdout_path.clone());
-            viewer.stdout_content = format!(
-                "Could not read file: {}\n\nThe file may not exist if:\n- The job has not run yet\n- The output directory is different\n- You are on a different system\n- The job used a stdio mode that doesn't capture stdout",
-                stdout_path
+            viewer.stdout_content = self.missing_log_message(
+                &stdout_path,
+                &["The job used a stdio mode that doesn't capture stdout"],
             );
+            viewer.stdout_path = Some(stdout_path);
         }
 
         // Try separate .e file first, then fall back to combined .log
@@ -4439,12 +4488,16 @@ impl App {
             viewer.stderr_path = Some(combined_path);
             viewer.stderr_content = content;
         } else {
-            viewer.stderr_path = Some(stderr_path.clone());
-            viewer.stderr_content = format!(
-                "Could not read file: {}\n\nThe file may not exist if:\n- The job has not run yet\n- The output directory is different\n- You are on a different system\n- The job used a stdio mode that doesn't capture stderr",
-                stderr_path
+            viewer.stderr_content = self.missing_log_message(
+                &stderr_path,
+                &["The job used a stdio mode that doesn't capture stderr"],
             );
+            viewer.stderr_path = Some(stderr_path);
         }
+    }
+
+    fn missing_log_message(&self, path: &str, extra_reasons: &[&str]) -> String {
+        missing_log_message(path, &self.resolve_log_output_dir(), extra_reasons)
     }
 
     // === Slurm Log Viewer ===
@@ -4479,6 +4532,7 @@ impl App {
                 )));
             }
 
+            self.log_view_source = Some(LogSource::Slurm);
             self.previous_focus = self.focus;
             self.focus = Focus::Popup;
             self.popup = Some(PopupType::LogViewer(viewer));
@@ -4502,20 +4556,14 @@ impl App {
         if let Ok(content) = std::fs::read_to_string(&stdout_path) {
             viewer.stdout_content = content;
         } else {
-            viewer.stdout_content = format!(
-                "Could not read file: {}\n\nThe file may not exist if:\n- The Slurm job has not run yet\n- The output directory is different\n- You are on a different system",
-                stdout_path
-            );
+            viewer.stdout_content = self.missing_log_message(&stdout_path, &[]);
         }
 
         // Try to read stderr
         if let Ok(content) = std::fs::read_to_string(&stderr_path) {
             viewer.stderr_content = content;
         } else {
-            viewer.stderr_content = format!(
-                "Could not read file: {}\n\nThe file may not exist if:\n- The Slurm job has not run yet\n- The output directory is different\n- You are on a different system",
-                stderr_path
-            );
+            viewer.stderr_content = self.missing_log_message(&stderr_path, &[]);
         }
 
         Ok(())
@@ -5132,4 +5180,54 @@ pub fn filter_workflow_list(
         })
         .cloned()
         .collect()
+}
+
+/// Placeholder shown in the log viewer when a log file cannot be read.
+///
+/// Names the output directory the path was built from and the key that changes
+/// it. A workflow run with a non-default `--output-dir` is the most common
+/// reason the file is missing, and the directory is otherwise invisible from
+/// inside the popup.
+fn missing_log_message(path: &str, output_dir: &Path, extra_reasons: &[&str]) -> String {
+    let mut message = format!(
+        "Could not read file: {}\n\n\
+         Reading logs from output directory: {}\n\
+         Press 'o' to read them from a different directory.\n\n\
+         The file may not exist if:\n\
+         - The job has not run yet\n\
+         - The workflow ran with a different --output-dir\n\
+         - You are on a different system",
+        path,
+        output_dir.display()
+    );
+    for reason in extra_reasons {
+        message.push_str("\n- ");
+        message.push_str(reason);
+    }
+    message
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_missing_log_message_names_output_dir_and_shortcut() {
+        let message = missing_log_message(
+            "runs/job_stdio/job_wf1_j2_r1_a1.o",
+            Path::new("/scratch/runs"),
+            &["The job used a stdio mode that doesn't capture stdout"],
+        );
+        assert!(message.contains("Could not read file: runs/job_stdio/job_wf1_j2_r1_a1.o"));
+        assert!(message.contains("Reading logs from output directory: /scratch/runs"));
+        assert!(message.contains("Press 'o'"));
+        assert!(message.contains("- The job used a stdio mode that doesn't capture stdout"));
+    }
+
+    #[test]
+    fn test_missing_log_message_without_extra_reasons() {
+        let message = missing_log_message("out/slurm.o", Path::new("out"), &[]);
+        assert!(message.contains("Reading logs from output directory: out"));
+        assert!(message.ends_with("- You are on a different system"));
+    }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -5222,6 +5222,9 @@ mod tests {
         assert!(message.contains("Reading logs from output directory: /scratch/runs"));
         assert!(message.contains("Press 'o'"));
         assert!(message.contains("- The job used a stdio mode that doesn't capture stdout"));
+        // The `\` line continuations must not leak source indentation into the
+        // popup: every line has to start hard against the left margin.
+        assert!(message.lines().all(|line| !line.starts_with(' ')));
     }
 
     #[test]

--- a/src/tui/components.rs
+++ b/src/tui/components.rs
@@ -650,7 +650,10 @@ impl HelpPopup {
 
         lines.extend(Self::section("Connection"));
         lines.push(Self::key_line("u", "Change server URL"));
-        lines.push(Self::key_line("o", "Change output directory"));
+        lines.push(Self::key_line(
+            "o",
+            "Change output directory (where job/Slurm logs are read from)",
+        ));
         lines.push(Self::key_line("w", "Change user filter"));
         lines.push(Self::key_line("a", "Toggle show all users"));
 
@@ -1256,7 +1259,9 @@ impl LogViewer {
             Span::styled("g/G", Style::default().fg(Color::Yellow)),
             Span::raw(": top/bottom | "),
             Span::styled("y", Style::default().fg(Color::Yellow)),
-            Span::raw(": copy path"),
+            Span::raw(": copy path | "),
+            Span::styled("o", Style::default().fg(Color::Yellow)),
+            Span::raw(": output dir"),
         ]);
 
         let status_para = Paragraph::new(vec![status_line, help_line]);

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -532,11 +532,27 @@ fn draw_tabs(f: &mut Frame, area: Rect, app: &App) {
         .position(|t| *t == app.detail_view)
         .unwrap_or(0);
 
+    // Surface the directory the Jobs/Results/Scheduled Nodes log viewers read
+    // from. It is a per-workflow choice (`torc run --output-dir`), so it has to
+    // be visible rather than buried in the help popup.
+    let output_dir = Line::from(vec![
+        Span::styled(" logs: ", Style::default().fg(Color::White)),
+        Span::styled(
+            app.output_dir.display().to_string(),
+            Style::default().fg(Color::Cyan),
+        ),
+        Span::styled(" ", Style::default()),
+        Span::styled("o", Style::default().fg(Color::Yellow)),
+        Span::styled(": change ", Style::default().fg(Color::DarkGray)),
+    ])
+    .right_aligned();
+
     let tabs = Tabs::new(titles)
         .block(
             Block::default()
                 .borders(Borders::ALL)
                 .title("◈ Detail View")
+                .title_top(output_dir)
                 .border_style(Style::default().fg(Color::DarkGray)),
         )
         .select(selected)

--- a/tests/test_jobs.rs
+++ b/tests/test_jobs.rs
@@ -573,7 +573,7 @@ fn test_jobs_complete_with_different_statuses(start_server: &ServerProcess) {
     ];
     for status in &statuses {
         let status_str = status.to_string();
-        let job = create_test_job(config, workflow_id, &format!("job_{}", &status_str));
+        let job = create_test_job(config, workflow_id, &format!("job_{}", status_str));
         let job_id = job.id.unwrap();
 
         // Create a ResultModel for the completion


### PR DESCRIPTION
## Log output directory in the TUI

The TUI could already read logs from a directory other than `torc_output` (the `o` key, feeding `resolve_log_output_dir()` for the Jobs, Results and Scheduled Nodes viewers), but nothing on screen said so: the current directory was only visible in the help popup, and `o` did nothing while a log viewer was open — exactly when a user discovers the directory is wrong.

- The directory logs are read from is now shown on the right of the Detail View tab bar, with the `o` hint: `logs: torc_output  o: change`.
- The log viewer's "could not read file" placeholder names the directory it searched and tells you to press `o`, and lists "the workflow ran with a different `--output-dir`" as a likely cause instead of the vague "the output directory is different".
- `o` works from inside the log viewer. The viewer re-opens against the same job/result/node once the directory is applied or canceled, so the key the message advertises works where you read it.
- The output-directory input returns you to the pane you opened it from, rather than always jumping back to the Workflows pane.

## One log line per job start/stop

Job start and completion were each logged twice, once from `AsyncCliCommand` and once from `JobRunner`. Consolidated on `JobRunner`, which is the side that has the compute node, attempt and target node, with the PID added:

```
INFO torc::client::job_runner] Job started   workflow_id=3 job_id=3 run_id=1 compute_node_id=3 attempt_id=1 pid=16769
INFO torc::client::job_runner] Job completed workflow_id=3 job_id=3 run_id=1 attempt_id=1 return_code=0 status=completed exec_time_s=0.005
```

`AsyncCliCommand` now exposes `pid()` (replacing a commented-out `get_pid`) and no longer logs starts or completions.

Note: "Job completed" now logs in `check_job_status()`, where the process exit is detected, rather than after the completion batch is accepted by the server. The old site is skipped when the server rejects a completion, which meant a job that ran and exited could produce no completion line at all. Timestamps are unchanged, since this is when the old `AsyncCliCommand` line fired.

`docs/src/core/monitoring/debugging.md` told users to `grep -r "Job process completed"`; that string no longer exists, so it now greps the surviving message for non-zero return codes.

## Verification

Driven against a real server, with a workflow run into a non-default output dir (`torc run -o my_run_logs`) and the actual TUI driven in a pty:

- Jobs and Results tabs: `l` shows the missing-file message naming `…/torc_output`; `o` → type `my_run_logs` → Enter re-opens the viewer with the job's real output, and the tab bar updates to `logs: my_run_logs`.
- Logged `pid=` matches the job shell's own `$$`; a failing job logs `return_code=7 status=failed`. Exactly one start and one completion line per job.
- `cargo fmt`, `cargo clippy --all --all-targets --all-features -- -D warnings`, `dprint check`, 429 lib tests, and 75 tests across `test_async_cli_command`, `test_direct_mode_e2e` and `test_full_workflows` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)