### PR TITLE
docs: adopt native parameter sequences in examples and docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,7 +272,9 @@ a single specification:
 - **Parameter Formats**:
   - Integer ranges: `"1:100"` (inclusive) or `"0:100:10"` (with step)
   - Float ranges: `"0.0:1.0:0.1"`
-  - Lists: `"[1,5,10]"` or `"['train','test','validation']"`
+  - Lists: native YAML/JSON sequences, e.g. `[1, 5, 10]` or `[train, test, validation]`. The legacy
+    string-encoded form (`"[1,5,10]"`, `"['train','test']"`) is still accepted and remains required
+    in KDL specs, where parameter values must be strings.
 - **Multi-dimensional**: Multiple parameters create Cartesian product (e.g., 3 learning rates × 3
   batch sizes = 9 jobs)
 - **Table-based (`parameters_file`)**: Point a job/file/user_data at a CSV, JSON (array of objects),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,9 +272,9 @@ a single specification:
 - **Parameter Formats**:
   - Integer ranges: `"1:100"` (inclusive) or `"0:100:10"` (with step)
   - Float ranges: `"0.0:1.0:0.1"`
-  - Lists: native YAML/JSON sequences, e.g. `[1, 5, 10]` or `[train, test, validation]`. The legacy
-    string-encoded form (`"[1,5,10]"`, `"['train','test']"`) is still accepted and remains required
-    in KDL specs, where parameter values must be strings.
+  - Lists: native YAML/JSON sequences, e.g. `[1, 5, 10]` or `[train, test, validation]` (in JSON,
+    quote the strings). The legacy string-encoded form (`"[1,5,10]"`, `"['train','test']"`) is still
+    accepted and remains required in KDL specs, where parameter values must be strings.
 - **Multi-dimensional**: Multiple parameters create Cartesian product (e.g., 3 learning rates × 3
   batch sizes = 9 jobs)
 - **Table-based (`parameters_file`)**: Point a job/file/user_data at a CSV, JSON (array of objects),

--- a/docs/src/core/concepts/workflow-definition.md
+++ b/docs/src/core/concepts/workflow-definition.md
@@ -50,8 +50,11 @@ This expands to 10 jobs: `task_1`, `task_2`, ..., `task_10`.
 | --------------- | ---------------- | ------------------------- |
 | Range           | `"1:5"`          | 1, 2, 3, 4, 5             |
 | Range with step | `"0:10:2"`       | 0, 2, 4, 6, 8, 10         |
-| List            | `"[a,b,c]"`      | a, b, c                   |
+| List            | `[a, b, c]`      | a, b, c                   |
 | Float range     | `"0.0:1.0:0.25"` | 0.0, 0.25, 0.5, 0.75, 1.0 |
+
+Lists are native YAML/JSON sequences; the legacy string form (`"[a,b,c]"`) is still accepted and is
+required in KDL specs.
 
 ### Format Specifiers
 
@@ -64,7 +67,7 @@ Control how values appear in names:
 
 - name: lr_{lr:.4f}      # lr_0.0010, lr_0.0100, ...
   parameters:
-    lr: "[0.001,0.01,0.1]"
+    lr: [0.001, 0.01, 0.1]
 ```
 
 ## Resource Requirements

--- a/docs/src/core/concepts/workflow-definition.md
+++ b/docs/src/core/concepts/workflow-definition.md
@@ -53,8 +53,8 @@ This expands to 10 jobs: `task_1`, `task_2`, ..., `task_10`.
 | List            | `[a, b, c]`      | a, b, c                   |
 | Float range     | `"0.0:1.0:0.25"` | 0.0, 0.25, 0.5, 0.75, 1.0 |
 
-Lists are native YAML/JSON sequences; the legacy string form (`"[a,b,c]"`) is still accepted and is
-required in KDL specs.
+Lists are native YAML/JSON sequences (in JSON, quote the strings); the legacy string form
+(`"[a,b,c]"`) is still accepted and is required in KDL specs.
 
 ### Format Specifiers
 

--- a/docs/src/core/how-to/parameterize-with-files.md
+++ b/docs/src/core/how-to/parameterize-with-files.md
@@ -13,7 +13,7 @@ jobs:
   - name: process_{dataset}
     command: python process.py --input data/{dataset}.csv --output results/{dataset}.json
     parameters:
-      dataset: "[train, test, validation]"
+      dataset: [train, test, validation]
 ```
 
 This creates 3 jobs:
@@ -39,14 +39,14 @@ jobs:
   - name: process_{dataset}
     command: python process.py -i ${files.input.raw_{dataset}} -o ${files.output.processed_{dataset}}
     parameters:
-      dataset: "[train, test, validation]"
+      dataset: [train, test, validation]
 
   - name: aggregate
     command: python aggregate.py --input results/ --output summary.json
     depends_on:
       - process_{dataset}
     parameters:
-      dataset: "[train, test, validation]"
+      dataset: [train, test, validation]
 ```
 
 The `aggregate` job automatically waits for all `process_*` jobs to complete.
@@ -74,7 +74,7 @@ jobs:
   - name: analyze_{region}_{year}
     command: python analyze.py --region {region} --year {year} --output results/{region}_{year}.json
     parameters:
-      region: "[north, south, east, west]"
+      region: [north, south, east, west]
       year: "2020:2024"
 ```
 

--- a/docs/src/core/reference/parameterization.md
+++ b/docs/src/core/reference/parameterization.md
@@ -25,23 +25,27 @@ parameters:
 
 ```yaml
 parameters:
-  batch_size: "[16,32,64,128]"
+  batch_size: [16, 32, 64, 128]
 ```
 
 ### Lists (Float)
 
 ```yaml
 parameters:
-  threshold: "[0.1,0.5,0.9]"
+  threshold: [0.1, 0.5, 0.9]
 ```
 
 ### Lists (String)
 
 ```yaml
 parameters:
-  optimizer: "['adam','sgd','rmsprop']"
-  dataset: "['train','test','validation']"
+  optimizer: [adam, sgd, rmsprop]
+  dataset: [train, test, validation]
 ```
+
+Lists are written as native YAML/JSON sequences. The legacy string-encoded form (e.g. `"[16,32,64]"`
+or `"['adam','sgd']"`) is still accepted in YAML/JSON/JSON5 specs, and remains the required form in
+KDL specs, where parameter values must be strings.
 
 ## Template Substitution
 
@@ -89,7 +93,7 @@ jobs:
   - name: train_lr{lr:.4f}
     command: python train.py --lr={lr}
     parameters:
-      lr: "[0.0001,0.001,0.01]"
+      lr: [0.0001, 0.001, 0.01]
 ```
 
 Expands to: `train_lr0.0001`, `train_lr0.0010`, `train_lr0.0100`
@@ -120,8 +124,8 @@ jobs:
         --learning-rate={lr} \
         --batch-size={batch_size}
     parameters:
-      lr: "[0.0001,0.001,0.01]"
-      batch_size: "[16,32,64]"
+      lr: [0.0001, 0.001, 0.01]
+      batch_size: [16, 32, 64]
 ```
 
 This expands to 3 × 3 = **9 jobs**:
@@ -139,7 +143,7 @@ jobs:
   - name: process_{dataset}_rep{rep:02d}
     command: python process.py --data={dataset} --replicate={rep}
     parameters:
-      dataset: "['train','validation','test']"
+      dataset: [train, validation, test]
       rep: "1:5"
 ```
 
@@ -157,7 +161,7 @@ jobs:
     output_files:
       - data_{config}
     parameters:
-      config: "['A','B','C']"
+      config: [A, B, C]
 
   # Process each generated dataset
   - name: process_{config}
@@ -167,7 +171,7 @@ jobs:
     depends_on:
       - generate_{config}
     parameters:
-      config: "['A','B','C']"
+      config: [A, B, C]
 ```
 
 This creates 6 jobs with proper dependencies:
@@ -198,7 +202,7 @@ user_data:
       learning_rate: 0.001
       output_dir: /results/{experiment}
     parameters:
-      experiment: "['baseline','ablation','full']"
+      experiment: [baseline, ablation, full]
 ```
 
 Parameter tokens (`{name}` / `{name:fmt}`) are substituted into the user_data `name` and into every
@@ -331,9 +335,9 @@ Define parameters once at the workflow level and reuse them across multiple jobs
 ```yaml
 name: hyperparameter_sweep
 parameters:
-  lr: "[0.0001,0.001,0.01]"
-  batch_size: "[16,32,64]"
-  optimizer: "['adam','sgd']"
+  lr: [0.0001, 0.001, 0.01]
+  batch_size: [16, 32, 64]
+  optimizer: [adam, sgd]
 
 jobs:
   # Training jobs - inherit parameters via use_parameters
@@ -376,9 +380,9 @@ Jobs don't have to use all workflow parameters:
 
 ```yaml
 parameters:
-  lr: "[0.0001,0.001,0.01]"
-  batch_size: "[16,32,64]"
-  dataset: "['train','validation']"
+  lr: [0.0001, 0.001, 0.01]
+  batch_size: [16, 32, 64]
+  dataset: [train, validation]
 
 jobs:
   # Only uses lr and batch_size (9 jobs)
@@ -401,7 +405,7 @@ Jobs can define local parameters that take precedence over workflow-level parame
 
 ```yaml
 parameters:
-  lr: "[0.0001,0.001,0.01]"
+  lr: [0.0001, 0.001, 0.01]
 
 jobs:
   # Uses workflow parameter (3 jobs)
@@ -414,10 +418,12 @@ jobs:
   - name: special_lr{lr:.4f}
     command: python special.py --lr={lr}
     parameters:
-      lr: "[0.01,0.1]"  # Local override - ignores workflow's lr
+      lr: [0.01, 0.1] # Local override - ignores workflow's lr
 ```
 
 ### KDL Syntax
+
+KDL parameter values must be strings, so lists use the string-encoded form:
 
 ```kdl
 parameters {
@@ -436,8 +442,8 @@ job "train_lr{lr:.4f}_bs{batch_size}" {
 ```json5
 {
   parameters: {
-    lr: "[0.0001,0.001,0.01]",
-    batch_size: "[16,32,64]"
+    lr: [0.0001, 0.001, 0.01],
+    batch_size: [16, 32, 64]
   },
   jobs: [
     {
@@ -463,8 +469,8 @@ jobs:
   - name: job_{a}_{b}
     command: echo {a} {b}
     parameters:
-      a: "[1, 2, 3]"
-      b: "['x', 'y', 'z']"
+      a: [1, 2, 3]
+      b: [x, y, z]
     # parameter_mode: product  # This is the default
 ```
 
@@ -480,8 +486,8 @@ jobs:
   - name: train_{dataset}_{model}
     command: python train.py --dataset={dataset} --model={model}
     parameters:
-      dataset: "['cifar10', 'mnist', 'imagenet']"
-      model: "['resnet', 'cnn', 'transformer']"
+      dataset: [cifar10, mnist, imagenet]
+      model: [resnet, cnn, transformer]
     parameter_mode: zip
 ```
 
@@ -507,6 +513,8 @@ Parameter 'dataset' has 3 values, but 'model' has 2 values.
 
 ### KDL Syntax
 
+KDL parameter values must be strings, so lists use the string-encoded form:
+
 ```kdl
 job "train_{dataset}_{model}" {
     command "python train.py --dataset={dataset} --model={model}"
@@ -525,8 +533,8 @@ job "train_{dataset}_{model}" {
   name: "train_{dataset}_{model}",
   command: "python train.py --dataset={dataset} --model={model}",
   parameters: {
-    dataset: "['cifar10', 'mnist', 'imagenet']",
-    model: "['resnet', 'cnn', 'transformer']"
+    dataset: ["cifar10", "mnist", "imagenet"],
+    model: ["resnet", "cnn", "transformer"]
   },
   parameter_mode: "zip"
 }

--- a/docs/src/core/reference/workflow-spec.md
+++ b/docs/src/core/reference/workflow-spec.md
@@ -590,14 +590,18 @@ jobs:
 
 Parameters support several formats for generating multiple jobs or files:
 
-| Format                  | Example                      | Description                   |
-| ----------------------- | ---------------------------- | ----------------------------- |
-| Integer range           | `"1:100"`                    | Inclusive range from 1 to 100 |
-| Integer range with step | `"0:100:10"`                 | Range with step size          |
-| Float range             | `"0.0:1.0:0.1"`              | Float range with step         |
-| Integer list            | `"[1,5,10,100]"`             | Explicit list of integers     |
-| Float list              | `"[0.1,0.5,0.9]"`            | Explicit list of floats       |
-| String list             | `"['adam','sgd','rmsprop']"` | Explicit list of strings      |
+| Format                  | Example                | Description                   |
+| ----------------------- | ---------------------- | ----------------------------- |
+| Integer range           | `"1:100"`              | Inclusive range from 1 to 100 |
+| Integer range with step | `"0:100:10"`           | Range with step size          |
+| Float range             | `"0.0:1.0:0.1"`        | Float range with step         |
+| Integer list            | `[1, 5, 10, 100]`      | Explicit list of integers     |
+| Float list              | `[0.1, 0.5, 0.9]`      | Explicit list of floats       |
+| String list             | `[adam, sgd, rmsprop]` | Explicit list of strings      |
+
+Lists are native YAML/JSON sequences. The legacy string-encoded form (e.g. `"[1,5,10]"` or
+`"['adam','sgd']"`) is still accepted, and is required in KDL specs, where parameter values must be
+strings.
 
 **Template substitution in strings:**
 

--- a/docs/src/core/reference/workflow-spec.md
+++ b/docs/src/core/reference/workflow-spec.md
@@ -599,9 +599,9 @@ Parameters support several formats for generating multiple jobs or files:
 | Float list              | `[0.1, 0.5, 0.9]`      | Explicit list of floats       |
 | String list             | `[adam, sgd, rmsprop]` | Explicit list of strings      |
 
-Lists are native YAML/JSON sequences. The legacy string-encoded form (e.g. `"[1,5,10]"` or
-`"['adam','sgd']"`) is still accepted, and is required in KDL specs, where parameter values must be
-strings.
+Lists are native YAML/JSON sequences (in JSON, quote the strings). The legacy string-encoded form
+(e.g. `"[1,5,10]"` or `"['adam','sgd']"`) is still accepted, and is required in KDL specs, where
+parameter values must be strings.
 
 **Template substitution in strings:**
 

--- a/docs/src/core/tutorials/advanced-params.md
+++ b/docs/src/core/tutorials/advanced-params.md
@@ -25,8 +25,8 @@ values:
 
 ```yaml
 parameters:
-  lr: "[0.001,0.01]"   # 2 values
-  bs: "[16,32]"        # 2 values
+  lr: [0.001, 0.01] # 2 values
+  bs: [16, 32]      # 2 values
 ```
 
 This generates 2 × 2 = **4 jobs**:
@@ -40,9 +40,9 @@ With three parameters:
 
 ```yaml
 parameters:
-  lr: "[0.0001,0.001,0.01]"  # 3 values
-  bs: "[16,32,64]"            # 3 values
-  opt: "['adam','sgd']"       # 2 values
+  lr: [0.0001, 0.001, 0.01] # 3 values
+  bs: [16, 32, 64]          # 3 values
+  opt: [adam, sgd]          # 2 values
 ```
 
 This generates 3 × 3 × 2 = **18 jobs**.
@@ -80,9 +80,9 @@ jobs:
       - model_lr{lr:.4f}_bs{bs}_opt{opt}
       - metrics_lr{lr:.4f}_bs{bs}_opt{opt}
     parameters:
-      lr: "[0.0001,0.001,0.01]"
-      bs: "[16,32,64]"
-      opt: "['adam','sgd']"
+      lr: [0.0001, 0.001, 0.01]
+      bs: [16, 32, 64]
+      opt: [adam, sgd]
 
   # Aggregate results (depends on ALL training jobs via file dependencies)
   - name: aggregate_results
@@ -94,9 +94,9 @@ jobs:
     input_files:
       - metrics_lr{lr:.4f}_bs{bs}_opt{opt}
     parameters:
-      lr: "[0.0001,0.001,0.01]"
-      bs: "[16,32,64]"
-      opt: "['adam','sgd']"
+      lr: [0.0001, 0.001, 0.01]
+      bs: [16, 32, 64]
+      opt: [adam, sgd]
 
   # Find best model (explicit dependency, no parameters)
   - name: select_best_model
@@ -115,16 +115,16 @@ files:
   - name: model_lr{lr:.4f}_bs{bs}_opt{opt}
     path: /models/model_lr{lr:.4f}_bs{bs}_opt{opt}.pt
     parameters:
-      lr: "[0.0001,0.001,0.01]"
-      bs: "[16,32,64]"
-      opt: "['adam','sgd']"
+      lr: [0.0001, 0.001, 0.01]
+      bs: [16, 32, 64]
+      opt: [adam, sgd]
 
   - name: metrics_lr{lr:.4f}_bs{bs}_opt{opt}
     path: /results/metrics_lr{lr:.4f}_bs{bs}_opt{opt}.json
     parameters:
-      lr: "[0.0001,0.001,0.01]"
-      bs: "[16,32,64]"
-      opt: "['adam','sgd']"
+      lr: [0.0001, 0.001, 0.01]
+      bs: [16, 32, 64]
+      opt: [adam, sgd]
 
 resource_requirements:
   - name: data_prep

--- a/docs/src/core/tutorials/simple-params.md
+++ b/docs/src/core/tutorials/simple-params.md
@@ -132,7 +132,7 @@ all 5 process jobs.
 
 **Parameter Values:**
 
-- `"[0.0001,0.0005,0.001,0.005,0.01]"` - A list of 5 specific values
+- `[0.0001, 0.0005, 0.001, 0.005, 0.01]` - A list of 5 specific values
 
 **File Parameterization:** Notice that both jobs AND files have `parameters:`. When Torc expands:
 
@@ -222,13 +222,16 @@ their specific training job completes.
 
 ### List Format
 
-Explicit list of values:
+Explicit list of values, written as a native YAML sequence:
 
 ```yaml
 parameters:
-  lr: "[0.0001,0.0005,0.001,0.005,0.01]"  # Numbers
-  opt: "['adam','sgd','rmsprop']"          # Strings (note the quotes)
+  lr: [0.0001, 0.0005, 0.001, 0.005, 0.01] # Numbers
+  opt: [adam, sgd, rmsprop]                # Strings
 ```
+
+The legacy string-encoded form (`"[0.0001,0.001]"`, `"['adam','sgd']"`) is still accepted, and is
+required in KDL specs, where parameter values must be strings.
 
 ### Range Format
 
@@ -294,15 +297,15 @@ jobs:
   - name: train_{dataset}_{model}
     command: python train.py --dataset={dataset} --model={model}
     parameters:
-      dataset: "['cifar10', 'mnist', 'imagenet']"
-      model: "['resnet', 'vgg', 'transformer']"
+      dataset: [cifar10, mnist, imagenet]
+      model: [resnet, vgg, transformer]
 
   # Zip mode: 3 paired jobs (cifar10+resnet, mnist+vgg, imagenet+transformer)
   - name: paired_{dataset}_{model}
     command: python train.py --dataset={dataset} --model={model}
     parameters:
-      dataset: "['cifar10', 'mnist', 'imagenet']"
-      model: "['resnet', 'vgg', 'transformer']"
+      dataset: [cifar10, mnist, imagenet]
+      model: [resnet, vgg, transformer]
     parameter_mode: zip
 ```
 
@@ -316,7 +319,7 @@ See [Parameterization Reference](../reference/parameterization.md#parameter-mode
 In this tutorial, you learned:
 
 - ✅ How to use `parameters:` to expand one job definition into many
-- ✅ List format (`"[a,b,c]"`) and range format (`"1:100"`)
+- ✅ List format (`[a, b, c]`) and range format (`"1:100"`)
 - ✅ Format specifiers (`{i:03d}`, `{lr:.4f}`) for consistent naming
 - ✅ How parameterized files create one-to-one dependencies
 - ✅ The efficiency of parameter-matched dependencies (each chain runs independently)

--- a/examples/json/data_pipeline_parameterized.json5
+++ b/examples/json/data_pipeline_parameterized.json5
@@ -14,7 +14,7 @@
         "raw_{dataset}"
       ],
       "parameters": {
-        "dataset": "['sales','inventory','customers','products']"
+        "dataset": ["sales", "inventory", "customers", "products"]
       }
     },
     {
@@ -31,7 +31,7 @@
         "clean_{dataset}"
       ],
       "parameters": {
-        "dataset": "['sales','inventory','customers','products']"
+        "dataset": ["sales", "inventory", "customers", "products"]
       }
     },
     {
@@ -48,8 +48,8 @@
         "results_{dataset}_{analysis_type}"
       ],
       "parameters": {
-        "dataset": "['sales','inventory','customers','products']",
-        "analysis_type": "['summary','trends','anomalies']"
+        "dataset": ["sales", "inventory", "customers", "products"],
+        "analysis_type": ["summary", "trends", "anomalies"]
       }
     },
     // Generate one report per (dataset, analysis_type) combination. Both
@@ -68,8 +68,8 @@
         "results_{dataset}_{analysis_type}"
       ],
       "parameters": {
-        "dataset": "['sales','inventory','customers','products']",
-        "analysis_type": "['summary','trends','anomalies']"
+        "dataset": ["sales", "inventory", "customers", "products"],
+        "analysis_type": ["summary", "trends", "anomalies"]
       }
     },
     // Create executive summary per dataset. `{dataset}` appears in the name
@@ -85,7 +85,7 @@
         "report_{dataset}_anomalies"
       ],
       "parameters": {
-        "dataset": "['sales','inventory','customers','products']"
+        "dataset": ["sales", "inventory", "customers", "products"]
       }
     }
   ],
@@ -96,22 +96,22 @@
       "name": "raw_{dataset}",
       "path": "/data/raw/{dataset}.csv",
       "parameters": {
-        "dataset": "['sales','inventory','customers','products']"
+        "dataset": ["sales", "inventory", "customers", "products"]
       }
     },
     {
       "name": "clean_{dataset}",
       "path": "/data/clean/{dataset}.csv",
       "parameters": {
-        "dataset": "['sales','inventory','customers','products']"
+        "dataset": ["sales", "inventory", "customers", "products"]
       }
     },
     {
       "name": "results_{dataset}_{analysis_type}",
       "path": "/results/{dataset}_{analysis_type}_results.json",
       "parameters": {
-        "dataset": "['sales','inventory','customers','products']",
-        "analysis_type": "['summary','trends','anomalies']"
+        "dataset": ["sales", "inventory", "customers", "products"],
+        "analysis_type": ["summary", "trends", "anomalies"]
       }
     }
   ],

--- a/examples/json/hyperparameter_sweep.json5
+++ b/examples/json/hyperparameter_sweep.json5
@@ -39,9 +39,9 @@
         "metrics_lr{lr:.4f}_bs{batch_size}_opt{optimizer}"
       ],
       "parameters": {
-        "lr": "[0.0001,0.001,0.01]",
-        "batch_size": "[16,32,64]",
-        "optimizer": "['adam','sgd']"
+        "lr": [0.0001, 0.001, 0.01],
+        "batch_size": [16, 32, 64],
+        "optimizer": ["adam", "sgd"]
       }
     },
     // One aggregate job per (lr, batch_size, optimizer) combination.
@@ -58,9 +58,9 @@
         "metrics_lr{lr:.4f}_bs{batch_size}_opt{optimizer}"
       ],
       "parameters": {
-        "lr": "[0.0001,0.001,0.01]",
-        "batch_size": "[16,32,64]",
-        "optimizer": "['adam','sgd']"
+        "lr": [0.0001, 0.001, 0.01],
+        "batch_size": [16, 32, 64],
+        "optimizer": ["adam", "sgd"]
       }
     }
   ],
@@ -79,18 +79,18 @@
       "name": "model_lr{lr:.4f}_bs{batch_size}_opt{optimizer}",
       "path": "/models/model_lr{lr:.4f}_bs{batch_size}_opt{optimizer}.pt",
       "parameters": {
-        "lr": "[0.0001,0.001,0.01]",
-        "batch_size": "[16,32,64]",
-        "optimizer": "['adam','sgd']"
+        "lr": [0.0001, 0.001, 0.01],
+        "batch_size": [16, 32, 64],
+        "optimizer": ["adam", "sgd"]
       }
     },
     {
       "name": "metrics_lr{lr:.4f}_bs{batch_size}_opt{optimizer}",
       "path": "/results/metrics_lr{lr:.4f}_bs{batch_size}_opt{optimizer}.json",
       "parameters": {
-        "lr": "[0.0001,0.001,0.01]",
-        "batch_size": "[16,32,64]",
-        "optimizer": "['adam','sgd']"
+        "lr": [0.0001, 0.001, 0.01],
+        "batch_size": [16, 32, 64],
+        "optimizer": ["adam", "sgd"]
       }
     }
   ],

--- a/examples/json/hyperparameter_sweep_shared_params.json5
+++ b/examples/json/hyperparameter_sweep_shared_params.json5
@@ -9,9 +9,9 @@
 
   // Workflow-level shared parameters - defined once, used by multiple jobs and files
   parameters: {
-    lr: "[0.0001,0.001,0.01]",
-    batch_size: "[16,32,64]",
-    optimizer: "['adam','sgd']"
+    lr: [0.0001, 0.001, 0.01],
+    batch_size: [16, 32, 64],
+    optimizer: ["adam", "sgd"]
   },
 
   jobs: [

--- a/examples/json/workflow_actions_data_pipeline.json5
+++ b/examples/json/workflow_actions_data_pipeline.json5
@@ -11,7 +11,7 @@
       "command": "wget https://data.example.com/{dataset}.tar.gz -O raw/{dataset}.tar.gz && tar -xzf raw/{dataset}.tar.gz -C raw/",
       "resource_requirements": "download",
       "parameters": {
-        "dataset": "['users', 'transactions', 'products', 'reviews']"
+        "dataset": ["users", "transactions", "products", "reviews"]
       }
     },
     {
@@ -22,7 +22,7 @@
         "download_dataset_{dataset}"
       ],
       "parameters": {
-        "dataset": "['users', 'transactions', 'products', 'reviews']"
+        "dataset": ["users", "transactions", "products", "reviews"]
       }
     },
     {
@@ -33,7 +33,7 @@
         "validate_{dataset}"
       ],
       "parameters": {
-        "dataset": "['users', 'transactions', 'products', 'reviews']"
+        "dataset": ["users", "transactions", "products", "reviews"]
       }
     },
     {

--- a/examples/json/workflow_actions_ml_training.json5
+++ b/examples/json/workflow_actions_ml_training.json5
@@ -19,7 +19,7 @@
         "preprocess_data"
       ],
       "parameters": {
-        "model_id": "[1,2,3,4,5,6,7,8]"
+        "model_id": [1, 2, 3, 4, 5, 6, 7, 8]
       }
     },
     {

--- a/examples/json/zip_parameter_mode.json5
+++ b/examples/json/zip_parameter_mode.json5
@@ -22,8 +22,8 @@
       "command": "python train.py --dataset={dataset} --model={model}",
       "output_files": ["model_{dataset}_{model}"],
       "parameters": {
-        "dataset": "['cifar10', 'mnist', 'imagenet']",
-        "model": "['resnet', 'cnn', 'transformer']"
+        "dataset": ["cifar10", "mnist", "imagenet"],
+        "model": ["resnet", "cnn", "transformer"]
       },
       "parameter_mode": "zip"
     },
@@ -34,8 +34,8 @@
       "depends_on": ["train_{dataset}_{model}"],
       "input_files": ["model_{dataset}_{model}"],
       "parameters": {
-        "dataset": "['cifar10', 'mnist', 'imagenet']",
-        "model": "['resnet', 'cnn', 'transformer']"
+        "dataset": ["cifar10", "mnist", "imagenet"],
+        "model": ["resnet", "cnn", "transformer"]
       },
       "parameter_mode": "zip"
     }
@@ -47,8 +47,8 @@
       "name": "model_{dataset}_{model}",
       "path": "/models/{dataset}_{model}.pt",
       "parameters": {
-        "dataset": "['cifar10', 'mnist', 'imagenet']",
-        "model": "['resnet', 'cnn', 'transformer']"
+        "dataset": ["cifar10", "mnist", "imagenet"],
+        "model": ["resnet", "cnn", "transformer"]
       },
       "parameter_mode": "zip"
     }

--- a/examples/yaml/data_pipeline_parameterized.yaml
+++ b/examples/yaml/data_pipeline_parameterized.yaml
@@ -13,7 +13,7 @@ jobs:
     output_files:
       - raw_{dataset}
     parameters:
-      dataset: "['sales','inventory','customers','products']"
+      dataset: [sales, inventory, customers, products]
 
   # Stage 2: Clean and preprocess each dataset
   - name: preprocess_{dataset}
@@ -26,7 +26,7 @@ jobs:
     output_files:
       - clean_{dataset}
     parameters:
-      dataset: "['sales','inventory','customers','products']"
+      dataset: [sales, inventory, customers, products]
 
   # Stage 3: Run multiple analysis types on each dataset
   - name: analyze_{dataset}_{analysis_type}
@@ -43,8 +43,8 @@ jobs:
     output_files:
       - results_{dataset}_{analysis_type}
     parameters:
-      dataset: "['sales','inventory','customers','products']"
-      analysis_type: "['summary','trends','anomalies']"
+      dataset: [sales, inventory, customers, products]
+      analysis_type: [summary, trends, anomalies]
 
   # Stage 4: Generate one report per (dataset, analysis_type) combination.
   # Both varying parameters appear in the name so post-expansion names are
@@ -63,8 +63,8 @@ jobs:
     input_files:
       - results_{dataset}_{analysis_type}
     parameters:
-      dataset: "['sales','inventory','customers','products']"
-      analysis_type: "['summary','trends','anomalies']"
+      dataset: [sales, inventory, customers, products]
+      analysis_type: [summary, trends, anomalies]
 
   # Stage 5: Create executive summary per dataset. `{dataset}` appears in
   # the name template so the 4 expanded jobs have unique names. The summary
@@ -77,7 +77,7 @@ jobs:
       - report_{dataset}_trends
       - report_{dataset}_anomalies
     parameters:
-      dataset: "['sales','inventory','customers','products']"
+      dataset: [sales, inventory, customers, products]
 
 # File specifications with parameterization
 files:
@@ -85,20 +85,20 @@ files:
   - name: raw_{dataset}
     path: /data/raw/{dataset}.csv
     parameters:
-      dataset: "['sales','inventory','customers','products']"
+      dataset: [sales, inventory, customers, products]
 
   # Cleaned data files
   - name: clean_{dataset}
     path: /data/clean/{dataset}.csv
     parameters:
-      dataset: "['sales','inventory','customers','products']"
+      dataset: [sales, inventory, customers, products]
 
   # Analysis results (4 datasets * 3 analysis types = 12 files)
   - name: results_{dataset}_{analysis_type}
     path: /results/{dataset}_{analysis_type}_results.json
     parameters:
-      dataset: "['sales','inventory','customers','products']"
-      analysis_type: "['summary','trends','anomalies']"
+      dataset: [sales, inventory, customers, products]
+      analysis_type: [summary, trends, anomalies]
 
 # Resource requirements
 resource_requirements:

--- a/examples/yaml/direct_mode_checkpointing.yaml
+++ b/examples/yaml/direct_mode_checkpointing.yaml
@@ -79,7 +79,7 @@ files:
   - name: "model_{i}"
     path: "/workspace/models/model_{i}.pt"
     parameters:
-      i: "[0,1,2]"
+      i: [0, 1, 2]
 
   - name: "eval_report"
     path: "/workspace/results/evaluation.json"
@@ -101,7 +101,7 @@ jobs:
     input_files: ["dataset"]
     output_files: ["model_{i}"]
     parameters:
-      i: "[0,1,2]"
+      i: [0, 1, 2]
 
   - name: "evaluate_best"
     command: bash examples/scripts/checkpointing_evaluate.sh

--- a/examples/yaml/fan_in_with_regexes.yaml
+++ b/examples/yaml/fan_in_with_regexes.yaml
@@ -46,14 +46,14 @@ files:
   - name: "sim_{region}_{seed:03d}"
     path: "output/sim_{region}_{seed:03d}.csv"
     parameters:
-      region: "['north','south','east','west']"
+      region: [north, south, east, west]
       seed: "0:5"
 
   # Regional summary files: one per region
   - name: "summary_{region}"
     path: "output/summary_{region}.json"
     parameters:
-      region: "['north','south','east','west']"
+      region: [north, south, east, west]
 
   - name: "global_report"
     path: "output/global_report.json"
@@ -75,7 +75,7 @@ jobs:
     input_files: ["config"]
     output_files: ["sim_{region}_{seed:03d}"]
     parameters:
-      region: "['north','south','east','west']"
+      region: [north, south, east, west]
       seed: "0:5"
 
   # Fan-in: each regional summary aggregates all seeds for its region.
@@ -87,7 +87,7 @@ jobs:
     input_file_regexes: ["^sim_{region}_\\d+$"]
     output_files: ["summary_{region}"]
     parameters:
-      region: "['north','south','east','west']"
+      region: [north, south, east, west]
 
   # Global fan-in: aggregates all 4 regional summaries via regex
   - name: "global_report"

--- a/examples/yaml/hyperparameter_sweep.yaml
+++ b/examples/yaml/hyperparameter_sweep.yaml
@@ -53,9 +53,9 @@ jobs:
       - model_lr{lr:.4f}_bs{batch_size}_opt{optimizer}
       - metrics_lr{lr:.4f}_bs{batch_size}_opt{optimizer}
     parameters:
-      lr: "[0.0001,0.001,0.01]"
-      batch_size: "[16,32,64]"
-      optimizer: "['adam','sgd']"
+      lr: [0.0001, 0.001, 0.01]
+      batch_size: [16, 32, 64]
+      optimizer: [adam, sgd]
 
   # Aggregate results for each training run. One aggregate job per
   # (lr, batch_size, optimizer) combination, mirroring the training jobs.
@@ -71,9 +71,9 @@ jobs:
     input_files:
       - metrics_lr{lr:.4f}_bs{batch_size}_opt{optimizer}
     parameters:
-      lr: "[0.0001,0.001,0.01]"
-      batch_size: "[16,32,64]"
-      optimizer: "['adam','sgd']"
+      lr: [0.0001, 0.001, 0.01]
+      batch_size: [16, 32, 64]
+      optimizer: [adam, sgd]
 
 # File specifications
 files:
@@ -87,17 +87,17 @@ files:
   - name: model_lr{lr:.4f}_bs{batch_size}_opt{optimizer}
     path: /models/model_lr{lr:.4f}_bs{batch_size}_opt{optimizer}.pt
     parameters:
-      lr: "[0.0001,0.001,0.01]"
-      batch_size: "[16,32,64]"
-      optimizer: "['adam','sgd']"
+      lr: [0.0001, 0.001, 0.01]
+      batch_size: [16, 32, 64]
+      optimizer: [adam, sgd]
 
   # Metrics files - one per hyperparameter combination
   - name: metrics_lr{lr:.4f}_bs{batch_size}_opt{optimizer}
     path: /results/metrics_lr{lr:.4f}_bs{batch_size}_opt{optimizer}.json
     parameters:
-      lr: "[0.0001,0.001,0.01]"
-      batch_size: "[16,32,64]"
-      optimizer: "['adam','sgd']"
+      lr: [0.0001, 0.001, 0.01]
+      batch_size: [16, 32, 64]
+      optimizer: [adam, sgd]
 
 # Resource requirements
 resource_requirements:

--- a/examples/yaml/hyperparameter_sweep_shared_params.yaml
+++ b/examples/yaml/hyperparameter_sweep_shared_params.yaml
@@ -9,9 +9,9 @@ description: Grid search over learning rate, batch size, and optimizer (using sh
 
 # Workflow-level shared parameters - defined once, used by multiple jobs and files
 parameters:
-  lr: "[0.0001,0.001,0.01]"
-  batch_size: "[16,32,64]"
-  optimizer: "['adam','sgd']"
+  lr: [0.0001, 0.001, 0.01]
+  batch_size: [16, 32, 64]
+  optimizer: [adam, sgd]
 
 # Prepare datasets (one-time setup jobs - no parameters needed)
 jobs:

--- a/examples/yaml/parameterized_user_data.yaml
+++ b/examples/yaml/parameterized_user_data.yaml
@@ -17,7 +17,7 @@ user_data:
       learning_rate: 0.001
       output_dir: /results/{experiment}
     parameters:
-      experiment: "['baseline','ablation','full']"
+      experiment: [baseline, ablation, full]
 
 jobs:
   - name: train_{experiment}
@@ -29,7 +29,7 @@ jobs:
     input_user_data:
       - config_{experiment}
     parameters:
-      experiment: "['baseline','ablation','full']"
+      experiment: [baseline, ablation, full]
 
 resource_requirements:
   - name: small

--- a/examples/yaml/workflow_actions_data_pipeline.yaml
+++ b/examples/yaml/workflow_actions_data_pipeline.yaml
@@ -6,21 +6,21 @@ jobs:
     command: "wget https://data.example.com/{dataset}.tar.gz -O raw/{dataset}.tar.gz && tar -xzf raw/{dataset}.tar.gz -C raw/"
     resource_requirements: "download"
     parameters:
-      dataset: "['users', 'transactions', 'products', 'reviews']"
+      dataset: [users, transactions, products, reviews]
 
   - name: "validate_{dataset}"
     command: "python scripts/validate.py --input raw/{dataset} --output validated/{dataset}"
     resource_requirements: "cpu"
     depends_on: ["download_dataset_{dataset}"]
     parameters:
-      dataset: "['users', 'transactions', 'products', 'reviews']"
+      dataset: [users, transactions, products, reviews]
 
   - name: "transform_{dataset}"
     command: "python scripts/transform.py --input validated/{dataset} --output transformed/{dataset}"
     resource_requirements: "cpu"
     depends_on: ["validate_{dataset}"]
     parameters:
-      dataset: "['users', 'transactions', 'products', 'reviews']"
+      dataset: [users, transactions, products, reviews]
 
   - name: "aggregate_data"
     command: "python scripts/aggregate.py --input transformed/ --output aggregated/final.parquet"

--- a/examples/yaml/workflow_actions_ml_training.yaml
+++ b/examples/yaml/workflow_actions_ml_training.yaml
@@ -11,7 +11,7 @@ jobs:
     resource_requirements: "gpu"
     depends_on: ["preprocess_data"]
     parameters:
-      model_id: "[1,2,3,4,5,6,7,8]"
+      model_id: [1, 2, 3, 4, 5, 6, 7, 8]
 
   - name: "evaluate"
     command: "python scripts/evaluate.py --models models/ --output results/evaluation.json"

--- a/examples/yaml/zip_parameter_mode.yaml
+++ b/examples/yaml/zip_parameter_mode.yaml
@@ -33,8 +33,8 @@ jobs:
     output_files:
       - model_{dataset}_{model}
     parameters:
-      dataset: "['cifar10', 'mnist', 'imagenet']"
-      model: "['resnet', 'cnn', 'transformer']"
+      dataset: [cifar10, mnist, imagenet]
+      model: [resnet, cnn, transformer]
     parameter_mode: zip
 
   # Evaluation job that processes all models
@@ -52,8 +52,8 @@ jobs:
     output_files:
       - metrics_{dataset}_{model}
     parameters:
-      dataset: "['cifar10', 'mnist', 'imagenet']"
-      model: "['resnet', 'cnn', 'transformer']"
+      dataset: [cifar10, mnist, imagenet]
+      model: [resnet, cnn, transformer]
     parameter_mode: zip
 
   # Final aggregation job
@@ -71,13 +71,13 @@ files:
   - name: model_{dataset}_{model}
     path: /models/{dataset}_{model}.pt
     parameters:
-      dataset: "['cifar10', 'mnist', 'imagenet']"
-      model: "['resnet', 'cnn', 'transformer']"
+      dataset: [cifar10, mnist, imagenet]
+      model: [resnet, cnn, transformer]
     parameter_mode: zip
 
   - name: metrics_{dataset}_{model}
     path: /results/{dataset}_{model}_metrics.json
     parameters:
-      dataset: "['cifar10', 'mnist', 'imagenet']"
-      model: "['resnet', 'cnn', 'transformer']"
+      dataset: [cifar10, mnist, imagenet]
+      model: [resnet, cnn, transformer]
     parameter_mode: zip


### PR DESCRIPTION
## Summary

Follow-up to #423, where @pesap added support for native YAML/JSON sequences in `parameters` at every spec scope (workflow-level, jobs, files, and user_data). This PR updates the shipped examples and user documentation to use the improved syntax as the primary form.

- **Examples** — 15 files converted from string-encoded lists to native sequences:
  - `examples/yaml` (9 files): e.g. `optimizer: "['adam','sgd']"` → `optimizer: [adam, sgd]`, covering job, file, user_data, workflow-level shared, and zip-mode parameters
  - `examples/json` (6 JSON5 files): e.g. `"model_id": "[1,2,3,4,5,6,7,8]"` → `"model_id": [1, 2, 3, 4, 5, 6, 7, 8]`
- **Docs** — parameterization reference, workflow-spec reference, workflow-definition concepts, simple/advanced params tutorials, parameterize-with-files how-to, and CLAUDE.md now show native sequences, with notes that the legacy string form is still accepted

## Deliberately unchanged

- **KDL examples and KDL doc snippets** keep the string-encoded form: the KDL converter (`kdl_string_map_to_json`) still requires parameter values to be strings, and the docs now call this out explicitly
- **Range notation** (`"1:100"`, `"0.0:1.0:0.1"`) has no native equivalent and stays as-is
- The workflow-wizard doc, which describes a dashboard text-input field rather than spec files

## Testing

- `cargo nextest run -E 'test(test_create_workflows_from_all_example_files)'` passes — every example spec (including all converted files) parses, expands, and creates a workflow against a live test server
- `dprint check` passes; mdbook rebuilds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)