### PR TITLE
Cancel Slurm allocations when canceling a workflow from the TUI

### DIFF
--- a/docs/src/core/how-to/cancel-workflow.md
+++ b/docs/src/core/how-to/cancel-workflow.md
@@ -15,6 +15,11 @@ This:
 - Sends SIGKILL to all running processes
 - Sends `scancel` to all active or pending Slurm allocations
 
+## Cancel from the TUI
+
+Press `C` on a workflow in `torc tui`. This runs the same cancellation as `torc cancel`, including
+the `scancel` of outstanding Slurm allocations, and reports how many were canceled.
+
 ## Check Cancellation Status
 
 Verify the workflow was canceled:

--- a/docs/src/core/monitoring/tui.md
+++ b/docs/src/core/monitoring/tui.md
@@ -94,7 +94,7 @@ Select a workflow and use these keys:
 | `W` | Watch         | Watch workflow with auto-recovery (live output)         |
 | `V` | Recover       | One-shot recovery: bump resources and resubmit failures |
 | `v` | Recover (dry) | Preview recovery without applying changes               |
-| `C` | Cancel        | Cancel running workflow                                 |
+| `C` | Cancel        | Cancel workflow and its Slurm allocations               |
 | `d` | Delete        | Delete workflow (destructive!)                          |
 
 Most destructive actions show a yes/no confirmation dialog. Recovery (`V`) is gated by the

--- a/src/client.rs
+++ b/src/client.rs
@@ -33,6 +33,7 @@ pub mod slurm_utils;
 pub mod sse_client;
 pub mod utils;
 pub mod version_check;
+pub mod workflow_cancel;
 pub mod workflow_graph;
 pub mod workflow_manager;
 pub mod workflow_spec;

--- a/src/client/commands/workflows.rs
+++ b/src/client/commands/workflows.rs
@@ -48,11 +48,10 @@ use crate::client::apis;
 use crate::client::apis::configuration::Configuration;
 use crate::client::commands::pagination::{
     ComputeNodeListParams, EventListParams, FileListParams, JobListParams,
-    ResourceRequirementsListParams, ResultListParams, ScheduledComputeNodeListParams,
-    SlurmSchedulersListParams, UserDataListParams, WorkflowListParams, paginate_compute_nodes,
-    paginate_events, paginate_files, paginate_jobs, paginate_resource_requirements,
-    paginate_results, paginate_scheduled_compute_nodes, paginate_slurm_schedulers,
-    paginate_user_data, paginate_workflows,
+    ResourceRequirementsListParams, ResultListParams, SlurmSchedulersListParams,
+    UserDataListParams, WorkflowListParams, paginate_compute_nodes, paginate_events,
+    paginate_files, paginate_jobs, paginate_resource_requirements, paginate_results,
+    paginate_slurm_schedulers, paginate_user_data, paginate_workflows,
 };
 use crate::client::commands::reports::check_resource_utilization;
 use crate::client::commands::workflow_export::{
@@ -64,7 +63,6 @@ use crate::client::commands::{
     print_error, select_workflow_interactively,
     table_format::{display_csv, display_table_with_count},
 };
-use crate::client::hpc::hpc_interface::HpcInterface;
 use crate::client::report_models::ResourceUtilizationReport;
 use crate::client::resource_correction::{
     ResourceCorrectionContext, ResourceCorrectionOptions, ResourceLookupContext,
@@ -72,6 +70,7 @@ use crate::client::resource_correction::{
     detect_runtime_violation, detect_timeout,
 };
 use crate::client::utils::format_local_timestamp;
+use crate::client::workflow_cancel::{CancelProgress, cancel_scheduler_allocations};
 use crate::client::workflow_manager::WorkflowManager;
 use crate::client::workflow_spec::WorkflowSpec;
 use crate::config::TorcConfig;
@@ -1812,136 +1811,50 @@ pub fn handle_cancel(
         }
     }
 
-    // Get all scheduled compute nodes for this workflow
-    let nodes = match paginate_scheduled_compute_nodes(
-        config,
-        selected_workflow_id,
-        ScheduledComputeNodeListParams::new(),
-    ) {
-        Ok(nodes) => nodes,
-        Err(e) => {
-            if format == "json" {
-                let error_response = serde_json::json!({
-                    "status": "error",
-                    "message": format!("Failed to list scheduled compute nodes: {}", e),
-                    "workflow_id": selected_workflow_id
-                });
-                println!("{}", serde_json::to_string_pretty(&error_response).unwrap());
-            } else {
-                print_error("listing scheduled compute nodes", &e);
-            }
-            std::process::exit(1);
+    // Cancel any outstanding Slurm allocations. Otherwise a queued allocation would start
+    // later, find no runnable jobs, and exit immediately.
+    let quiet = format == "json";
+    let mut report_progress = |progress: CancelProgress<'_>| {
+        if quiet {
+            return;
+        }
+        match progress {
+            CancelProgress::Info(message) => println!("  {}", message),
+            CancelProgress::Error(message) => eprintln!("  {}", message),
         }
     };
 
-    let mut canceled_jobs = Vec::new();
-    let mut errors = Vec::new();
-
-    for node in nodes {
-        if node.scheduler_type == "slurm" {
-            match crate::client::hpc::slurm_interface::SlurmInterface::new() {
-                Ok(slurm_interface) => {
-                    let job_id_str = node.scheduler_id.to_string();
-                    match slurm_interface.cancel_job(&job_id_str) {
-                        Ok(_) => {
-                            canceled_jobs.push(node.scheduler_id);
-                            if format != "json" {
-                                println!("  Canceled Slurm job: {}", node.scheduler_id);
-                            }
-                            // Update the ScheduledComputeNode status to "canceled"
-                            if let Some(node_id) = node.id {
-                                let updated_node = models::ScheduledComputeNodesModel::new(
-                                    node.workflow_id,
-                                    node.scheduler_id,
-                                    node.scheduler_config_id,
-                                    node.scheduler_type.clone(),
-                                    "canceled".to_string(),
-                                );
-                                if let Err(e) =
-                                    apis::scheduled_compute_nodes_api::update_scheduled_compute_node(
-                                        config,
-                                        node_id,
-                                        updated_node,
-                                    )
-                                {
-                                    let error_msg =
-                                        format!("Failed to update node {} status: {}", node_id, e);
-                                    errors.push(error_msg.clone());
-                                    if format != "json" {
-                                        eprintln!("  {}", error_msg);
-                                    }
-                                } else if format != "json" {
-                                    println!(
-                                        "  Updated node {} status to canceled",
-                                        node.scheduler_id
-                                    );
-                                }
-
-                                // `scancel` kills the job runner ungracefully, so it never
-                                // deactivates its own compute node. Do it here, otherwise the
-                                // ComputeNode rows stay is_active=true and block `torc recover`.
-                                match super::orphan_detection::deactivate_compute_nodes_for_scheduled_node(
-                                    config,
-                                    node.workflow_id,
-                                    node_id,
-                                    &node.scheduler_id.to_string(),
-                                    false,
-                                ) {
-                                    Ok(count) => {
-                                        if count > 0 && format != "json" {
-                                            println!(
-                                                "  Deactivated {} compute node(s) for node {}",
-                                                count, node.scheduler_id
-                                            );
-                                        }
-                                    }
-                                    Err(e) => {
-                                        let error_msg = format!(
-                                            "Failed to deactivate compute nodes for node {}: {}",
-                                            node.scheduler_id, e
-                                        );
-                                        errors.push(error_msg.clone());
-                                        if format != "json" {
-                                            eprintln!("  {}", error_msg);
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        Err(e) => {
-                            let error_msg =
-                                format!("Failed to cancel Slurm job {}: {}", node.scheduler_id, e);
-                            errors.push(error_msg.clone());
-                            if format != "json" {
-                                eprintln!("  {}", error_msg);
-                            }
-                        }
-                    }
+    let outcome =
+        match cancel_scheduler_allocations(config, selected_workflow_id, &mut report_progress) {
+            Ok(outcome) => outcome,
+            Err(e) => {
+                if format == "json" {
+                    let error_response = serde_json::json!({
+                        "status": "error",
+                        "message": format!("Failed to list scheduled compute nodes: {}", e),
+                        "workflow_id": selected_workflow_id
+                    });
+                    println!("{}", serde_json::to_string_pretty(&error_response).unwrap());
+                } else {
+                    print_error("listing scheduled compute nodes", &e);
                 }
-                Err(e) => {
-                    let error_msg = format!(
-                        "Failed to create SlurmInterface for job {}: {}",
-                        node.scheduler_id, e
-                    );
-                    errors.push(error_msg.clone());
-                    if format != "json" {
-                        eprintln!("  {}", error_msg);
-                    }
-                }
+                std::process::exit(1);
             }
-        }
-    }
+        };
 
     if format == "json" {
         let response = serde_json::json!({
-            "status": if errors.is_empty() { "success" } else { "partial_success" },
+            "status": if outcome.errors.is_empty() { "success" } else { "partial_success" },
             "workflow_id": selected_workflow_id,
-            "canceled_slurm_jobs": canceled_jobs,
-            "errors": if errors.is_empty() { None } else { Some(errors) }
+            "canceled_slurm_jobs": outcome.canceled_slurm_jobs,
+            "errors": if outcome.errors.is_empty() { None } else { Some(outcome.errors) }
         });
         println!("{}", serde_json::to_string_pretty(&response).unwrap());
-    } else if !canceled_jobs.is_empty() {
-        println!("Canceled {} Slurm job(s)", canceled_jobs.len());
+    } else if !outcome.canceled_slurm_jobs.is_empty() {
+        println!(
+            "Canceled {} Slurm job(s)",
+            outcome.canceled_slurm_jobs.len()
+        );
     }
 }
 

--- a/src/client/workflow_cancel.rs
+++ b/src/client/workflow_cancel.rs
@@ -1,0 +1,172 @@
+//! Shared workflow cancellation logic.
+//!
+//! Canceling a workflow has two parts: telling the server to cancel the workflow (which
+//! cancels its jobs) and canceling any outstanding scheduler allocations. Skipping the
+//! second part leaves Slurm allocations queued; when one starts it finds no runnable jobs
+//! and exits immediately.
+//!
+//! Both `torc cancel` and the TUI call [`cancel_scheduler_allocations`] so they behave
+//! identically.
+
+use crate::client::apis;
+use crate::client::apis::configuration::Configuration;
+use crate::client::commands::orphan_detection::deactivate_compute_nodes_for_scheduled_node;
+use crate::client::commands::pagination::{
+    ScheduledComputeNodeListParams, paginate_scheduled_compute_nodes,
+};
+use crate::client::hpc::hpc_interface::HpcInterface;
+use crate::client::hpc::slurm_interface::SlurmInterface;
+use crate::models;
+
+/// Error returned when the scheduled compute nodes for a workflow cannot be listed.
+pub type ListScheduledNodesError =
+    apis::Error<apis::scheduled_compute_nodes_api::ListScheduledComputeNodesError>;
+
+/// A progress message emitted while canceling scheduler allocations.
+///
+/// Callers decide how to surface these; `torc cancel` prints them, the TUI ignores them
+/// and reports the summary in [`CanceledAllocations`] instead.
+pub enum CancelProgress<'a> {
+    /// Something succeeded (an allocation was canceled, a status was updated).
+    Info(&'a str),
+    /// A non-fatal failure. The same text is also recorded in [`CanceledAllocations::errors`].
+    Error(&'a str),
+}
+
+/// Summary of what happened while canceling a workflow's scheduler allocations.
+#[derive(Debug, Default)]
+pub struct CanceledAllocations {
+    /// Scheduler job IDs that were canceled.
+    pub canceled_slurm_jobs: Vec<i64>,
+    /// Number of compute nodes deactivated after their allocation was canceled.
+    pub deactivated_compute_nodes: usize,
+    /// Non-fatal errors encountered along the way.
+    pub errors: Vec<String>,
+}
+
+/// Cancel every Slurm allocation associated with `workflow_id`.
+///
+/// For each canceled allocation the scheduled compute node is marked `canceled` and its
+/// compute nodes are deactivated -- `scancel` kills the job runner ungracefully, so it never
+/// deactivates its own compute node, and the leftover `is_active=true` rows block
+/// `torc recover`.
+///
+/// This does not cancel the workflow itself; call `apis::workflows_api::cancel_workflow`
+/// first. Per-allocation failures are collected in the returned [`CanceledAllocations`]
+/// rather than aborting the sweep; only a failure to list the workflow's scheduled compute
+/// nodes is returned as an error.
+#[allow(clippy::result_large_err)]
+pub fn cancel_scheduler_allocations(
+    config: &Configuration,
+    workflow_id: i64,
+    progress: &mut dyn FnMut(CancelProgress<'_>),
+) -> Result<CanceledAllocations, ListScheduledNodesError> {
+    let nodes = paginate_scheduled_compute_nodes(
+        config,
+        workflow_id,
+        ScheduledComputeNodeListParams::new(),
+    )?;
+
+    let mut outcome = CanceledAllocations::default();
+
+    let slurm_nodes: Vec<models::ScheduledComputeNodesModel> = nodes
+        .into_iter()
+        .filter(|node| node.scheduler_type == "slurm")
+        .collect();
+    if slurm_nodes.is_empty() {
+        return Ok(outcome);
+    }
+
+    let slurm_interface = match SlurmInterface::new() {
+        Ok(interface) => interface,
+        Err(e) => {
+            record_error(
+                &mut outcome,
+                format!("Failed to create SlurmInterface: {}", e),
+                progress,
+            );
+            return Ok(outcome);
+        }
+    };
+
+    for node in slurm_nodes {
+        if let Err(e) = slurm_interface.cancel_job(&node.scheduler_id.to_string()) {
+            record_error(
+                &mut outcome,
+                format!("Failed to cancel Slurm job {}: {}", node.scheduler_id, e),
+                progress,
+            );
+            continue;
+        }
+
+        outcome.canceled_slurm_jobs.push(node.scheduler_id);
+        progress(CancelProgress::Info(&format!(
+            "Canceled Slurm job: {}",
+            node.scheduler_id
+        )));
+
+        let Some(node_id) = node.id else {
+            continue;
+        };
+
+        let updated_node = models::ScheduledComputeNodesModel::new(
+            node.workflow_id,
+            node.scheduler_id,
+            node.scheduler_config_id,
+            node.scheduler_type.clone(),
+            "canceled".to_string(),
+        );
+        match apis::scheduled_compute_nodes_api::update_scheduled_compute_node(
+            config,
+            node_id,
+            updated_node,
+        ) {
+            Ok(_) => progress(CancelProgress::Info(&format!(
+                "Updated node {} status to canceled",
+                node.scheduler_id
+            ))),
+            Err(e) => record_error(
+                &mut outcome,
+                format!("Failed to update node {} status: {}", node_id, e),
+                progress,
+            ),
+        }
+
+        match deactivate_compute_nodes_for_scheduled_node(
+            config,
+            node.workflow_id,
+            node_id,
+            &node.scheduler_id.to_string(),
+            false,
+        ) {
+            Ok(count) => {
+                outcome.deactivated_compute_nodes += count;
+                if count > 0 {
+                    progress(CancelProgress::Info(&format!(
+                        "Deactivated {} compute node(s) for node {}",
+                        count, node.scheduler_id
+                    )));
+                }
+            }
+            Err(e) => record_error(
+                &mut outcome,
+                format!(
+                    "Failed to deactivate compute nodes for node {}: {}",
+                    node.scheduler_id, e
+                ),
+                progress,
+            ),
+        }
+    }
+
+    Ok(outcome)
+}
+
+fn record_error(
+    outcome: &mut CanceledAllocations,
+    message: String,
+    progress: &mut dyn FnMut(CancelProgress<'_>),
+) {
+    progress(CancelProgress::Error(&message));
+    outcome.errors.push(message);
+}

--- a/src/tui/api.rs
+++ b/src/tui/api.rs
@@ -1,6 +1,7 @@
 use crate::client::apis;
 use crate::client::apis::configuration::{BasicAuth, Configuration, TlsConfig};
 use crate::client::config::TorcConfig;
+use crate::client::workflow_cancel::{CanceledAllocations, cancel_scheduler_allocations};
 use crate::client::workflow_spec::WorkflowSpec;
 use crate::models::{
     ComputeNodeModel, FileModel, JobDependencyModel, JobModel, JobStatus, ResultModel,
@@ -370,11 +371,24 @@ impl TorcClient {
         Ok(())
     }
 
-    pub fn cancel_workflow(&self, workflow_id: i64) -> Result<()> {
+    /// Cancel a workflow and any Slurm allocations scheduled for it.
+    ///
+    /// Canceling the workflow alone leaves its allocations queued; when one starts it
+    /// finds no runnable jobs and exits immediately, so the allocations are canceled too
+    /// (same as `torc cancel`). Returns the allocation-cancellation summary; failures
+    /// there are reported in it rather than failing the whole call, since the workflow
+    /// itself was already canceled.
+    pub fn cancel_workflow(&self, workflow_id: i64) -> Result<CanceledAllocations> {
         apis::workflows_api::cancel_workflow(&self.config, workflow_id)
             .context("Failed to cancel workflow")?;
 
-        Ok(())
+        let outcome = cancel_scheduler_allocations(&self.config, workflow_id, &mut |_| {})
+            .unwrap_or_else(|e| CanceledAllocations {
+                errors: vec![format!("Failed to list scheduled compute nodes: {}", e)],
+                ..Default::default()
+            });
+
+        Ok(outcome)
     }
 
     // === Job Actions ===

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -105,7 +105,11 @@ impl WorkflowAction {
                 "DELETE workflow '{}'?\nThis action cannot be undone!",
                 workflow_name
             ),
-            Self::Cancel => format!("Cancel workflow '{}'?", workflow_name),
+            Self::Cancel => format!(
+                "Cancel workflow '{}'?\n\
+                 This cancels running jobs and any associated Slurm allocations.",
+                workflow_name
+            ),
         }
     }
 
@@ -3493,6 +3497,11 @@ impl App {
             return self.reset_workflow_cli(workflow_id, workflow_name);
         }
 
+        // Handle Cancel specially - it also cancels Slurm allocations and reports on them
+        if action == WorkflowAction::Cancel {
+            return self.cancel_workflow_with_allocations(workflow_id, workflow_name);
+        }
+
         let result = match action {
             WorkflowAction::Initialize => unreachable!(), // Handled above
             WorkflowAction::InitializeForce => unreachable!(), // Handled above
@@ -3504,9 +3513,9 @@ impl App {
             WorkflowAction::WatchNoAuto => unreachable!(), // Handled above
             WorkflowAction::Recover => unreachable!(),    // Handled above
             WorkflowAction::RecoverDryRun => unreachable!(), // Handled above
+            WorkflowAction::Cancel => unreachable!(),     // Handled above
             WorkflowAction::Submit => self.client.submit_workflow(workflow_id),
             WorkflowAction::Delete => self.client.delete_workflow(workflow_id),
-            WorkflowAction::Cancel => self.client.cancel_workflow(workflow_id),
         };
 
         match result {
@@ -3522,11 +3531,11 @@ impl App {
                     WorkflowAction::WatchNoAuto => unreachable!(),
                     WorkflowAction::Recover => unreachable!(),
                     WorkflowAction::RecoverDryRun => unreachable!(),
+                    WorkflowAction::Cancel => unreachable!(),
                     WorkflowAction::Submit => {
                         format!("Workflow '{}' submitted to scheduler", workflow_name)
                     }
                     WorkflowAction::Delete => format!("Workflow '{}' deleted", workflow_name),
-                    WorkflowAction::Cancel => format!("Workflow '{}' canceled", workflow_name),
                 };
                 self.set_status(StatusMessage::success(&msg));
 
@@ -3542,6 +3551,53 @@ impl App {
                 self.set_status(StatusMessage::error(&format!(
                     "Failed to {} workflow: {}",
                     action.title().to_lowercase(),
+                    e
+                )));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Cancel a workflow along with its outstanding Slurm allocations.
+    ///
+    /// Canceling the workflow without the allocations leaves them queued; when one starts
+    /// it finds no runnable jobs and exits immediately. Allocation failures are reported
+    /// as a warning rather than an error because the workflow itself was canceled.
+    fn cancel_workflow_with_allocations(
+        &mut self,
+        workflow_id: i64,
+        workflow_name: &str,
+    ) -> Result<()> {
+        self.set_status(StatusMessage::info(&format!(
+            "Canceling workflow '{}'...",
+            workflow_name
+        )));
+
+        match self.client.cancel_workflow(workflow_id) {
+            Ok(outcome) => {
+                let canceled = outcome.canceled_slurm_jobs.len();
+                let mut msg = format!("Workflow '{}' canceled", workflow_name);
+                if canceled > 0 {
+                    msg.push_str(&format!(" ({} Slurm allocation(s) canceled)", canceled));
+                }
+
+                if outcome.errors.is_empty() {
+                    self.set_status(StatusMessage::success(&msg));
+                } else {
+                    self.set_status(StatusMessage::warning(&format!(
+                        "{}, but canceling allocations had errors: {}",
+                        msg,
+                        outcome.errors.join("; ")
+                    )));
+                }
+
+                // Reload the detail data to show updated status
+                let _ = self.load_detail_data();
+            }
+            Err(e) => {
+                self.set_status(StatusMessage::error(&format!(
+                    "Failed to cancel workflow: {}",
                     e
                 )));
             }

--- a/tests/test_slurm_commands.rs
+++ b/tests/test_slurm_commands.rs
@@ -1794,6 +1794,117 @@ fn test_slurm_run_jobs(start_server: &ServerProcess) {
     );
 }
 
+/// Regression test for the bug where canceling a workflow from the TUI left its Slurm
+/// allocations queued (https://github.com/NatLabRockies/torc/issues/433). The TUI now calls
+/// the same `cancel_scheduler_allocations` used by `torc cancel`, so exercise that shared
+/// function directly: the allocation must be scancel'd, the scheduled compute node marked
+/// canceled, and its compute node deactivated.
+#[rstest]
+#[serial(slurm)]
+fn test_cancel_scheduler_allocations_cancels_slurm_jobs(start_server: &ServerProcess) {
+    let config = &start_server.config;
+
+    cleanup_fake_slurm_state();
+    setup_fake_slurm_commands();
+
+    // Seed the fake Slurm jobs file so fake_scancel.sh recognizes the allocation.
+    let slurm_job_id: i64 = 4242;
+    let jobs_file = format!(
+        "{}/fake_slurm_jobs.txt",
+        env::var("TMPDIR").unwrap_or_else(|_| "/tmp".to_string())
+    );
+    fs::write(
+        &jobs_file,
+        format!(
+            "{}|test_job|PENDING|2026-01-01T00:00:00|Unknown|test_account|debug|normal\n",
+            slurm_job_id
+        ),
+    )
+    .expect("Failed to seed fake Slurm jobs file");
+
+    let workflow = create_test_workflow(config, "test_cancel_scheduler_allocations");
+    let workflow_id = workflow.id.unwrap();
+    let scheduler = create_test_slurm_scheduler(config, workflow_id);
+    let scheduler_config_id = scheduler.id.unwrap();
+
+    // A queued allocation, as `torc submit` leaves it.
+    let scheduled_node = models::ScheduledComputeNodesModel::new(
+        workflow_id,
+        slurm_job_id,
+        scheduler_config_id,
+        "slurm".to_string(),
+        "pending".to_string(),
+    );
+    let created_scheduled =
+        apis::scheduled_compute_nodes_api::create_scheduled_compute_node(config, scheduled_node)
+            .expect("Failed to create scheduled compute node");
+    let scheduled_compute_node_id = created_scheduled.id.unwrap();
+
+    // An active compute node running under that allocation. `scancel` kills the job runner
+    // ungracefully, so cancellation has to deactivate it.
+    let mut compute_node = models::ComputeNodeModel::new(
+        workflow_id,
+        "cancel-alloc-host".to_string(),
+        std::process::id() as i64,
+        chrono::Utc::now().to_rfc3339(),
+        4,
+        8.0,
+        0,
+        1,
+        "slurm".to_string(),
+        Some(json!({ "scheduler_id": scheduled_compute_node_id })),
+    );
+    compute_node.is_active = Some(true);
+    let created_node = apis::compute_nodes_api::create_compute_node(config, compute_node)
+        .expect("Failed to create compute node");
+    let compute_node_id = created_node.id.unwrap();
+
+    let outcome = torc::client::workflow_cancel::cancel_scheduler_allocations(
+        config,
+        workflow_id,
+        &mut |_| {},
+    )
+    .expect("cancel_scheduler_allocations failed");
+
+    assert!(
+        outcome.errors.is_empty(),
+        "expected no errors, got {:?}",
+        outcome.errors
+    );
+    assert_eq!(
+        outcome.canceled_slurm_jobs,
+        vec![slurm_job_id],
+        "the queued Slurm allocation should have been canceled"
+    );
+    assert_eq!(outcome.deactivated_compute_nodes, 1);
+
+    // The fake scancel marks the allocation CANCELLED in its jobs file.
+    let jobs_contents =
+        fs::read_to_string(&jobs_file).expect("Failed to read fake Slurm jobs file");
+    assert!(
+        jobs_contents.contains("CANCELLED"),
+        "scancel should have been invoked, jobs file: {}",
+        jobs_contents
+    );
+
+    let final_scheduled = apis::scheduled_compute_nodes_api::get_scheduled_compute_node(
+        config,
+        scheduled_compute_node_id,
+    )
+    .expect("Failed to get scheduled compute node");
+    assert_eq!(final_scheduled.status, "canceled");
+
+    let final_node = apis::compute_nodes_api::get_compute_node(config, compute_node_id)
+        .expect("Failed to get compute node");
+    assert_eq!(
+        final_node.is_active,
+        Some(false),
+        "compute node should be deactivated so `torc recover` is not blocked"
+    );
+
+    cleanup_fake_slurm_state();
+}
+
 /// Helper function to create a test Slurm scheduler
 fn create_test_slurm_scheduler(
     config: &torc::client::Configuration,


### PR DESCRIPTION
Fixes #433

## Problem

Canceling a workflow from the TUI only marked the workflow canceled — it left outstanding Slurm allocations queued. Each allocation would eventually start, find no runnable jobs, and exit immediately. `torc cancel` did the right thing, so the two paths disagreed.

## Change

- New `src/client/workflow_cancel.rs` holds the allocation-cancellation logic lifted out of `torc cancel`: `scancel` each Slurm allocation for the workflow, mark the scheduled compute node `canceled`, and deactivate its compute nodes (leftover `is_active=true` rows otherwise block `torc recover`). Per-allocation failures are collected into a `CanceledAllocations` summary rather than aborting the sweep; callers surface progress through a `CancelProgress::{Info,Error}` callback.
- `handle_cancel` (`torc cancel`) delegates to the shared function. Output is unchanged: same messages, same JSON shape (`status`, `canceled_slurm_jobs`, `errors`), same exit-1 on a list failure. Incidentally, `SlurmInterface` is now created once instead of once per node.
- The TUI's `Cancel` action calls the same function, reporting e.g. `Workflow 'x' canceled (2 Slurm allocation(s) canceled)`, or a warning listing errors when the workflow was canceled but cleanup partly failed. The confirmation dialog now states that allocations are canceled too.

## Testing

- New `test_cancel_scheduler_allocations_cancels_slurm_jobs` sets up a fake Slurm job, a pending scheduled compute node, and an active compute node, then calls the shared function directly (the same call the TUI makes) and asserts the allocation was `scancel`'d, the node is `canceled`, and the compute node is deactivated.
- `test_slurm_commands` (44 tests) and `test_orphaned_jobs` pass. Note the pre-existing CLI-level `test_cancel_workflow_with_slurm_scheduler` is `#[ignore]`d and did not run.
- `cargo fmt`, `cargo clippy --all --all-targets --all-features -- -D warnings`, and `dprint check` are clean.

Docs updated in `cancel-workflow.md` and `tui.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)